### PR TITLE
fix(graph): warn when origin manifest is on main but missing at tag

### DIFF
--- a/docs/specs/origin_manifest_resolution.md
+++ b/docs/specs/origin_manifest_resolution.md
@@ -81,6 +81,7 @@ Every entry repeats a path the origin already told the world about. If origin re
 - **R11**: A dependency entry MAY include `force_path: true` to silence R10 warnings for that entry. `force_path` has no other effect on resolution.
 - **R12**: Manifest validation (`validateManifest`) MUST NOT require `path:` on remote dependencies. The existing requirement that `repo:`/`source:` and `local:` are mutually exclusive stays.
 - **R13**: `skilltree add --repo <url>` (and `--source <alias>`) MUST accept an omitted `--path`. If the origin manifest resolves the path at add-time, it MAY be written into the consumer's manifest; otherwise the manifest is written with no `path:` and resolution happens at install-time.
+- **R14 (stale-tag manifest)**: For each resolved remote repo, the resolver MUST check whether `skilltree.yaml` exists at the resolved tag. If it is absent at the tag but present on the default branch, the resolver MUST emit a single warning per repo that names the repo, the resolved tag, the default branch, and recommends cutting a new tag. This guards the common case where an author commits a manifest to `main` without tagging a release, so consumers silently lose R9/R10 signals.
 
 ## Constraints
 

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -90,6 +90,7 @@ export async function resolveAll(
 	};
 
 	await resolveRepoVersions(expanded, state);
+	await checkStaleTagManifests(state);
 	await processDeps(expanded.dependencies, "prod", state);
 	await processDeps(expanded["dev-dependencies"], "dev", state);
 	validateTypeConstraints(state);
@@ -633,6 +634,51 @@ function formatPathWarning(
 		`  skilltree.yaml declares this name at "${mismatch.originPath}" (${originRepo}).`,
 		`  If this override is intentional, set \`force_path: true\` to silence this warning.`,
 	].join("\n");
+}
+
+/**
+ * For every resolved remote repo, check whether origin's `skilltree.yaml` is
+ * present at the resolved tag. If absent at the tag but present on the
+ * default branch, emit a single warning — origin authored a manifest but
+ * never cut a tag that contains it, so consumers lose R9/R10 signals they
+ * would otherwise get.
+ */
+async function checkStaleTagManifests(state: ResolutionState): Promise<void> {
+	for (const [repo, resolution] of state.repoResolutions) {
+		const ref = resolution.tag ?? resolution.commit;
+
+		// If manifest is present at the resolved ref, nothing to check.
+		try {
+			await readFileAtRef(resolution.cachePath, ref, "skilltree.yaml");
+			continue;
+		} catch {
+			// Fall through — missing at tag.
+		}
+
+		let defaultBranch: string;
+		try {
+			defaultBranch = await getDefaultBranch(resolution.cachePath);
+		} catch {
+			continue;
+		}
+
+		try {
+			await readFileAtRef(resolution.cachePath, defaultBranch, "skilltree.yaml");
+		} catch {
+			// Not on default branch either — origin simply doesn't use skilltree.yaml.
+			continue;
+		}
+
+		const tagLabel = resolution.tag ?? `commit ${resolution.commit.slice(0, 8)}`;
+		state.warnings.push(
+			[
+				`Warning: origin \`${repo}\` has a skilltree.yaml on \`${defaultBranch}\` but not at the`,
+				`  resolved tag (${tagLabel}). Consumers resolve to the tag, so origin's manifest`,
+				`  is invisible to them — R9 path inference and R10 path warnings are skipped.`,
+				`  Fix: cut a new tag from \`${defaultBranch}\` that includes skilltree.yaml.`,
+			].join("\n"),
+		);
+	}
 }
 
 /**

--- a/tests/core/graph-path-warnings.test.ts
+++ b/tests/core/graph-path-warnings.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import simpleGit from "simple-git";
 import { resolveAll } from "../../src/core/graph.js";
 import type { Dependency, Manifest } from "../../src/types.js";
 import { createTestRepo } from "../helpers/git-fixtures.js";
@@ -414,5 +415,173 @@ describe("Side-quest: source/path gap coverage", () => {
 		const err = result.errors.join("\n");
 		expect(err).toContain("foo");
 		expect(err).toContain("no path");
+	});
+});
+
+/**
+ * Build an origin repo where:
+ *  - Tag v1.0.0 points at a commit that contains the skill but NO skilltree.yaml
+ *  - The default branch has a later commit that adds skilltree.yaml
+ *
+ * Simulates the open-vibes situation: author committed a skilltree.yaml to
+ * main but never cut a new tag, so consumers on version: "*" resolve to a
+ * tag that predates the manifest.
+ */
+async function setupStaleTagOrigin(baseDir: string): Promise<string> {
+	const repoDir = join(baseDir, "origin");
+	await mkdir(repoDir, { recursive: true });
+
+	const git = simpleGit(repoDir);
+	await git.init();
+	await git.addConfig("user.email", "test@test.com");
+	await git.addConfig("user.name", "Test");
+	// Force main so the default-branch probe is deterministic on systems where
+	// git init picks master.
+	await git.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+	const skillDir = join(repoDir, "skills/source/foo");
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(join(skillDir, "SKILL.md"), "---\nname: foo\n---\n\n# foo\n");
+	await git.add(".");
+	await git.commit("Initial commit");
+	await git.addTag("v1.0.0");
+
+	// Now add skilltree.yaml on main — no new tag.
+	await writeFile(
+		join(repoDir, "skilltree.yaml"),
+		["name: origin", "dependencies:", "  foo:", "    local: ./skills/source/foo", ""].join("\n"),
+	);
+	await git.add(".");
+	await git.commit("Add skilltree.yaml on main");
+
+	return repoDir;
+}
+
+describe("stale-tag origin manifest warning", () => {
+	test("warns when skilltree.yaml exists on default branch but not at resolved tag", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-stale-tag-"));
+		const originRepo = await setupStaleTagOrigin(tempDir);
+
+		const consumerManifest: Manifest = {
+			dependencies: {
+				foo: {
+					repo: `file://${originRepo}`,
+					path: "skills/source/foo",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumerManifest, tempDir);
+		expect(result.errors).toEqual([]);
+
+		const warnings = result.warnings.join("\n");
+		// Warning must name the repo and hint that authoring on main isn't
+		// reaching consumers because the tag is stale.
+		expect(warnings).toContain(originRepo);
+		expect(warnings).toMatch(/stale tag|not at tag|cut a new tag|missing at/i);
+	});
+
+	test("warns once per repo even with multiple consumer entries", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-stale-tag-"));
+		const originRepo = await setupStaleTagOrigin(tempDir);
+
+		// Add a second skill to the same repo without cutting a new tag;
+		// main still has the manifest, tag still doesn't.
+		const skillDir = join(originRepo, "skills/source/bar");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(join(skillDir, "SKILL.md"), "---\nname: bar\n---\n\n# bar\n");
+		const git = simpleGit(originRepo);
+		await git.add(".");
+		await git.commit("add bar on main");
+
+		// But tag v1.0.0 stays where it was — neither skilltree.yaml nor bar
+		// are reachable at the tag. Consumer can only depend on foo at the tag.
+		const consumerManifest: Manifest = {
+			dependencies: {
+				foo: {
+					repo: `file://${originRepo}`,
+					path: "skills/source/foo",
+					version: "*",
+				},
+				"foo-again": {
+					repo: `file://${originRepo}`,
+					path: "skills/source/foo",
+					version: "*",
+					name: "foo",
+				} as Dependency,
+			},
+		};
+
+		const result = await resolveAll(consumerManifest, tempDir);
+		// The stale-tag warning should appear exactly once despite two entries
+		// pointing at the same repo.
+		const staleWarnings = result.warnings.filter((w) =>
+			/stale tag|not at tag|cut a new tag|missing at/i.test(w),
+		);
+		expect(staleWarnings.length).toBe(1);
+	});
+
+	test("stays silent when origin has no skilltree.yaml anywhere", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-stale-tag-"));
+		// No skilltree.yaml ever — not on main, not at the tag.
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[{ path: "skills/source/foo", name: "foo" }],
+			"v1.0.0",
+			// manifestYaml intentionally omitted
+		);
+
+		const consumerManifest: Manifest = {
+			dependencies: {
+				foo: {
+					repo: `file://${originRepo}`,
+					path: "skills/source/foo",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumerManifest, tempDir);
+		const staleWarnings = result.warnings.filter((w) =>
+			/stale tag|not at tag|cut a new tag|missing at/i.test(w),
+		);
+		expect(staleWarnings).toEqual([]);
+	});
+
+	test("stays silent when the manifest is present at the resolved tag", async () => {
+		// Standard case — origin tagged its manifest. No staleness.
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-stale-tag-"));
+		const manifestYaml = [
+			"name: origin",
+			"dependencies:",
+			"  foo:",
+			"    local: ./skills/source/foo",
+			"",
+		].join("\n");
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[{ path: "skills/source/foo", name: "foo" }],
+			"v1.0.0",
+			manifestYaml,
+		);
+
+		const consumerManifest: Manifest = {
+			dependencies: {
+				foo: {
+					repo: `file://${originRepo}`,
+					path: "skills/source/foo",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumerManifest, tempDir);
+		const staleWarnings = result.warnings.filter((w) =>
+			/stale tag|not at tag|cut a new tag|missing at/i.test(w),
+		);
+		expect(staleWarnings).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Problem
When an origin repo commits \`skilltree.yaml\` to its default branch but doesn't cut a new tag, consumers resolving to the latest existing tag silently lose R9/R10 signals — path inference and redundancy/override warnings. The authoring work is invisible and undetectable from the consumer side.

**Real-world case**: \`github.com/imarios/open-vibes\` committed \`skilltree.yaml\` to \`main\` after tagging \`v1.6.0\`. Consumers pinning \`version: \"*\"\` resolved to v1.6.0 — a tag that predates the file. Their \`path: skills/python-coding\` declarations were functionally redundant but R10 stayed silent because \`detectPathMismatch\` couldn't read a manifest that didn't exist at the tag.

## Fix (R14)
Per-repo check after version resolution. For each resolved remote repo:
1. Try to read \`skilltree.yaml\` at the resolved tag → if present, nothing to do.
2. Otherwise check the default branch → if present there, emit a single warning naming the repo, tag, and branch with a \`Fix:\` hint to cut a new tag.
3. If absent on the default branch too → origin simply doesn't use skilltree.yaml → stay silent (current behavior preserved).

Deduped per-repo so a repo with N consumer entries still only emits one warning.

## Warning text
\`\`\`
Warning: origin \`github.com/imarios/open-vibes\` has a skilltree.yaml on \`main\` but not at the
  resolved tag (v1.6.0). Consumers resolve to the tag, so origin's manifest
  is invisible to them — R9 path inference and R10 path warnings are skipped.
  Fix: cut a new tag from \`main\` that includes skilltree.yaml.
\`\`\`

## Test plan
- [x] **Stale tag**: tag predates manifest on main → warning fires (names repo, tag, branch, \"cut a new tag\")
- [x] **Dedup**: two consumer entries pointing at the same stale-tag repo → exactly one stale warning
- [x] **Silent when truly absent**: origin has no manifest on main or at tag → no stale warning
- [x] **Silent when current**: manifest present at resolved tag → no stale warning
- [x] All 7 existing R10 tests still pass
- [x] Full suite: **731 pass / 0 fail**

## Docs
Added R14 to \`docs/specs/origin_manifest_resolution.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)