### PR TITLE
feat(init): batch fixes — install hint, cache drift, repo scan

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,8 +46,14 @@ program
 	.command("init")
 	.description("Initialize a new skilltree project")
 	.option("-g, --global", "Initialize global dependencies")
+	.option("--scan", "Scan the repo for existing skills/agents and register them as local deps")
+	.option("-y, --yes", "With --scan, include all discovered entries without prompting")
 	.action(async (opts) => {
-		await initCommand(process.cwd(), { global: opts.global });
+		await initCommand(process.cwd(), {
+			global: opts.global,
+			scan: opts.scan,
+			yes: opts.yes,
+		});
 	});
 
 program

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -60,6 +60,8 @@ export async function addCommand(name: string, opts: AddOptions, dir: string): P
 		await writeManifest(dir, manifest);
 	}
 	success(`Added ${name} to ${group}${opts.global ? " (global)" : ""}`);
+	const installCmd = opts.global ? "skilltree install --global" : "skilltree install";
+	console.log(dim(`  Run \`${installCmd}\` to install.`));
 }
 
 function validateAddFlags(opts: AddOptions): void {

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -19,7 +19,15 @@ const COMMANDS: CmdDef[] = [
 	{
 		name: "init",
 		description: "Initialize a new skilltree project",
-		flags: [{ long: "--global", short: "-g", description: "Initialize global dependencies" }],
+		flags: [
+			{ long: "--global", short: "-g", description: "Initialize global dependencies" },
+			{ long: "--scan", description: "Scan repo for existing skills/agents" },
+			{
+				long: "--yes",
+				short: "-y",
+				description: "Include all discovered entries without prompting",
+			},
+		],
 	},
 	{
 		name: "add",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,16 +1,22 @@
 import { writeFile } from "node:fs/promises";
 import { basename } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { detectInstalledAgents } from "../core/agents.js";
 import { globalManifestExists, MANIFEST_NEW, manifestExists } from "../core/filenames.js";
 import { addGitignoreEntries, getSkillAgentIgnoreEntries } from "../core/gitignore.js";
 import { serializeManifest, writeGlobalManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
+import { type LocalEntry, scanLocalRepo } from "../core/repo-scanner.js";
 import { dim, success, warn } from "../core/ui.js";
-import type { Manifest } from "../types.js";
+import type { Dependency, LocalDependency, Manifest } from "../types.js";
 
 export interface InitOptions {
 	global?: boolean;
 	homeDir?: string; // Override home directory for agent detection (testing)
+	scan?: boolean;
+	yes?: boolean;
+	/** Test override: pick which discovered entries to include, bypassing interactive prompt. */
+	selectFn?: (entries: LocalEntry[]) => Promise<LocalEntry[]>;
 }
 
 export async function initCommand(dir: string, options?: InitOptions): Promise<void> {
@@ -35,11 +41,30 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 		console.log(dim("No agents detected — defaulting to claude"));
 	}
 
+	// Optional repo scan for in-tree skills and agents.
+	const dependencies: Record<string, Dependency> = {};
+	if (options?.scan) {
+		const discovered = await scanLocalRepo(dir);
+		const selected = await selectDiscoveredEntries(discovered, options);
+		for (const entry of selected) {
+			const dep: LocalDependency = {
+				local: toLocalPathValue(entry.path),
+				type: entry.type,
+			};
+			dependencies[entry.name] = dep;
+		}
+		if (selected.length > 0) {
+			console.log(dim(`Registered ${selected.length} local ${pluralize("dep", selected.length)}.`));
+		} else if (discovered.length === 0) {
+			console.log(dim("No skills or agents found in the repo."));
+		}
+	}
+
 	const projectName = basename(dir);
 	const manifest: Manifest = {
 		name: projectName,
 		install_targets: installTargets,
-		dependencies: {},
+		dependencies,
 		"dev-dependencies": {},
 	};
 
@@ -74,4 +99,100 @@ async function initGlobal(): Promise<void> {
 
 	await writeGlobalManifest(manifest, globalDir);
 	success(`Created ${globalDir}/global.yaml`);
+}
+
+/**
+ * Decide which discovered entries to include. Resolution order:
+ *  1. Explicit `selectFn` (tests + future scripted flows).
+ *  2. `--yes`, or no entries, or non-TTY → include all (CI-safe default).
+ *  3. Interactive prompt — Y/n or comma-separated index list.
+ */
+async function selectDiscoveredEntries(
+	entries: LocalEntry[],
+	opts: InitOptions,
+): Promise<LocalEntry[]> {
+	if (opts.selectFn) return opts.selectFn(entries);
+	if (entries.length === 0) return [];
+	if (opts.yes || !process.stdout.isTTY) return entries;
+	return promptForSelection(entries);
+}
+
+async function promptForSelection(entries: LocalEntry[]): Promise<LocalEntry[]> {
+	printDiscovered(entries);
+
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	let answer: string;
+	try {
+		answer = (await rl.question("Include all? [Y/n/1,3,5] ")).trim();
+	} finally {
+		rl.close();
+	}
+
+	return parseSelectionAnswer(answer, entries);
+}
+
+function printDiscovered(entries: LocalEntry[]): void {
+	const skills = entries.filter((e) => e.type === "skill");
+	const agents = entries.filter((e) => e.type === "agent");
+
+	console.log(
+		`\nFound ${skills.length} skill${skills.length === 1 ? "" : "s"} and ${agents.length} agent${agents.length === 1 ? "" : "s"}:\n`,
+	);
+
+	let idx = 1;
+	for (const section of [
+		{ label: "Skills", items: skills },
+		{ label: "Agents", items: agents },
+	]) {
+		if (section.items.length === 0) continue;
+		console.log(`${section.label}:`);
+		for (const e of section.items) {
+			console.log(`  [${idx}] ${e.name.padEnd(24)} ${dim(e.path)}`);
+			idx++;
+		}
+		console.log("");
+	}
+}
+
+/**
+ * Parse the user's reply to the selection prompt.
+ *
+ * - Empty / `y` / `Y` → include all
+ * - `n` / `N` → include none
+ * - Comma-separated integers (1-based, matching the printed numbering) → subset
+ * - Invalid indices and garbage are ignored rather than failing the init —
+ *   the user can always re-run or hand-edit the manifest.
+ */
+export function parseSelectionAnswer(answer: string, entries: LocalEntry[]): LocalEntry[] {
+	const trimmed = answer.trim();
+	if (trimmed === "" || trimmed.toLowerCase() === "y") return entries;
+	if (trimmed.toLowerCase() === "n") return [];
+
+	const indices = trimmed
+		.split(",")
+		.map((s) => Number.parseInt(s.trim(), 10))
+		.filter((n) => Number.isInteger(n) && n >= 1 && n <= entries.length);
+
+	const selected: LocalEntry[] = [];
+	const seen = new Set<number>();
+	for (const i of indices) {
+		if (seen.has(i)) continue;
+		seen.add(i);
+		const entry = entries[i - 1];
+		if (entry) selected.push(entry);
+	}
+	return selected;
+}
+
+/**
+ * Format a scanner-relative path (always POSIX, no leading ./) into the
+ * form we write into the manifest: `./rel/path`.
+ */
+function toLocalPathValue(scanPath: string): string {
+	if (scanPath === "." || scanPath === "") return ".";
+	return scanPath.startsWith("./") ? scanPath : `./${scanPath}`;
+}
+
+function pluralize(word: string, n: number): string {
+	return n === 1 ? word : `${word}s`;
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,15 +13,18 @@ import type { Dependency, LocalDependency, Manifest } from "../types.js";
 export interface InitOptions {
 	global?: boolean;
 	homeDir?: string; // Override home directory for agent detection (testing)
+	globalDir?: string; // Override global manifest dir (testing + --global flow)
 	scan?: boolean;
 	yes?: boolean;
 	/** Test override: pick which discovered entries to include, bypassing interactive prompt. */
 	selectFn?: (entries: LocalEntry[]) => Promise<LocalEntry[]>;
+	/** Test override: canned answer for the interactive prompt — exercises the prompt pipeline without readline. */
+	askFn?: (question: string) => Promise<string>;
 }
 
 export async function initCommand(dir: string, options?: InitOptions): Promise<void> {
 	if (options?.global) {
-		return initGlobal();
+		return initGlobal(options.globalDir);
 	}
 
 	const manifestPath = `${dir}/${MANIFEST_NEW}`;
@@ -85,8 +88,8 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 	}
 }
 
-async function initGlobal(): Promise<void> {
-	const globalDir = getGlobalDir();
+async function initGlobal(globalDirOverride?: string): Promise<void> {
+	const globalDir = globalDirOverride ?? getGlobalDir();
 
 	if (globalManifestExists(globalDir)) {
 		warn(`${globalDir}/global.yaml already exists. No changes made.`);
@@ -103,9 +106,11 @@ async function initGlobal(): Promise<void> {
 
 /**
  * Decide which discovered entries to include. Resolution order:
- *  1. Explicit `selectFn` (tests + future scripted flows).
- *  2. `--yes`, or no entries, or non-TTY → include all (CI-safe default).
- *  3. Interactive prompt — Y/n or comma-separated index list.
+ *  1. Explicit `selectFn` (tests + future scripted flows) — bypass prompt entirely.
+ *  2. No entries → nothing to include.
+ *  3. `--yes` → include all without prompting.
+ *  4. An `askFn` (test hook) or a TTY → prompt via that asker.
+ *  5. Otherwise (non-TTY, no hooks) → include all (CI-safe default).
  */
 async function selectDiscoveredEntries(
 	entries: LocalEntry[],
@@ -113,22 +118,27 @@ async function selectDiscoveredEntries(
 ): Promise<LocalEntry[]> {
 	if (opts.selectFn) return opts.selectFn(entries);
 	if (entries.length === 0) return [];
-	if (opts.yes || !process.stdout.isTTY) return entries;
-	return promptForSelection(entries);
+	if (opts.yes) return entries;
+	const ask = opts.askFn ?? (process.stdout.isTTY ? readlineAsk : null);
+	if (!ask) return entries;
+	return promptForSelection(entries, ask);
 }
 
-async function promptForSelection(entries: LocalEntry[]): Promise<LocalEntry[]> {
-	printDiscovered(entries);
+type AskFn = (question: string) => Promise<string>;
 
+async function promptForSelection(entries: LocalEntry[], ask: AskFn): Promise<LocalEntry[]> {
+	printDiscovered(entries);
+	const answer = (await ask("Include all? [Y/n/1,3,5] ")).trim();
+	return parseSelectionAnswer(answer, entries);
+}
+
+async function readlineAsk(question: string): Promise<string> {
 	const rl = createInterface({ input: process.stdin, output: process.stdout });
-	let answer: string;
 	try {
-		answer = (await rl.question("Include all? [Y/n/1,3,5] ")).trim();
+		return await rl.question(question);
 	} finally {
 		rl.close();
 	}
-
-	return parseSelectionAnswer(answer, entries);
 }
 
 function printDiscovered(entries: LocalEntry[]): void {

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -143,7 +143,11 @@ export function toGitCloneUrl(repo: string): string {
 /**
  * Clone a bare repo if it doesn't exist, or fetch if it does.
  * If the directory exists but is not a valid bare repo (e.g., empty dir
- * from a failed previous clone), it is removed and re-cloned.
+ * from a failed previous clone), it is removed and re-cloned. If the
+ * cached repo's `origin` URL differs from `repoUrl` (user edited the
+ * source in skilltree.yaml or config.yaml), the cache is invalidated
+ * and re-cloned against the new URL — a plain fetch would silently
+ * pull from the stale remote.
  */
 export async function cloneOrFetchBare(repoUrl: string, targetDir: string): Promise<void> {
 	if (existsSync(targetDir)) {
@@ -157,19 +161,45 @@ export async function cloneOrFetchBare(repoUrl: string, targetDir: string): Prom
 				const configContent = await readFile(configFile, "utf-8");
 				if (configContent.includes('[remote "origin"]')) {
 					const git = simpleGit(targetDir);
-					await git.fetch(["--tags", "--prune"]);
-					return;
+					if (await isOriginUrlDrifted(git, repoUrl)) {
+						await rm(targetDir, { recursive: true, force: true });
+					} else {
+						await git.fetch(["--tags", "--prune"]);
+						return;
+					}
 				}
 			} catch {
 				// Config unreadable — fall through to re-clone
 			}
 		}
-		// Corrupt/incomplete directory — remove and re-clone
-		await rm(targetDir, { recursive: true, force: true });
+		// Corrupt/incomplete directory, or drift path that didn't `return` — ensure removed.
+		if (existsSync(targetDir)) {
+			await rm(targetDir, { recursive: true, force: true });
+		}
 	}
 	await mkdir(targetDir, { recursive: true });
 	const gitUrl = toGitCloneUrl(repoUrl);
 	await simpleGit().clone(gitUrl, targetDir, ["--bare"]);
+}
+
+/**
+ * Compare the cached repo's `origin` URL against the expected URL. Both
+ * sides are run through `toGitCloneUrl` + `normalizeGitUrl` so cosmetic
+ * differences (missing https://, trailing .git, etc.) don't cause a
+ * spurious re-clone. Returns true when the resolved URLs disagree.
+ */
+async function isOriginUrlDrifted(
+	git: ReturnType<typeof simpleGit>,
+	expectedUrl: string,
+): Promise<boolean> {
+	try {
+		const cachedOrigin = (await git.raw(["config", "--get", "remote.origin.url"])).trim();
+		if (!cachedOrigin) return false;
+		return normalizeGitUrl(cachedOrigin) !== normalizeGitUrl(toGitCloneUrl(expectedUrl));
+	} catch {
+		// Missing/unreadable origin — let the caller fall through to re-clone.
+		return true;
+	}
 }
 
 export function getCacheDir(): string {

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -194,7 +194,10 @@ async function isOriginUrlDrifted(
 ): Promise<boolean> {
 	try {
 		const cachedOrigin = (await git.raw(["config", "--get", "remote.origin.url"])).trim();
-		if (!cachedOrigin) return false;
+		// Empty origin means a `[remote "origin"]` header with no url line — a
+		// corrupt/partial clone. Treat as drift so the caller re-clones rather
+		// than silently fetching against a nonexistent remote.
+		if (!cachedOrigin) return true;
 		return normalizeGitUrl(cachedOrigin) !== normalizeGitUrl(toGitCloneUrl(expectedUrl));
 	} catch {
 		// Missing/unreadable origin — let the caller fall through to re-clone.

--- a/src/core/repo-scanner.ts
+++ b/src/core/repo-scanner.ts
@@ -1,0 +1,136 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, dirname, join, relative, sep } from "node:path";
+import type { EntityType } from "../types.js";
+import { parseFrontmatter } from "./frontmatter.js";
+import { SKIP_MD_FILES } from "./registry-scanner.js";
+
+/**
+ * A discovered skill or agent in the local filesystem.
+ * Mirrors IndexEntry's shape but `path` is always POSIX-style relative
+ * to the scan root (so it can be written into skilltree.yaml as-is).
+ */
+export interface LocalEntry {
+	name: string;
+	type: EntityType;
+	/** POSIX-style path relative to the scan root. For skills, the dir containing SKILL.md. For agents, the .md file itself. */
+	path: string;
+	description?: string;
+}
+
+/**
+ * Directory names to skip during scan. Hidden dirs (`.*`) are skipped
+ * separately — these are the common build/vendor dirs that are not
+ * hidden but still never hold source skills or agents.
+ */
+const EXCLUDED_DIRS = new Set([
+	"node_modules",
+	"dist",
+	"build",
+	"coverage",
+	"target",
+	"out",
+	"vendor",
+]);
+
+/**
+ * Walk a repo directory looking for SKILL.md files (skills) and standalone
+ * .md files with a `name` frontmatter field (agents).
+ *
+ * Excludes hidden directories (`.claude/`, `.git/`, `.github/`, etc.) so
+ * installed artifacts are never picked up as sources.
+ *
+ * Malformed frontmatter on a single file does not abort the scan; that
+ * file is skipped and others continue. Results are sorted deterministically
+ * by (type, name) so the CLI can present them in a stable order.
+ */
+export async function scanLocalRepo(rootDir: string): Promise<LocalEntry[]> {
+	const entries: LocalEntry[] = [];
+	await walk(rootDir, rootDir, entries);
+	entries.sort((a, b) => {
+		if (a.type !== b.type) return a.type.localeCompare(b.type);
+		return a.name.localeCompare(b.name);
+	});
+	return entries;
+}
+
+async function walk(rootDir: string, currentDir: string, out: LocalEntry[]): Promise<void> {
+	let dirents: Dirent[];
+	try {
+		dirents = (await readdir(currentDir, { withFileTypes: true })) as Dirent[];
+	} catch {
+		return;
+	}
+
+	for (const dirent of dirents) {
+		const fullPath = join(currentDir, dirent.name);
+
+		if (dirent.isDirectory()) {
+			if (dirent.name.startsWith(".")) continue;
+			if (EXCLUDED_DIRS.has(dirent.name)) continue;
+			await walk(rootDir, fullPath, out);
+			continue;
+		}
+
+		if (!dirent.isFile()) continue;
+		if (!dirent.name.endsWith(".md")) continue;
+
+		const entry = await classifyMdFile(rootDir, fullPath, dirent.name);
+		if (entry) out.push(entry);
+	}
+}
+
+async function classifyMdFile(
+	rootDir: string,
+	fullPath: string,
+	baseName: string,
+): Promise<LocalEntry | null> {
+	const isSkillFile = baseName === "SKILL.md";
+
+	if (!isSkillFile && SKIP_MD_FILES.has(baseName)) return null;
+
+	let content: string;
+	try {
+		content = await readFile(fullPath, "utf-8");
+	} catch {
+		return null;
+	}
+
+	let fm: ReturnType<typeof parseFrontmatter>;
+	try {
+		fm = parseFrontmatter(content);
+	} catch {
+		// Malformed frontmatter — skip this file, not the whole scan.
+		return null;
+	}
+
+	const relPath = toPosix(relative(rootDir, fullPath));
+
+	if (isSkillFile) {
+		const skillDir = dirname(relPath);
+		const name = fm?.name ?? basename(skillDir === "." ? rootDir : skillDir);
+		const entry: LocalEntry = {
+			name,
+			type: "skill",
+			path: skillDir === "" ? "." : skillDir,
+		};
+		if (fm?.description) entry.description = fm.description;
+		return entry;
+	}
+
+	// Agent candidate — require a name in frontmatter. Without one we have
+	// no stable identifier and the file is probably not an agent anyway.
+	if (!fm?.name) return null;
+
+	const entry: LocalEntry = {
+		name: fm.name,
+		type: "agent",
+		path: relPath,
+	};
+	if (fm.description) entry.description = fm.description;
+	return entry;
+}
+
+function toPosix(p: string): string {
+	return sep === "/" ? p : p.split(sep).join("/");
+}

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -428,4 +428,50 @@ describe("addCommand", () => {
 		const manifest = await readManifest(dir);
 		expect((manifest.dependencies?.["my-skill"] as { version: string }).version).toBe("^2.0.0");
 	});
+
+	test("prints hint to run `skilltree install` after adding a project dep", async () => {
+		const dir = await setup();
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (msg: string) => logs.push(msg);
+		try {
+			await addCommand(
+				"task-builder",
+				{ repo: "github.com/company/skills", path: "skills/task-builder", version: "^2.0.0" },
+				dir,
+			);
+		} finally {
+			console.log = originalLog;
+		}
+
+		// Must tell the user the next step — adding to the manifest alone
+		// does not install the dep (lockfile is the source of truth for list/install).
+		const joined = logs.join("\n");
+		expect(joined).toContain("skilltree install");
+		expect(joined).not.toContain("--global");
+	});
+
+	test("prints hint to run `skilltree install --global` after adding a global dep", async () => {
+		const dir = await setup();
+		const localPath = join(dir, "skills", "my-skill");
+		await mkdir(localPath, { recursive: true });
+		await writeFile(join(localPath, "SKILL.md"), "---\nname: my-skill\n---\n");
+
+		const globalDir = join(dir, "global-config");
+		const { writeGlobalManifest } = await import("../../src/core/manifest.js");
+		await writeGlobalManifest({ dependencies: {} }, globalDir);
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (msg: string) => logs.push(msg);
+		try {
+			await addCommand("my-skill", { local: localPath, global: true, globalDir }, dir);
+		} finally {
+			console.log = originalLog;
+		}
+
+		const joined = logs.join("\n");
+		expect(joined).toContain("skilltree install --global");
+	});
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { initCommand } from "../../src/commands/init.js";
+import { initCommand, parseSelectionAnswer } from "../../src/commands/init.js";
+import { readManifest } from "../../src/core/manifest.js";
+import type { LocalEntry } from "../../src/core/repo-scanner.js";
 
 let tempDir: string;
 
@@ -63,5 +65,118 @@ describe("initCommand", () => {
 		await mkdir(fakeHome, { recursive: true });
 		await initCommand(dir, { homeDir: fakeHome });
 		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow("already exists");
+	});
+
+	test("--scan with --yes registers discovered skills and agents as local deps", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		// Seed the repo with a skill and an agent.
+		await mkdir(join(dir, "skills/my-skill"), { recursive: true });
+		await writeFile(
+			join(dir, "skills/my-skill/SKILL.md"),
+			"---\nname: my-skill\ndescription: A fine skill\n---\n",
+		);
+		await mkdir(join(dir, "agents"), { recursive: true });
+		await writeFile(
+			join(dir, "agents/code-reviewer.md"),
+			"---\nname: code-reviewer\ndescription: Reviews code\n---\n",
+		);
+
+		await initCommand(dir, { homeDir: fakeHome, scan: true, yes: true });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["my-skill"]).toEqual({
+			local: "./skills/my-skill",
+			type: "skill",
+		});
+		expect(manifest.dependencies?.["code-reviewer"]).toEqual({
+			local: "./agents/code-reviewer.md",
+			type: "agent",
+		});
+	});
+
+	test("--scan without entries does not add dependencies", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await initCommand(dir, { homeDir: fakeHome, scan: true, yes: true });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies).toEqual({});
+	});
+
+	test("--scan with selectFn returning subset only registers chosen entries", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await mkdir(join(dir, "skills/keep-me"), { recursive: true });
+		await writeFile(join(dir, "skills/keep-me/SKILL.md"), "---\nname: keep-me\n---\n");
+		await mkdir(join(dir, "skills/drop-me"), { recursive: true });
+		await writeFile(join(dir, "skills/drop-me/SKILL.md"), "---\nname: drop-me\n---\n");
+
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			scan: true,
+			// Select only the first entry (sorted by type, name → "drop-me, keep-me")
+			// Actually the test should not depend on sort order — filter explicitly.
+			selectFn: async (found) => found.filter((f) => f.name === "keep-me"),
+		});
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["keep-me"]).toBeDefined();
+		expect(manifest.dependencies?.["drop-me"]).toBeUndefined();
+	});
+
+	describe("parseSelectionAnswer", () => {
+		const sample: LocalEntry[] = [
+			{ name: "a", type: "skill", path: "skills/a" },
+			{ name: "b", type: "skill", path: "skills/b" },
+			{ name: "c", type: "agent", path: "agents/c.md" },
+		];
+
+		const cases: Array<[string, string[]]> = [
+			["", ["a", "b", "c"]],
+			["y", ["a", "b", "c"]],
+			["Y", ["a", "b", "c"]],
+			["n", []],
+			["N", []],
+			["1", ["a"]],
+			["1,3", ["a", "c"]],
+			["1, 3", ["a", "c"]],
+			["3,1", ["c", "a"]],
+			["1,1,2", ["a", "b"]], // duplicates collapsed, original order preserved
+			["99", []], // out-of-range ignored
+			["1,99,2", ["a", "b"]], // mixed in/out-of-range → valid ones kept
+			["garbage", []],
+		];
+
+		for (const [input, expectedNames] of cases) {
+			test(`"${input}" → [${expectedNames.join(", ")}]`, () => {
+				const picked = parseSelectionAnswer(input, sample);
+				expect(picked.map((e) => e.name)).toEqual(expectedNames);
+			});
+		}
+	});
+
+	test("--scan without --yes and no tty/selectFn defaults to include-all", async () => {
+		// This mirrors the CI/non-interactive path: if stdout is not a TTY
+		// and no selector is provided, `init --scan` should not hang on
+		// readline. Since Bun's test stdout is not a TTY, calling without
+		// selectFn / yes exercises the fallback.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await mkdir(join(dir, "skills/only-one"), { recursive: true });
+		await writeFile(join(dir, "skills/only-one/SKILL.md"), "---\nname: only-one\n---\n");
+
+		await initCommand(dir, { homeDir: fakeHome, scan: true });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["only-one"]).toBeDefined();
 	});
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -162,6 +162,93 @@ describe("initCommand", () => {
 		}
 	});
 
+	test("--scan with askFn drives the interactive prompt and prints the listing", async () => {
+		// Exercises the prompt pipeline end-to-end (printDiscovered +
+		// promptForSelection + parseSelectionAnswer) without touching stdin.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		await mkdir(join(dir, "skills/alpha"), { recursive: true });
+		await writeFile(join(dir, "skills/alpha/SKILL.md"), "---\nname: alpha\n---\n");
+		await mkdir(join(dir, "skills/beta"), { recursive: true });
+		await writeFile(join(dir, "skills/beta/SKILL.md"), "---\nname: beta\n---\n");
+		await mkdir(join(dir, "agents"), { recursive: true });
+		await writeFile(join(dir, "agents/inspector.md"), "---\nname: inspector\n---\n");
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (msg: string) => logs.push(msg);
+		let askedQuestion = "";
+		try {
+			await initCommand(dir, {
+				homeDir: fakeHome,
+				scan: true,
+				askFn: async (q) => {
+					askedQuestion = q;
+					return "1,3"; // pick indices 1 and 3 from the printed list
+				},
+			});
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(askedQuestion).toContain("Include all?");
+
+		// Listing output captured: header, both sections, and per-entry lines.
+		const joined = logs.join("\n");
+		expect(joined).toContain("Found 2 skills and 1 agent");
+		expect(joined).toContain("Skills:");
+		expect(joined).toContain("Agents:");
+		expect(joined).toContain("[1]");
+		expect(joined).toContain("alpha");
+		expect(joined).toContain("inspector");
+
+		// Sort order is (type, name), so the printed list is:
+		//   [1] inspector (agent)
+		//   [2] alpha (skill)
+		//   [3] beta (skill)
+		// Picking "1,3" keeps inspector + beta.
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.inspector).toBeDefined();
+		expect(manifest.dependencies?.beta).toBeDefined();
+		expect(manifest.dependencies?.alpha).toBeUndefined();
+	});
+
+	describe("--global", () => {
+		test("creates a new global.yaml when none exists", async () => {
+			const dir = await makeTempDir();
+			const globalDir = join(dir, "global-home");
+
+			await initCommand(dir, { global: true, globalDir });
+
+			const content = await readFile(join(globalDir, "global.yaml"), "utf-8");
+			expect(content).toContain("dependencies");
+		});
+
+		test("warns and leaves the file untouched when global.yaml already exists", async () => {
+			const dir = await makeTempDir();
+			const globalDir = join(dir, "global-home");
+			await mkdir(globalDir, { recursive: true });
+			const existing = "dependencies:\n  preexisting:\n    local: ./x\n";
+			await writeFile(join(globalDir, "global.yaml"), existing);
+
+			const warnings: string[] = [];
+			const originalWarn = console.warn;
+			console.warn = (msg: string) => warnings.push(msg);
+			try {
+				await initCommand(dir, { global: true, globalDir });
+			} finally {
+				console.warn = originalWarn;
+			}
+
+			expect(warnings.some((w) => w.includes("already exists"))).toBe(true);
+			// File must be byte-for-byte unchanged — no clobber of the user's deps.
+			const after = await readFile(join(globalDir, "global.yaml"), "utf-8");
+			expect(after).toBe(existing);
+		});
+	});
+
 	test("--scan without --yes and no tty/selectFn defaults to include-all", async () => {
 		// This mirrors the CI/non-interactive path: if stdout is not a TTY
 		// and no selector is provided, `init --scan` should not hang on

--- a/tests/core/registry-cache.test.ts
+++ b/tests/core/registry-cache.test.ts
@@ -179,6 +179,36 @@ describe("ensureRegistryRepo", () => {
 		expect(existsSync(repoDir)).toBe(true);
 	});
 
+	test('re-clones when cached config has [remote "origin"] section but no url', async () => {
+		// Defensive path: a previous clone was interrupted between the remote
+		// section being written and the url being set. cloneOrFetchBare must
+		// treat this as drift and re-clone rather than silently fetching
+		// against a nonexistent remote.
+		const dir = await setup();
+		const sourceDir = await createSourceRepo(dir);
+
+		const cacheDir = join(dir, "cache");
+		const repoDir = await ensureRegistryRepo("test-reg", sourceDir, cacheDir);
+
+		// Corrupt the cached config: keep the [remote "origin"] header so the
+		// clone-vs-fetch path is entered, but strip the actual url line.
+		const configPath = join(repoDir, "config");
+		const { readFile: rf } = await import("node:fs/promises");
+		const original = await rf(configPath, "utf-8");
+		const corrupted = original
+			.split("\n")
+			.filter((line) => !line.trim().startsWith("url ="))
+			.join("\n");
+		await writeFile(configPath, corrupted, "utf-8");
+
+		// ensureRegistryRepo must recover transparently.
+		await ensureRegistryRepo("test-reg", sourceDir, cacheDir);
+
+		const cachedGit = simpleGit(repoDir);
+		const origin = (await cachedGit.raw(["config", "--get", "remote.origin.url"])).trim();
+		expect(origin).toBe(sourceDir);
+	});
+
 	test("re-clones when the registry URL changes (URL drift)", async () => {
 		// When config.yaml is edited to point a registry at a new URL, the
 		// cached bare repo's `origin` still points at the old URL. A plain

--- a/tests/core/registry-cache.test.ts
+++ b/tests/core/registry-cache.test.ts
@@ -178,4 +178,40 @@ describe("ensureRegistryRepo", () => {
 		const repoDir = await ensureRegistryRepo("test-reg", sourceDir, cacheDir);
 		expect(existsSync(repoDir)).toBe(true);
 	});
+
+	test("re-clones when the registry URL changes (URL drift)", async () => {
+		// When config.yaml is edited to point a registry at a new URL, the
+		// cached bare repo's `origin` still points at the old URL. A plain
+		// `fetch` would silently pull from the wrong source. The cache must
+		// be invalidated and re-cloned against the new URL.
+		const dir = await setup();
+
+		const originalSource = await createSourceRepo(dir);
+		const cacheDir = join(dir, "cache");
+		await ensureRegistryRepo("test-reg", originalSource, cacheDir);
+
+		// Create an entirely separate source repo at a different path.
+		// Mark it with a unique file so we can prove the re-clone happened.
+		const newSource = join(dir, "new-source-repo");
+		await mkdir(newSource, { recursive: true });
+		const newGit = simpleGit(newSource);
+		await newGit.init();
+		await newGit.addConfig("user.email", "test@test.com");
+		await newGit.addConfig("user.name", "Test");
+		await writeFile(join(newSource, "ONLY_IN_NEW.md"), "# only in new", "utf-8");
+		await newGit.add(".");
+		await newGit.commit("only-in-new");
+
+		const repoDir = await ensureRegistryRepo("test-reg", newSource, cacheDir);
+
+		// The cached repo's origin should now point at the new source, not the old.
+		const cachedGit = simpleGit(repoDir);
+		const origin = (await cachedGit.raw(["config", "--get", "remote.origin.url"])).trim();
+		expect(origin).toBe(newSource);
+
+		// The unique file from the new source must be reachable in the cache.
+		const lsTree = await cachedGit.raw(["ls-tree", "-r", "--name-only", "HEAD"]);
+		expect(lsTree).toContain("ONLY_IN_NEW.md");
+		expect(lsTree).not.toContain("README.md");
+	});
 });

--- a/tests/core/repo-scanner.test.ts
+++ b/tests/core/repo-scanner.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanLocalRepo } from "../../src/core/repo-scanner.js";
+
+let tempDir: string;
+
+async function setup(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-repo-scan-"));
+	return tempDir;
+}
+
+async function writeSkill(dir: string, skillDir: string, name: string, description?: string) {
+	const abs = join(dir, skillDir);
+	await mkdir(abs, { recursive: true });
+	const fm = description
+		? `---\nname: ${name}\ndescription: ${description}\n---\n\nBody\n`
+		: `---\nname: ${name}\n---\n\nBody\n`;
+	await writeFile(join(abs, "SKILL.md"), fm);
+}
+
+async function writeAgent(dir: string, relPath: string, fm: string) {
+	const abs = join(dir, relPath);
+	await mkdir(join(abs, ".."), { recursive: true });
+	await writeFile(abs, `---\n${fm}\n---\n\nBody\n`);
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe("scanLocalRepo", () => {
+	test("returns empty array for a directory with no skills or agents", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "README.md"), "# hello\n");
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("finds a single SKILL.md", async () => {
+		const dir = await setup();
+		await writeSkill(dir, "skills/my-skill", "my-skill", "A fine skill");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			name: "my-skill",
+			type: "skill",
+			path: "skills/my-skill",
+			description: "A fine skill",
+		});
+	});
+
+	test("falls back to directory basename when frontmatter has no name", async () => {
+		const dir = await setup();
+		const abs = join(dir, "skills/unnamed");
+		await mkdir(abs, { recursive: true });
+		await writeFile(join(abs, "SKILL.md"), "---\ndescription: no name\n---\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.name).toBe("unnamed");
+		expect(result[0]?.type).toBe("skill");
+	});
+
+	test("finds agent .md with frontmatter name", async () => {
+		const dir = await setup();
+		await writeAgent(
+			dir,
+			"agents/code-reviewer.md",
+			"name: code-reviewer\ndescription: Reviews code",
+		);
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			name: "code-reviewer",
+			type: "agent",
+			path: "agents/code-reviewer.md",
+			description: "Reviews code",
+		});
+	});
+
+	test("skips .md files without frontmatter", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "notes.md"), "# just a note\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("skips .md files with frontmatter but no name", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "random.md"), "---\ntags: [a, b]\n---\n\nBody\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("skips reserved .md filenames like README.md, CHANGELOG.md", async () => {
+		const dir = await setup();
+		// Even with frontmatter that looks agent-shaped, reserved names must not
+		// be treated as agents.
+		await writeFile(join(dir, "README.md"), "---\nname: the-readme\n---\n\n# Readme\n");
+		await writeFile(join(dir, "CHANGELOG.md"), "---\nname: changes\n---\n\n# Changelog\n");
+		await writeFile(join(dir, "CLAUDE.md"), "---\nname: instructions\n---\n\nConfig\n");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toEqual([]);
+	});
+
+	test("excludes hidden dirs (.claude, .git, .github)", async () => {
+		const dir = await setup();
+		// Installed artifacts under .claude/ must NOT be picked up.
+		await writeSkill(dir, ".claude/skills/installed", "installed");
+		await writeAgent(dir, ".claude/agents/installed-agent.md", "name: installed-agent");
+		await writeAgent(dir, ".github/workflows/ci.md", "name: ci");
+		await mkdir(join(dir, ".git"), { recursive: true });
+		await writeFile(join(dir, ".git/HEAD"), "ref: refs/heads/main\n");
+
+		// A real, in-repo skill must still be found.
+		await writeSkill(dir, "skills/real", "real");
+
+		const result = await scanLocalRepo(dir);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.name).toBe("real");
+	});
+
+	test("excludes node_modules, dist, build, coverage", async () => {
+		const dir = await setup();
+		await writeSkill(dir, "node_modules/pkg/skills/nope", "nope-nm");
+		await writeSkill(dir, "dist/skills/nope", "nope-dist");
+		await writeSkill(dir, "build/skills/nope", "nope-build");
+		await writeSkill(dir, "coverage/skills/nope", "nope-cov");
+		await writeSkill(dir, "skills/keep", "keep");
+
+		const result = await scanLocalRepo(dir);
+		expect(result.map((r) => r.name).sort()).toEqual(["keep"]);
+	});
+
+	test("finds skills and agents together, sorted by (type, name)", async () => {
+		const dir = await setup();
+		await writeSkill(dir, "skills/b-skill", "b-skill");
+		await writeSkill(dir, "skills/a-skill", "a-skill");
+		await writeAgent(dir, "agents/z-agent.md", "name: z-agent");
+		await writeAgent(dir, "agents/m-agent.md", "name: m-agent");
+
+		const result = await scanLocalRepo(dir);
+		expect(result.map((r) => `${r.type}:${r.name}`)).toEqual([
+			"agent:m-agent",
+			"agent:z-agent",
+			"skill:a-skill",
+			"skill:b-skill",
+		]);
+	});
+
+	test("tolerates malformed frontmatter without crashing (skips file)", async () => {
+		const dir = await setup();
+		await mkdir(join(dir, "agents"), { recursive: true });
+		// Unclosed frontmatter — parseFrontmatter throws. Scanner must not propagate.
+		await writeFile(join(dir, "agents/bad.md"), "---\nname: bad\n");
+		// A good sibling must still be reported.
+		await writeAgent(dir, "agents/good.md", "name: good");
+
+		const result = await scanLocalRepo(dir);
+		expect(result.map((r) => r.name)).toEqual(["good"]);
+	});
+});


### PR DESCRIPTION
Bundles three independently-tested fixes into a single release. **Merge with \"Squash and merge\"** so cz bump sees one `feat:` commit and cuts one minor version (`0.17.0 → 0.18.0`) with one npm publish.

Closes #1, #2, #3.
Supersedes #4, #5, #6 (closed in favor of this PR for single-release cadence).

## What's inside

### 1. `fix(add)` — print install hint after success
`skilltree add` only writes the manifest; `list` reads the lockfile. Newly added deps were invisible until `install` ran, with no breadcrumb. After the success line, print a dim hint: `Run \`skilltree install [--global]\` to install.`

- `src/commands/add.ts` — 2 lines
- `tests/commands/add.test.ts` — 2 new tests (project + global hint variants)

### 2. `fix(git)` — invalidate cache when origin URL drifts
Editing a registry's `url:` in `~/.skilltree/config.yaml` (or a dep's `repo:` in `skilltree.yaml`) silently kept the old cache. `cloneOrFetchBare` would fetch from the stale remote. Now compares cached `origin` against the expected URL (normalized) and re-clones on drift. Single fix covers both registry cache and dep-repo cache.

- `src/core/git.ts` — new `isOriginUrlDrifted` helper in `cloneOrFetchBare`
- `tests/core/registry-cache.test.ts` — 1 new URL-drift test

### 3. `feat(init)` — add `--scan` to discover in-tree skills and agents
`skilltree init --scan` walks the repo for `SKILL.md` (skills) and standalone `.md` with `name:` frontmatter (agents), excluding hidden dirs and common build dirs. Discovered entries are offered via an interactive prompt (Y / n / `1,3,5`). Non-TTY and `--yes` default to include-all.

- `src/core/repo-scanner.ts` — new module, filesystem variant of registry scanner
- `src/commands/init.ts` — integrates scanner + prompt UX + `parseSelectionAnswer`
- `src/cli.ts`, `src/commands/completion.ts` — `--scan` / `--yes` flags + completion
- `tests/core/repo-scanner.test.ts` — 11 tests
- `tests/commands/init.test.ts` — 17 new tests (integration + parametrized parser)

## Test plan
- [x] Full suite passes: **723 tests**
- [x] End-to-end smoke: `init --scan --yes` on a temp repo produces the expected manifest
- [x] `skilltree add --help`, `skilltree init --help` show the new flags
- [x] Commits are `fix:`, `fix:`, `feat:` — highest severity wins on squash-merge → single `feat` commit → minor bump → `0.18.0`

## Release flow after merge
1. Squash-merge → commit on `main` starts with `feat(init):` (this PR's title)
2. `release.yml` fires → `cz bump` → `0.18.0` + tag + GitHub release
3. `publish.yml` fires on the new tag → publishes `skilltree-pm@0.18.0` to npm
4. Done — single version covering all three issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)