### PR TITLE
feat(init): add --scan to discover in-tree skills and agents

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,8 +46,14 @@ program
 	.command("init")
 	.description("Initialize a new skilltree project")
 	.option("-g, --global", "Initialize global dependencies")
+	.option("--scan", "Scan the repo for existing skills/agents and register them as local deps")
+	.option("-y, --yes", "With --scan, include all discovered entries without prompting")
 	.action(async (opts) => {
-		await initCommand(process.cwd(), { global: opts.global });
+		await initCommand(process.cwd(), {
+			global: opts.global,
+			scan: opts.scan,
+			yes: opts.yes,
+		});
 	});
 
 program

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -19,7 +19,15 @@ const COMMANDS: CmdDef[] = [
 	{
 		name: "init",
 		description: "Initialize a new skilltree project",
-		flags: [{ long: "--global", short: "-g", description: "Initialize global dependencies" }],
+		flags: [
+			{ long: "--global", short: "-g", description: "Initialize global dependencies" },
+			{ long: "--scan", description: "Scan repo for existing skills/agents" },
+			{
+				long: "--yes",
+				short: "-y",
+				description: "Include all discovered entries without prompting",
+			},
+		],
 	},
 	{
 		name: "add",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,16 +1,22 @@
 import { writeFile } from "node:fs/promises";
 import { basename } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { detectInstalledAgents } from "../core/agents.js";
 import { globalManifestExists, MANIFEST_NEW, manifestExists } from "../core/filenames.js";
 import { addGitignoreEntries, getSkillAgentIgnoreEntries } from "../core/gitignore.js";
 import { serializeManifest, writeGlobalManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
+import { type LocalEntry, scanLocalRepo } from "../core/repo-scanner.js";
 import { dim, success, warn } from "../core/ui.js";
-import type { Manifest } from "../types.js";
+import type { Dependency, LocalDependency, Manifest } from "../types.js";
 
 export interface InitOptions {
 	global?: boolean;
 	homeDir?: string; // Override home directory for agent detection (testing)
+	scan?: boolean;
+	yes?: boolean;
+	/** Test override: pick which discovered entries to include, bypassing interactive prompt. */
+	selectFn?: (entries: LocalEntry[]) => Promise<LocalEntry[]>;
 }
 
 export async function initCommand(dir: string, options?: InitOptions): Promise<void> {
@@ -35,11 +41,30 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 		console.log(dim("No agents detected — defaulting to claude"));
 	}
 
+	// Optional repo scan for in-tree skills and agents.
+	const dependencies: Record<string, Dependency> = {};
+	if (options?.scan) {
+		const discovered = await scanLocalRepo(dir);
+		const selected = await selectDiscoveredEntries(discovered, options);
+		for (const entry of selected) {
+			const dep: LocalDependency = {
+				local: toLocalPathValue(entry.path),
+				type: entry.type,
+			};
+			dependencies[entry.name] = dep;
+		}
+		if (selected.length > 0) {
+			console.log(dim(`Registered ${selected.length} local ${pluralize("dep", selected.length)}.`));
+		} else if (discovered.length === 0) {
+			console.log(dim("No skills or agents found in the repo."));
+		}
+	}
+
 	const projectName = basename(dir);
 	const manifest: Manifest = {
 		name: projectName,
 		install_targets: installTargets,
-		dependencies: {},
+		dependencies,
 		"dev-dependencies": {},
 	};
 
@@ -74,4 +99,100 @@ async function initGlobal(): Promise<void> {
 
 	await writeGlobalManifest(manifest, globalDir);
 	success(`Created ${globalDir}/global.yaml`);
+}
+
+/**
+ * Decide which discovered entries to include. Resolution order:
+ *  1. Explicit `selectFn` (tests + future scripted flows).
+ *  2. `--yes`, or no entries, or non-TTY → include all (CI-safe default).
+ *  3. Interactive prompt — Y/n or comma-separated index list.
+ */
+async function selectDiscoveredEntries(
+	entries: LocalEntry[],
+	opts: InitOptions,
+): Promise<LocalEntry[]> {
+	if (opts.selectFn) return opts.selectFn(entries);
+	if (entries.length === 0) return [];
+	if (opts.yes || !process.stdout.isTTY) return entries;
+	return promptForSelection(entries);
+}
+
+async function promptForSelection(entries: LocalEntry[]): Promise<LocalEntry[]> {
+	printDiscovered(entries);
+
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	let answer: string;
+	try {
+		answer = (await rl.question("Include all? [Y/n/1,3,5] ")).trim();
+	} finally {
+		rl.close();
+	}
+
+	return parseSelectionAnswer(answer, entries);
+}
+
+function printDiscovered(entries: LocalEntry[]): void {
+	const skills = entries.filter((e) => e.type === "skill");
+	const agents = entries.filter((e) => e.type === "agent");
+
+	console.log(
+		`\nFound ${skills.length} skill${skills.length === 1 ? "" : "s"} and ${agents.length} agent${agents.length === 1 ? "" : "s"}:\n`,
+	);
+
+	let idx = 1;
+	for (const section of [
+		{ label: "Skills", items: skills },
+		{ label: "Agents", items: agents },
+	]) {
+		if (section.items.length === 0) continue;
+		console.log(`${section.label}:`);
+		for (const e of section.items) {
+			console.log(`  [${idx}] ${e.name.padEnd(24)} ${dim(e.path)}`);
+			idx++;
+		}
+		console.log("");
+	}
+}
+
+/**
+ * Parse the user's reply to the selection prompt.
+ *
+ * - Empty / `y` / `Y` → include all
+ * - `n` / `N` → include none
+ * - Comma-separated integers (1-based, matching the printed numbering) → subset
+ * - Invalid indices and garbage are ignored rather than failing the init —
+ *   the user can always re-run or hand-edit the manifest.
+ */
+export function parseSelectionAnswer(answer: string, entries: LocalEntry[]): LocalEntry[] {
+	const trimmed = answer.trim();
+	if (trimmed === "" || trimmed.toLowerCase() === "y") return entries;
+	if (trimmed.toLowerCase() === "n") return [];
+
+	const indices = trimmed
+		.split(",")
+		.map((s) => Number.parseInt(s.trim(), 10))
+		.filter((n) => Number.isInteger(n) && n >= 1 && n <= entries.length);
+
+	const selected: LocalEntry[] = [];
+	const seen = new Set<number>();
+	for (const i of indices) {
+		if (seen.has(i)) continue;
+		seen.add(i);
+		const entry = entries[i - 1];
+		if (entry) selected.push(entry);
+	}
+	return selected;
+}
+
+/**
+ * Format a scanner-relative path (always POSIX, no leading ./) into the
+ * form we write into the manifest: `./rel/path`.
+ */
+function toLocalPathValue(scanPath: string): string {
+	if (scanPath === "." || scanPath === "") return ".";
+	return scanPath.startsWith("./") ? scanPath : `./${scanPath}`;
+}
+
+function pluralize(word: string, n: number): string {
+	return n === 1 ? word : `${word}s`;
 }

--- a/src/core/repo-scanner.ts
+++ b/src/core/repo-scanner.ts
@@ -1,0 +1,136 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, dirname, join, relative, sep } from "node:path";
+import type { EntityType } from "../types.js";
+import { parseFrontmatter } from "./frontmatter.js";
+import { SKIP_MD_FILES } from "./registry-scanner.js";
+
+/**
+ * A discovered skill or agent in the local filesystem.
+ * Mirrors IndexEntry's shape but `path` is always POSIX-style relative
+ * to the scan root (so it can be written into skilltree.yaml as-is).
+ */
+export interface LocalEntry {
+	name: string;
+	type: EntityType;
+	/** POSIX-style path relative to the scan root. For skills, the dir containing SKILL.md. For agents, the .md file itself. */
+	path: string;
+	description?: string;
+}
+
+/**
+ * Directory names to skip during scan. Hidden dirs (`.*`) are skipped
+ * separately — these are the common build/vendor dirs that are not
+ * hidden but still never hold source skills or agents.
+ */
+const EXCLUDED_DIRS = new Set([
+	"node_modules",
+	"dist",
+	"build",
+	"coverage",
+	"target",
+	"out",
+	"vendor",
+]);
+
+/**
+ * Walk a repo directory looking for SKILL.md files (skills) and standalone
+ * .md files with a `name` frontmatter field (agents).
+ *
+ * Excludes hidden directories (`.claude/`, `.git/`, `.github/`, etc.) so
+ * installed artifacts are never picked up as sources.
+ *
+ * Malformed frontmatter on a single file does not abort the scan; that
+ * file is skipped and others continue. Results are sorted deterministically
+ * by (type, name) so the CLI can present them in a stable order.
+ */
+export async function scanLocalRepo(rootDir: string): Promise<LocalEntry[]> {
+	const entries: LocalEntry[] = [];
+	await walk(rootDir, rootDir, entries);
+	entries.sort((a, b) => {
+		if (a.type !== b.type) return a.type.localeCompare(b.type);
+		return a.name.localeCompare(b.name);
+	});
+	return entries;
+}
+
+async function walk(rootDir: string, currentDir: string, out: LocalEntry[]): Promise<void> {
+	let dirents: Dirent[];
+	try {
+		dirents = (await readdir(currentDir, { withFileTypes: true })) as Dirent[];
+	} catch {
+		return;
+	}
+
+	for (const dirent of dirents) {
+		const fullPath = join(currentDir, dirent.name);
+
+		if (dirent.isDirectory()) {
+			if (dirent.name.startsWith(".")) continue;
+			if (EXCLUDED_DIRS.has(dirent.name)) continue;
+			await walk(rootDir, fullPath, out);
+			continue;
+		}
+
+		if (!dirent.isFile()) continue;
+		if (!dirent.name.endsWith(".md")) continue;
+
+		const entry = await classifyMdFile(rootDir, fullPath, dirent.name);
+		if (entry) out.push(entry);
+	}
+}
+
+async function classifyMdFile(
+	rootDir: string,
+	fullPath: string,
+	baseName: string,
+): Promise<LocalEntry | null> {
+	const isSkillFile = baseName === "SKILL.md";
+
+	if (!isSkillFile && SKIP_MD_FILES.has(baseName)) return null;
+
+	let content: string;
+	try {
+		content = await readFile(fullPath, "utf-8");
+	} catch {
+		return null;
+	}
+
+	let fm: ReturnType<typeof parseFrontmatter>;
+	try {
+		fm = parseFrontmatter(content);
+	} catch {
+		// Malformed frontmatter — skip this file, not the whole scan.
+		return null;
+	}
+
+	const relPath = toPosix(relative(rootDir, fullPath));
+
+	if (isSkillFile) {
+		const skillDir = dirname(relPath);
+		const name = fm?.name ?? basename(skillDir === "." ? rootDir : skillDir);
+		const entry: LocalEntry = {
+			name,
+			type: "skill",
+			path: skillDir === "" ? "." : skillDir,
+		};
+		if (fm?.description) entry.description = fm.description;
+		return entry;
+	}
+
+	// Agent candidate — require a name in frontmatter. Without one we have
+	// no stable identifier and the file is probably not an agent anyway.
+	if (!fm?.name) return null;
+
+	const entry: LocalEntry = {
+		name: fm.name,
+		type: "agent",
+		path: relPath,
+	};
+	if (fm.description) entry.description = fm.description;
+	return entry;
+}
+
+function toPosix(p: string): string {
+	return sep === "/" ? p : p.split(sep).join("/");
+}

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { initCommand } from "../../src/commands/init.js";
+import { initCommand, parseSelectionAnswer } from "../../src/commands/init.js";
+import { readManifest } from "../../src/core/manifest.js";
+import type { LocalEntry } from "../../src/core/repo-scanner.js";
 
 let tempDir: string;
 
@@ -63,5 +65,118 @@ describe("initCommand", () => {
 		await mkdir(fakeHome, { recursive: true });
 		await initCommand(dir, { homeDir: fakeHome });
 		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow("already exists");
+	});
+
+	test("--scan with --yes registers discovered skills and agents as local deps", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		// Seed the repo with a skill and an agent.
+		await mkdir(join(dir, "skills/my-skill"), { recursive: true });
+		await writeFile(
+			join(dir, "skills/my-skill/SKILL.md"),
+			"---\nname: my-skill\ndescription: A fine skill\n---\n",
+		);
+		await mkdir(join(dir, "agents"), { recursive: true });
+		await writeFile(
+			join(dir, "agents/code-reviewer.md"),
+			"---\nname: code-reviewer\ndescription: Reviews code\n---\n",
+		);
+
+		await initCommand(dir, { homeDir: fakeHome, scan: true, yes: true });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["my-skill"]).toEqual({
+			local: "./skills/my-skill",
+			type: "skill",
+		});
+		expect(manifest.dependencies?.["code-reviewer"]).toEqual({
+			local: "./agents/code-reviewer.md",
+			type: "agent",
+		});
+	});
+
+	test("--scan without entries does not add dependencies", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await initCommand(dir, { homeDir: fakeHome, scan: true, yes: true });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies).toEqual({});
+	});
+
+	test("--scan with selectFn returning subset only registers chosen entries", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await mkdir(join(dir, "skills/keep-me"), { recursive: true });
+		await writeFile(join(dir, "skills/keep-me/SKILL.md"), "---\nname: keep-me\n---\n");
+		await mkdir(join(dir, "skills/drop-me"), { recursive: true });
+		await writeFile(join(dir, "skills/drop-me/SKILL.md"), "---\nname: drop-me\n---\n");
+
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			scan: true,
+			// Select only the first entry (sorted by type, name → "drop-me, keep-me")
+			// Actually the test should not depend on sort order — filter explicitly.
+			selectFn: async (found) => found.filter((f) => f.name === "keep-me"),
+		});
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["keep-me"]).toBeDefined();
+		expect(manifest.dependencies?.["drop-me"]).toBeUndefined();
+	});
+
+	describe("parseSelectionAnswer", () => {
+		const sample: LocalEntry[] = [
+			{ name: "a", type: "skill", path: "skills/a" },
+			{ name: "b", type: "skill", path: "skills/b" },
+			{ name: "c", type: "agent", path: "agents/c.md" },
+		];
+
+		const cases: Array<[string, string[]]> = [
+			["", ["a", "b", "c"]],
+			["y", ["a", "b", "c"]],
+			["Y", ["a", "b", "c"]],
+			["n", []],
+			["N", []],
+			["1", ["a"]],
+			["1,3", ["a", "c"]],
+			["1, 3", ["a", "c"]],
+			["3,1", ["c", "a"]],
+			["1,1,2", ["a", "b"]], // duplicates collapsed, original order preserved
+			["99", []], // out-of-range ignored
+			["1,99,2", ["a", "b"]], // mixed in/out-of-range → valid ones kept
+			["garbage", []],
+		];
+
+		for (const [input, expectedNames] of cases) {
+			test(`"${input}" → [${expectedNames.join(", ")}]`, () => {
+				const picked = parseSelectionAnswer(input, sample);
+				expect(picked.map((e) => e.name)).toEqual(expectedNames);
+			});
+		}
+	});
+
+	test("--scan without --yes and no tty/selectFn defaults to include-all", async () => {
+		// This mirrors the CI/non-interactive path: if stdout is not a TTY
+		// and no selector is provided, `init --scan` should not hang on
+		// readline. Since Bun's test stdout is not a TTY, calling without
+		// selectFn / yes exercises the fallback.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await mkdir(join(dir, "skills/only-one"), { recursive: true });
+		await writeFile(join(dir, "skills/only-one/SKILL.md"), "---\nname: only-one\n---\n");
+
+		await initCommand(dir, { homeDir: fakeHome, scan: true });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["only-one"]).toBeDefined();
 	});
 });

--- a/tests/core/repo-scanner.test.ts
+++ b/tests/core/repo-scanner.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanLocalRepo } from "../../src/core/repo-scanner.js";
+
+let tempDir: string;
+
+async function setup(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-repo-scan-"));
+	return tempDir;
+}
+
+async function writeSkill(dir: string, skillDir: string, name: string, description?: string) {
+	const abs = join(dir, skillDir);
+	await mkdir(abs, { recursive: true });
+	const fm = description
+		? `---\nname: ${name}\ndescription: ${description}\n---\n\nBody\n`
+		: `---\nname: ${name}\n---\n\nBody\n`;
+	await writeFile(join(abs, "SKILL.md"), fm);
+}
+
+async function writeAgent(dir: string, relPath: string, fm: string) {
+	const abs = join(dir, relPath);
+	await mkdir(join(abs, ".."), { recursive: true });
+	await writeFile(abs, `---\n${fm}\n---\n\nBody\n`);
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe("scanLocalRepo", () => {
+	test("returns empty array for a directory with no skills or agents", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "README.md"), "# hello\n");
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("finds a single SKILL.md", async () => {
+		const dir = await setup();
+		await writeSkill(dir, "skills/my-skill", "my-skill", "A fine skill");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			name: "my-skill",
+			type: "skill",
+			path: "skills/my-skill",
+			description: "A fine skill",
+		});
+	});
+
+	test("falls back to directory basename when frontmatter has no name", async () => {
+		const dir = await setup();
+		const abs = join(dir, "skills/unnamed");
+		await mkdir(abs, { recursive: true });
+		await writeFile(join(abs, "SKILL.md"), "---\ndescription: no name\n---\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.name).toBe("unnamed");
+		expect(result[0]?.type).toBe("skill");
+	});
+
+	test("finds agent .md with frontmatter name", async () => {
+		const dir = await setup();
+		await writeAgent(
+			dir,
+			"agents/code-reviewer.md",
+			"name: code-reviewer\ndescription: Reviews code",
+		);
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			name: "code-reviewer",
+			type: "agent",
+			path: "agents/code-reviewer.md",
+			description: "Reviews code",
+		});
+	});
+
+	test("skips .md files without frontmatter", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "notes.md"), "# just a note\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("skips .md files with frontmatter but no name", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "random.md"), "---\ntags: [a, b]\n---\n\nBody\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("skips reserved .md filenames like README.md, CHANGELOG.md", async () => {
+		const dir = await setup();
+		// Even with frontmatter that looks agent-shaped, reserved names must not
+		// be treated as agents.
+		await writeFile(join(dir, "README.md"), "---\nname: the-readme\n---\n\n# Readme\n");
+		await writeFile(join(dir, "CHANGELOG.md"), "---\nname: changes\n---\n\n# Changelog\n");
+		await writeFile(join(dir, "CLAUDE.md"), "---\nname: instructions\n---\n\nConfig\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("excludes hidden dirs (.claude, .git, .github)", async () => {
+		const dir = await setup();
+		// Installed artifacts under .claude/ must NOT be picked up.
+		await writeSkill(dir, ".claude/skills/installed", "installed");
+		await writeAgent(dir, ".claude/agents/installed-agent.md", "name: installed-agent");
+		await writeAgent(dir, ".github/workflows/ci.md", "name: ci");
+		await mkdir(join(dir, ".git"), { recursive: true });
+		await writeFile(join(dir, ".git/HEAD"), "ref: refs/heads/main\n");
+
+		// A real, in-repo skill must still be found.
+		await writeSkill(dir, "skills/real", "real");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.name).toBe("real");
+	});
+
+	test("excludes node_modules, dist, build, coverage", async () => {
+		const dir = await setup();
+		await writeSkill(dir, "node_modules/pkg/skills/nope", "nope-nm");
+		await writeSkill(dir, "dist/skills/nope", "nope-dist");
+		await writeSkill(dir, "build/skills/nope", "nope-build");
+		await writeSkill(dir, "coverage/skills/nope", "nope-cov");
+		await writeSkill(dir, "skills/keep", "keep");
+
+		const result = await scanLocalRepo(dir);
+		expect(result.map((r) => r.name).sort()).toEqual(["keep"]);
+	});
+
+	test("finds skills and agents together, sorted by (type, name)", async () => {
+		const dir = await setup();
+		await writeSkill(dir, "skills/b-skill", "b-skill");
+		await writeSkill(dir, "skills/a-skill", "a-skill");
+		await writeAgent(dir, "agents/z-agent.md", "name: z-agent");
+		await writeAgent(dir, "agents/m-agent.md", "name: m-agent");
+
+		const result = await scanLocalRepo(dir);
+		expect(result.map((r) => `${r.type}:${r.name}`)).toEqual([
+			"agent:m-agent",
+			"agent:z-agent",
+			"skill:a-skill",
+			"skill:b-skill",
+		]);
+	});
+
+	test("tolerates malformed frontmatter without crashing (skips file)", async () => {
+		const dir = await setup();
+		await mkdir(join(dir, "agents"), { recursive: true });
+		// Unclosed frontmatter — parseFrontmatter throws. Scanner must not propagate.
+		await writeFile(join(dir, "agents/bad.md"), "---\nname: bad\n");
+		// A good sibling must still be reported.
+		await writeAgent(dir, "agents/good.md", "name: good");
+
+		const result = await scanLocalRepo(dir);
+		expect(result.map((r) => r.name)).toEqual(["good"]);
+	});
+});


### PR DESCRIPTION
Closes #1.

## Summary
`skilltree init --scan` walks the repo filesystem for existing skills (via `SKILL.md`) and agents (via `.md` files with `name:` in YAML frontmatter), offering discovered entries for inclusion as `local:` deps in the new manifest. No more `skilltree add ./skills/foo` N times when onboarding a skills-heavy repo.

## UX (Option A from #1)

```
❯ skilltree init --scan
Detected agents: claude, cursor

Found 3 skills and 2 agents:

Skills:
  [1] general-coding        skills/general-coding
  [2] python-coding         skills/python-coding
  [3] typescript-coding     skills/typescript-coding

Agents:
  [4] code-reviewer         agents/code-reviewer.md
  [5] test-runner           agents/test-runner.md

Include all? [Y/n/1,3,5]
```

Input handling: empty or `Y` → all; `n` → none; comma-separated indices → subset. Invalid/out-of-range indices are silently dropped (user can re-run or hand-edit the manifest).

`--yes` and non-TTY (CI) default to "include all" — the prompt never blocks unattended runs.

## What's excluded from the scan
- Hidden directories (`.claude/`, `.git/`, `.github/`, `.cursor/`, etc.) — keeps installed artifacts from being picked up as sources.
- `node_modules/`, `dist/`, `build/`, `coverage/`, `target/`, `out/`, `vendor/`.
- Reserved `.md` filenames (`README.md`, `CHANGELOG.md`, `CLAUDE.md`, etc. — the full `SKIP_MD_FILES` list from `registry-scanner.ts`).

## Test plan

### Scanner (11 tests, `tests/core/repo-scanner.test.ts`)
- [x] Empty dir → `[]`
- [x] Single `SKILL.md` → one skill entry with description from frontmatter
- [x] SKILL.md without `name` → falls back to directory basename
- [x] Standalone `.md` with `name` frontmatter → agent entry
- [x] Plain `.md` (no frontmatter) → skipped
- [x] `.md` with frontmatter but no `name` → skipped
- [x] Reserved names (README, CHANGELOG, CLAUDE) → skipped even with agent-shaped frontmatter
- [x] Hidden dirs excluded (`.claude/`, `.github/`, `.git/`) — real skill outside still found
- [x] Build dirs excluded (`node_modules/`, `dist/`, `build/`, `coverage/`)
- [x] Skills + agents together → sorted by `(type, name)`
- [x] Malformed frontmatter → that file skipped, scan continues

### Init integration (init.test.ts additions)
- [x] `--scan --yes` with seeded skill + agent → both registered as `local:` deps with correct `type:`
- [x] `--scan --yes` on empty repo → `dependencies: {}`
- [x] `--scan` with `selectFn` filter → only chosen entry registered
- [x] `--scan` without `--yes` in non-TTY (test env) → include-all fallback

### parseSelectionAnswer (13 parametrized cases)
- [x] Empty / `y` / `Y` → all; `n` / `N` → none
- [x] Single index, multi-index, reordered, duplicates collapsed
- [x] Out-of-range silently dropped; mixed valid+invalid keeps valid
- [x] Garbage input → none

### Completion + CLI
- [x] `--scan` and `--yes` added to `completion.ts` (freshness test passes)
- [x] `skilltree init --help` shows both flags

### Regression
- [x] Full suite: **720 tests pass**
- [x] End-to-end smoke: `init --scan --yes` on a temp repo produces a correct manifest

## Deferred
- `.gitignore`-aware exclusion (currently hardcoded common dirs).
- `--no-scan` explicit opt-out (only matters if we ever make `--scan` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)