### PR TITLE
fix(git): invalidate cache when origin URL drifts

### DIFF
--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -143,7 +143,11 @@ export function toGitCloneUrl(repo: string): string {
 /**
  * Clone a bare repo if it doesn't exist, or fetch if it does.
  * If the directory exists but is not a valid bare repo (e.g., empty dir
- * from a failed previous clone), it is removed and re-cloned.
+ * from a failed previous clone), it is removed and re-cloned. If the
+ * cached repo's `origin` URL differs from `repoUrl` (user edited the
+ * source in skilltree.yaml or config.yaml), the cache is invalidated
+ * and re-cloned against the new URL — a plain fetch would silently
+ * pull from the stale remote.
  */
 export async function cloneOrFetchBare(repoUrl: string, targetDir: string): Promise<void> {
 	if (existsSync(targetDir)) {
@@ -157,19 +161,45 @@ export async function cloneOrFetchBare(repoUrl: string, targetDir: string): Prom
 				const configContent = await readFile(configFile, "utf-8");
 				if (configContent.includes('[remote "origin"]')) {
 					const git = simpleGit(targetDir);
-					await git.fetch(["--tags", "--prune"]);
-					return;
+					if (await isOriginUrlDrifted(git, repoUrl)) {
+						await rm(targetDir, { recursive: true, force: true });
+					} else {
+						await git.fetch(["--tags", "--prune"]);
+						return;
+					}
 				}
 			} catch {
 				// Config unreadable — fall through to re-clone
 			}
 		}
-		// Corrupt/incomplete directory — remove and re-clone
-		await rm(targetDir, { recursive: true, force: true });
+		// Corrupt/incomplete directory, or drift path that didn't `return` — ensure removed.
+		if (existsSync(targetDir)) {
+			await rm(targetDir, { recursive: true, force: true });
+		}
 	}
 	await mkdir(targetDir, { recursive: true });
 	const gitUrl = toGitCloneUrl(repoUrl);
 	await simpleGit().clone(gitUrl, targetDir, ["--bare"]);
+}
+
+/**
+ * Compare the cached repo's `origin` URL against the expected URL. Both
+ * sides are run through `toGitCloneUrl` + `normalizeGitUrl` so cosmetic
+ * differences (missing https://, trailing .git, etc.) don't cause a
+ * spurious re-clone. Returns true when the resolved URLs disagree.
+ */
+async function isOriginUrlDrifted(
+	git: ReturnType<typeof simpleGit>,
+	expectedUrl: string,
+): Promise<boolean> {
+	try {
+		const cachedOrigin = (await git.raw(["config", "--get", "remote.origin.url"])).trim();
+		if (!cachedOrigin) return false;
+		return normalizeGitUrl(cachedOrigin) !== normalizeGitUrl(toGitCloneUrl(expectedUrl));
+	} catch {
+		// Missing/unreadable origin — let the caller fall through to re-clone.
+		return true;
+	}
 }
 
 export function getCacheDir(): string {

--- a/tests/core/registry-cache.test.ts
+++ b/tests/core/registry-cache.test.ts
@@ -178,4 +178,40 @@ describe("ensureRegistryRepo", () => {
 		const repoDir = await ensureRegistryRepo("test-reg", sourceDir, cacheDir);
 		expect(existsSync(repoDir)).toBe(true);
 	});
+
+	test("re-clones when the registry URL changes (URL drift)", async () => {
+		// When config.yaml is edited to point a registry at a new URL, the
+		// cached bare repo's `origin` still points at the old URL. A plain
+		// `fetch` would silently pull from the wrong source. The cache must
+		// be invalidated and re-cloned against the new URL.
+		const dir = await setup();
+
+		const originalSource = await createSourceRepo(dir);
+		const cacheDir = join(dir, "cache");
+		await ensureRegistryRepo("test-reg", originalSource, cacheDir);
+
+		// Create an entirely separate source repo at a different path.
+		// Mark it with a unique file so we can prove the re-clone happened.
+		const newSource = join(dir, "new-source-repo");
+		await mkdir(newSource, { recursive: true });
+		const newGit = simpleGit(newSource);
+		await newGit.init();
+		await newGit.addConfig("user.email", "test@test.com");
+		await newGit.addConfig("user.name", "Test");
+		await writeFile(join(newSource, "ONLY_IN_NEW.md"), "# only in new", "utf-8");
+		await newGit.add(".");
+		await newGit.commit("only-in-new");
+
+		const repoDir = await ensureRegistryRepo("test-reg", newSource, cacheDir);
+
+		// The cached repo's origin should now point at the new source, not the old.
+		const cachedGit = simpleGit(repoDir);
+		const origin = (await cachedGit.raw(["config", "--get", "remote.origin.url"])).trim();
+		expect(origin).toBe(newSource);
+
+		// The unique file from the new source must be reachable in the cache.
+		const lsTree = await cachedGit.raw(["ls-tree", "-r", "--name-only", "HEAD"]);
+		expect(lsTree).toContain("ONLY_IN_NEW.md");
+		expect(lsTree).not.toContain("README.md");
+	});
 });


### PR DESCRIPTION
Closes #2.

## Problem
Editing a registry's `url:` in `~/.skilltree/config.yaml` (or a dep's `repo:` in `skilltree.yaml`) to point at a new source was silently ineffective — the cached bare repo still had the old origin, and `cloneOrFetchBare` would `git fetch` against it, pulling from the stale remote. The only recovery was `skilltree registry remove` + re-add, or manual `skilltree cache clean`.

## Fix
Before fetching an existing cache, compare the cached repo's `origin` URL against the expected URL (both normalized through `toGitCloneUrl` + `normalizeGitUrl`, so cosmetic differences like missing `https://` or trailing `.git` don't trigger false positives). On drift, wipe the cache and re-clone against the new URL.

Implemented in `cloneOrFetchBare` — this one spot covers **both** the registry cache (`~/.skilltree/registry-cache/…`) and the dep-repo cache (`~/.skilltree/cache/…`).

## Test plan
- [x] New test: `ensureRegistryRepo` re-clones when URL changes (asserts new origin + new content, absence of old content)
- [x] Existing `ensureRegistryRepo` tests still pass (first-clone, subsequent-fetch)
- [x] Full suite passes (693 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)