### PR TITLE
fix(add): print install hint after success

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -60,6 +60,8 @@ export async function addCommand(name: string, opts: AddOptions, dir: string): P
 		await writeManifest(dir, manifest);
 	}
 	success(`Added ${name} to ${group}${opts.global ? " (global)" : ""}`);
+	const installCmd = opts.global ? "skilltree install --global" : "skilltree install";
+	console.log(dim(`  Run \`${installCmd}\` to install.`));
 }
 
 function validateAddFlags(opts: AddOptions): void {

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -428,4 +428,50 @@ describe("addCommand", () => {
 		const manifest = await readManifest(dir);
 		expect((manifest.dependencies?.["my-skill"] as { version: string }).version).toBe("^2.0.0");
 	});
+
+	test("prints hint to run `skilltree install` after adding a project dep", async () => {
+		const dir = await setup();
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (msg: string) => logs.push(msg);
+		try {
+			await addCommand(
+				"task-builder",
+				{ repo: "github.com/company/skills", path: "skills/task-builder", version: "^2.0.0" },
+				dir,
+			);
+		} finally {
+			console.log = originalLog;
+		}
+
+		// Must tell the user the next step — adding to the manifest alone
+		// does not install the dep (lockfile is the source of truth for list/install).
+		const joined = logs.join("\n");
+		expect(joined).toContain("skilltree install");
+		expect(joined).not.toContain("--global");
+	});
+
+	test("prints hint to run `skilltree install --global` after adding a global dep", async () => {
+		const dir = await setup();
+		const localPath = join(dir, "skills", "my-skill");
+		await mkdir(localPath, { recursive: true });
+		await writeFile(join(localPath, "SKILL.md"), "---\nname: my-skill\n---\n");
+
+		const globalDir = join(dir, "global-config");
+		const { writeGlobalManifest } = await import("../../src/core/manifest.js");
+		await writeGlobalManifest({ dependencies: {} }, globalDir);
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (msg: string) => logs.push(msg);
+		try {
+			await addCommand("my-skill", { local: localPath, global: true, globalDir }, dir);
+		} finally {
+			console.log = originalLog;
+		}
+
+		const joined = logs.join("\n");
+		expect(joined).toContain("skilltree install --global");
+	});
 });


### PR DESCRIPTION
Closes #3.

## Problem
`skilltree add` only writes to the manifest; `list` reads from the lockfile. Newly added deps were invisible to `list` until `install` ran — and `add` gave no breadcrumb to install.

```
❯ skilltree add github-issue-creator --repo ... --global
✔ Added github-issue-creator to dependencies (global)

❯ skilltree list --global
# ← missing github-issue-creator
```

## Fix
After the success line, print a dim one-liner with the exact next command, matched to `--global`:

```
✔ Added task-builder to dependencies
  Run `skilltree install` to install.
```

## Why not change `list` to show pending deps?
That was the alternative proposed in #3. It's more invasive (manifest+lockfile merge, new row state, table rendering changes, footer count). Filed as potential follow-up — this patch covers the immediate UX trap.

## Test plan
- [x] New test: project-level `add` prints `skilltree install` hint (without `--global`)
- [x] New test: `add --global` prints `skilltree install --global` hint
- [x] Full suite passes (694 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)