### PR TITLE
fix(teach,completion): make skilltree usable when installed globally

### DIFF
--- a/src/bundled.d.ts
+++ b/src/bundled.d.ts
@@ -1,0 +1,5 @@
+// Bun's `with { type: "text" }` import attribute — typed as `string`.
+declare module "*.md" {
+	const content: string;
+	export default content;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { Command } from "commander";
 import pkg from "../package.json";
+import { completeCommand } from "./commands/_complete.js";
 import { addCommand } from "./commands/add.js";
 import { cacheCleanCommand } from "./commands/cache.js";
 import { completionCommand } from "./commands/completion.js";
@@ -265,8 +266,20 @@ program
 program
 	.command("completion [shell]")
 	.description("Output shell completion script (zsh or bash)")
-	.action(async (shell?: string) => {
-		await completionCommand(shell);
+	.option("--install", "Write the script to the conventional location instead of stdout")
+	.action(async (shell?: string, opts?: { install?: boolean }) => {
+		await completionCommand(shell, { install: opts?.install });
+	});
+
+// Hidden subcommand backing dynamic shell completion. Emits one suggestion
+// per line on stdout. See `src/commands/_complete.ts` for the rules: never
+// throws, never prints diagnostics — must be safe to call on every <TAB>.
+program
+	.command("_complete <kind>", { hidden: true })
+	.description("(internal) Emit dynamic completion suggestions")
+	.option("-g, --global", "Read from the global manifest")
+	.action(async (kind: string, opts) => {
+		await completeCommand(kind, { global: opts.global });
 	});
 
 const targets = program.command("targets").description("Manage install targets (coding agents)");

--- a/src/commands/_complete.ts
+++ b/src/commands/_complete.ts
@@ -1,0 +1,70 @@
+/**
+ * Hidden `_complete` subcommand — backs dynamic shell completion.
+ *
+ * Hard requirements (this runs on every <TAB>):
+ *  - MUST NOT throw user-facing errors. A failing call would pollute the
+ *    user's shell with stack traces. Any error (missing manifest, bad
+ *    YAML, IO error) collapses to no suggestions; the shell falls back to
+ *    its default completion.
+ *  - MUST stay fast. No network, no git, no resolution — just the
+ *    manifest read.
+ *  - MUST NOT use `process.cwd()` for global completion. When the user
+ *    tabs `skilltree remove --global <TAB>` from anywhere, we go straight
+ *    to `~/.skilltree/global.yaml`.
+ */
+
+import { getKnownAgentNames } from "../core/agents.js";
+import { getAllDependencyNames, readGlobalManifest, readManifest } from "../core/manifest.js";
+import type { Manifest } from "../types.js";
+
+export const COMPLETE_KINDS = ["deps", "targets", "agents"] as const;
+export type CompleteKind = (typeof COMPLETE_KINDS)[number];
+
+export function isCompleteKind(value: string): value is CompleteKind {
+	return COMPLETE_KINDS.includes(value as CompleteKind);
+}
+
+export interface CompleteOptions {
+	global?: boolean;
+	dir?: string; // override CWD (testing)
+	globalDir?: string; // override ~/.skilltree (testing)
+}
+
+/**
+ * Print completion suggestions to stdout, one per line. Validates `kind`
+ * at the boundary; unknown kinds are silent (never break the shell).
+ */
+export async function completeCommand(kind: string, opts: CompleteOptions = {}): Promise<void> {
+	if (!isCompleteKind(kind)) return;
+	const suggestions = await getSuggestions(kind, opts);
+	if (suggestions.length === 0) return;
+	process.stdout.write(`${suggestions.join("\n")}\n`);
+}
+
+/**
+ * Pure helper exposed for tests. Errors and unknown kinds collapse to `[]`.
+ */
+export async function getSuggestions(
+	kind: CompleteKind,
+	opts: CompleteOptions = {},
+): Promise<string[]> {
+	try {
+		switch (kind) {
+			case "deps":
+				return getAllDependencyNames(await loadManifest(opts));
+			case "targets":
+				return [...((await loadManifest(opts)).install_targets ?? [])].sort();
+			case "agents":
+				return getKnownAgentNames();
+			default:
+				kind satisfies never;
+				return [];
+		}
+	} catch {
+		return [];
+	}
+}
+
+function loadManifest(opts: CompleteOptions): Promise<Manifest> {
+	return opts.global ? readGlobalManifest(opts.globalDir) : readManifest(opts.dir ?? process.cwd());
+}

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,18 +1,41 @@
 /**
  * Shell completion generators for skilltree.
  *
- * These build completion scripts from the command/flag definitions below.
- * The freshness test in tests/commands/completion.test.ts verifies that
- * every command and flag from cli.ts appears in the generated output.
- * If you add a command or flag to cli.ts, add it here too — the test will
- * catch it if you forget.
+ * Two halves:
+ *  - Static structure (top-level commands, subcommands, flag names) is built
+ *    from the `COMMANDS` table below. Drift between this table and `cli.ts`
+ *    is caught by the freshness test in `tests/commands/completion.test.ts`.
+ *  - Dynamic value completion (installed dep names, targets, agents) is
+ *    delegated at <TAB>-time to the hidden `skilltree _complete <kind>`
+ *    subcommand. The shell scripts emitted here include small helper
+ *    functions that shell out to it. See `src/commands/_complete.ts`.
+ *
+ * If you add a command, subcommand, or flag to cli.ts, mirror it in
+ * `COMMANDS` here. If you add a positional argument that should
+ * tab-complete from runtime state, set `positionalComplete` on the entry.
  */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import pkg from "../../package.json" with { type: "json" };
+import { dim, pc, success } from "../core/ui.js";
+import type { CompleteKind } from "./_complete.js";
+
+interface FlagDef {
+	long: string;
+	short?: string;
+	description: string;
+	takesArg?: boolean;
+}
 
 interface CmdDef {
 	name: string;
 	description: string;
-	flags?: Array<{ long: string; short?: string; description: string; takesArg?: boolean }>;
+	flags?: FlagDef[];
 	subcommands?: CmdDef[];
+	/** What the first positional argument should tab-complete to, if anything. */
+	positionalComplete?: CompleteKind;
 }
 
 const COMMANDS: CmdDef[] = [
@@ -59,6 +82,7 @@ const COMMANDS: CmdDef[] = [
 	{
 		name: "update",
 		description: "Update dependencies to latest versions",
+		positionalComplete: "deps",
 		flags: [
 			{ long: "--dry-run", short: "-n", description: "Preview version bumps" },
 			{ long: "--global", short: "-g", description: "Update global dependencies" },
@@ -67,6 +91,7 @@ const COMMANDS: CmdDef[] = [
 	{
 		name: "remove",
 		description: "Remove a dependency",
+		positionalComplete: "deps",
 		flags: [
 			{ long: "--force", short: "-f", description: "Skip confirmation" },
 			{ long: "--keep-files", description: "Leave installed files in place" },
@@ -113,6 +138,7 @@ const COMMANDS: CmdDef[] = [
 	{
 		name: "info",
 		description: "Show detailed information about a skill or agent",
+		positionalComplete: "deps",
 		flags: [{ long: "--json", description: "Output results as JSON" }],
 	},
 	{
@@ -179,11 +205,13 @@ const COMMANDS: CmdDef[] = [
 			{
 				name: "add",
 				description: "Add an agent or path to install_targets",
+				positionalComplete: "agents",
 				flags: [{ long: "--global", short: "-g", description: "Add to global manifest" }],
 			},
 			{
 				name: "remove",
 				description: "Remove an agent or path from install_targets",
+				positionalComplete: "targets",
 				flags: [{ long: "--global", short: "-g", description: "Remove from global manifest" }],
 			},
 			{
@@ -203,8 +231,213 @@ const COMMANDS: CmdDef[] = [
 		description: "Cache management commands",
 		subcommands: [{ name: "clean", description: "Remove cached repositories" }],
 	},
-	{ name: "completion", description: "Output shell completion script" },
+	{
+		name: "completion",
+		description: "Output shell completion script",
+		flags: [{ long: "--install", description: "Write to the conventional path instead of stdout" }],
+	},
 ];
+
+// --- Shared helpers used by both shell generators ---------------------------
+
+/**
+ * Identity string for a (sub)command, used in the generated `--global`-aware
+ * lists. Top-level: `"remove"`. Subcommand: `"targets:remove"`. The colon
+ * separator is chosen because zsh's `case` patterns and bash's substring
+ * match both treat it as an opaque character — no escaping needed.
+ */
+function commandPath(cmd: CmdDef, parent?: CmdDef): string {
+	return parent ? `${parent.name}:${cmd.name}` : cmd.name;
+}
+
+/** True iff this command declares `--global` as one of its flags. */
+function commandSupportsGlobal(cmd: CmdDef): boolean {
+	return (cmd.flags ?? []).some((f) => f.long === "--global");
+}
+
+/**
+ * Walk the COMMANDS table and collect identity strings for every command
+ * that (a) has a `positionalComplete` and (b) accepts `--global`. Used by
+ * the dynamic-completion helpers in both shells to decide whether to honor
+ * a `--global` token they see on the line.
+ *
+ * Why this matters: `skilltree info <name>` has dynamic completion (deps)
+ * but does NOT accept `--global`. If a user accidentally types
+ * `skilltree info xxx --global`, we don't want completion to silently
+ * switch to the global manifest — that would suggest names that have no
+ * meaning in the local context. Scoping `--global` detection to only the
+ * commands that declare it preserves user intent.
+ */
+function globalAwareCommandPaths(): string[] {
+	const paths: string[] = [];
+	for (const cmd of COMMANDS) {
+		if (cmd.positionalComplete && commandSupportsGlobal(cmd)) {
+			paths.push(commandPath(cmd));
+		}
+		for (const sub of cmd.subcommands ?? []) {
+			if (sub.positionalComplete && commandSupportsGlobal(sub)) {
+				paths.push(commandPath(sub, cmd));
+			}
+		}
+	}
+	return paths;
+}
+
+/**
+ * Names of every top-level command that has subcommands. Used to teach the
+ * `_skilltree_cmd_path` shell helper to *only* treat `$words[2]` as a
+ * subcommand when `$words[1]` is one of these — otherwise a positional or
+ * a flag in slot 2 (`skilltree remove --global …`) gets wrongly stitched
+ * into a `parent:flag` identity that matches nothing.
+ */
+function parentCommandNames(): string[] {
+	return COMMANDS.filter((c) => (c.subcommands?.length ?? 0) > 0).map((c) => c.name);
+}
+
+// --- Zsh ---------------------------------------------------------------------
+
+/**
+ * Per-flag arg spec. Always emits both forms when a short alias exists, so
+ * `skilltree install -<TAB>` lists `-f -n -g` alongside `--force --dry-run
+ * --global`. Mutex via `(a b)` prevents both forms appearing as further
+ * suggestions once one has been typed.
+ */
+function zshFlagSpecs(flags: FlagDef[]): string[] {
+	const specs: string[] = [];
+	for (const f of flags) {
+		const desc = escapeZsh(f.description);
+		const argSuffix = f.takesArg ? ":arg:" : "";
+		if (f.short) {
+			specs.push(`'(${f.long} ${f.short})'{${f.long},${f.short}}'[${desc}]${argSuffix}'`);
+		} else {
+			specs.push(`'${f.long}[${desc}]${argSuffix}'`);
+		}
+	}
+	return specs;
+}
+
+/**
+ * Map a `positionalComplete` value to the zsh helper-function name we emit.
+ * Single source of truth so the case-branch generator and the helper-emitter
+ * can't drift.
+ */
+function zshHelperName(kind: CompleteKind): string {
+	return `_skilltree_complete_${kind}`;
+}
+
+/**
+ * Build the `_arguments` spec for a single positional value slot. We use
+ * `:value:func` (single positional) rather than `*::value:func` (any number)
+ * because every command with `positionalComplete` takes exactly one
+ * argument; the multi-positional form caused completion to keep firing
+ * after the first arg was already typed (cosmetic noise).
+ */
+function zshValueSpec(kind: CompleteKind): string {
+	return `':value:${zshHelperName(kind)}'`;
+}
+
+function generateZshFlagCase(cmd: CmdDef): string {
+	const args: string[] = cmd.flags ? zshFlagSpecs(cmd.flags) : [];
+	if (cmd.positionalComplete) {
+		args.push(zshValueSpec(cmd.positionalComplete));
+	}
+	if (args.length === 0) return "";
+	return `                ${cmd.name}) _arguments ${args.join(" ")} ;;`;
+}
+
+function generateZshSubcommandCase(cmd: CmdDef): string {
+	const subs = (cmd.subcommands ?? [])
+		.map((s) => `'${s.name}:${escapeZsh(s.description)}'`)
+		.join(" ");
+
+	const subCases = (cmd.subcommands ?? [])
+		.filter((s) => (s.flags?.length ?? 0) > 0 || s.positionalComplete)
+		.map((s) => {
+			const args: string[] = s.flags ? zshFlagSpecs(s.flags) : [];
+			if (s.positionalComplete) {
+				args.push(zshValueSpec(s.positionalComplete));
+			}
+			return `                        ${s.name}) _arguments ${args.join(" ")} ;;`;
+		})
+		.join("\n");
+
+	let body = `                    local -a subcmds\n                    subcmds=(${subs})\n                    _describe '${cmd.name} command' subcmds`;
+
+	if (subCases) {
+		body = `                    case $words[2] in
+${subCases}
+                        *)
+                            local -a subcmds
+                            subcmds=(${subs})
+                            _describe '${cmd.name} command' subcmds
+                            ;;
+                    esac`;
+	}
+
+	return `                ${cmd.name})
+${body}
+                    ;;`;
+}
+
+/** Emit the shared zsh helper functions that call back into `skilltree _complete`. */
+function generateZshHelpers(): string {
+	// `_skilltree_cmd_path` derives the same identity string used by
+	// `globalAwareCommandPaths()` from the live $words array, so the
+	// subsequent case-pattern match stays in sync with the generator.
+	//
+	// `_skilltree_global_flag` only honors `--global` for commands that
+	// actually declare the flag — see `globalAwareCommandPaths()` for the
+	// reasoning. The list is interpolated below at gen time.
+	const awarePaths = globalAwareCommandPaths().join(" ");
+	const parents = parentCommandNames().join("|");
+	return `# Build a "parent:sub" identity if $words[1] is a known parent command,
+# otherwise just $words[1]. Without the parent gate, "skilltree remove --global"
+# would synthesize "remove:--global" — matching nothing, but worse than that
+# it bypasses the awarePaths check below.
+_skilltree_cmd_path() {
+    local first="${"$"}{words[1]:-}" second="${"$"}{words[2]:-}"
+    case "$first" in
+        ${parents})
+            if [[ -n "$second" && "$second" != -* ]]; then
+                echo "$first:$second"
+                return
+            fi
+            ;;
+    esac
+    echo "$first"
+}
+
+_skilltree_global_flag() {
+    local cmd_path
+    cmd_path=$(_skilltree_cmd_path)
+    # Only commands that declare --global should switch scope.
+    case " ${awarePaths} " in
+        *" $cmd_path "*) ;;
+        *) return ;;
+    esac
+    if (( ${"$"}{words[(I)--global]} > 0 || ${"$"}{words[(I)-g]} > 0 )); then
+        echo "--global"
+    fi
+}
+
+_skilltree_complete_deps() {
+    local -a items
+    items=(${"$"}{(f)"$(skilltree _complete deps $(_skilltree_global_flag) 2>/dev/null)"})
+    _describe 'dep' items
+}
+
+_skilltree_complete_targets() {
+    local -a items
+    items=(${"$"}{(f)"$(skilltree _complete targets $(_skilltree_global_flag) 2>/dev/null)"})
+    _describe 'target' items
+}
+
+_skilltree_complete_agents() {
+    local -a items
+    items=(${"$"}{(f)"$(skilltree _complete agents 2>/dev/null)"})
+    _describe 'agent' items
+}`;
+}
 
 export function generateZshCompletion(): string {
 	const topLevelCmds = COMMANDS.map((c) => `'${c.name}:${escapeZsh(c.description)}'`).join(
@@ -215,17 +448,17 @@ export function generateZshCompletion(): string {
 		if (cmd.subcommands) {
 			return generateZshSubcommandCase(cmd);
 		}
-		if (cmd.flags?.length) {
-			return generateZshFlagCase(cmd.name, cmd.flags);
-		}
-		return "";
+		return generateZshFlagCase(cmd);
 	})
 		.filter(Boolean)
 		.join("\n");
 
 	return `#compdef skilltree
-# Zsh completion for skilltree v0.4.0
-# Install: eval "$(skilltree completion zsh)"
+# Zsh completion for skilltree v${pkg.version}
+# Install: skilltree completion --install
+#     or:  eval "$(skilltree completion zsh)"
+
+${generateZshHelpers()}
 
 _skilltree() {
     local -a commands
@@ -259,46 +492,49 @@ compdef _skilltree skilltree
 `;
 }
 
-function generateZshSubcommandCase(cmd: CmdDef): string {
-	const subs = (cmd.subcommands ?? [])
-		.map((s) => `'${s.name}:${escapeZsh(s.description)}'`)
-		.join(" ");
-
-	const subCases = (cmd.subcommands ?? [])
-		.filter((s) => s.flags?.length)
-		.map((s) => {
-			const flags = (s.flags ?? [])
-				.map((f) => `'${f.long}[${escapeZsh(f.description)}]'`)
-				.join(" ");
-			return `                        ${s.name}) _arguments ${flags} ;;`;
-		})
-		.join("\n");
-
-	let body = `                    local -a subcmds\n                    subcmds=(${subs})\n                    _describe '${cmd.name} command' subcmds`;
-
-	if (subCases) {
-		body = `                    case $words[2] in
-${subCases}
-                        *)
-                            local -a subcmds
-                            subcmds=(${subs})
-                            _describe '${cmd.name} command' subcmds
-                            ;;
-                    esac`;
-	}
-
-	return `                ${cmd.name})
-${body}
-                    ;;`;
-}
-
-function generateZshFlagCase(name: string, flags: NonNullable<CmdDef["flags"]>): string {
-	const flagArgs = flags.map((f) => `'${f.long}[${escapeZsh(f.description)}]'`).join(" ");
-	return `                ${name}) _arguments ${flagArgs} ;;`;
-}
-
 function escapeZsh(s: string): string {
 	return s.replace(/'/g, "'\\''").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+}
+
+// --- Bash --------------------------------------------------------------------
+
+/**
+ * Build the space-separated list of all flag tokens (long + short) we want
+ * `compgen` to suggest after a command. The helper is included verbatim in
+ * the generated script.
+ */
+function bashFlagWords(flags: FlagDef[]): string {
+	const words: string[] = [];
+	for (const f of flags) {
+		words.push(f.long);
+		if (f.short) words.push(f.short);
+	}
+	return words.join(" ");
+}
+
+function bashCmdBranch(cmd: CmdDef): string {
+	const flagWords = cmd.flags?.length ? bashFlagWords(cmd.flags) : "";
+	const completeKind = cmd.positionalComplete;
+
+	if (!flagWords && !completeKind) return "";
+
+	if (completeKind && flagWords) {
+		// Mix of flags and a value-completing positional. If the current
+		// word starts with `-`, suggest flags; otherwise suggest values.
+		return `        ${cmd.name})
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "${flagWords}" -- "$cur"))
+            else
+                COMPREPLY=($(compgen -W "$(_skilltree_dyn ${completeKind})" -- "$cur"))
+            fi
+            ;;`;
+	}
+
+	if (completeKind) {
+		return `        ${cmd.name}) COMPREPLY=($(compgen -W "$(_skilltree_dyn ${completeKind})" -- "$cur")) ;;`;
+	}
+
+	return `        ${cmd.name}) COMPREPLY=($(compgen -W "${flagWords}" -- "$cur")) ;;`;
 }
 
 export function generateBashCompletion(): string {
@@ -308,10 +544,22 @@ export function generateBashCompletion(): string {
 		if (cmd.subcommands) {
 			const subNames = cmd.subcommands.map((s) => s.name).join(" ");
 			const subCases = cmd.subcommands
-				.filter((s) => s.flags?.length)
+				.filter((s) => (s.flags?.length ?? 0) > 0 || s.positionalComplete)
 				.map((s) => {
-					const flagNames = (s.flags ?? []).map((f) => f.long).join(" ");
-					return `            ${s.name}) COMPREPLY=($(compgen -W "${flagNames}" -- "$cur")) ;;`;
+					const flagWords = s.flags?.length ? bashFlagWords(s.flags) : "";
+					if (s.positionalComplete && flagWords) {
+						return `            ${s.name})
+                if [[ "$cur" == -* ]]; then
+                    COMPREPLY=($(compgen -W "${flagWords}" -- "$cur"))
+                else
+                    COMPREPLY=($(compgen -W "$(_skilltree_dyn ${s.positionalComplete})" -- "$cur"))
+                fi
+                ;;`;
+					}
+					if (s.positionalComplete) {
+						return `            ${s.name}) COMPREPLY=($(compgen -W "$(_skilltree_dyn ${s.positionalComplete})" -- "$cur")) ;;`;
+					}
+					return `            ${s.name}) COMPREPLY=($(compgen -W "${flagWords}" -- "$cur")) ;;`;
 				})
 				.join("\n");
 
@@ -326,17 +574,61 @@ ${subCases}
             fi
             ;;`;
 		}
-		if (cmd.flags?.length) {
-			const flagNames = cmd.flags.map((f) => f.long).join(" ");
-			return `        ${cmd.name}) COMPREPLY=($(compgen -W "${flagNames}" -- "$cur")) ;;`;
-		}
-		return "";
+		return bashCmdBranch(cmd);
 	})
 		.filter(Boolean)
 		.join("\n");
 
-	return `# Bash completion for skilltree v0.4.0
-# Install: eval "$(skilltree completion bash)"
+	const awarePaths = globalAwareCommandPaths().join(" ");
+	const parents = parentCommandNames().join("|");
+	return `# Bash completion for skilltree v${pkg.version}
+# Install: skilltree completion --install
+#     or:  eval "$(skilltree completion bash)"
+
+# Derive the same identity string used by the gen-time globalAwareCommandPaths()
+# from the live COMP_WORDS array, so the case-pattern below can match. Only
+# stitch "parent:sub" when COMP_WORDS[1] is a known parent command — otherwise
+# "skilltree remove --global" would build "remove:--global" and bypass scope.
+_skilltree_cmd_path() {
+    local first="\${COMP_WORDS[1]:-}" second="\${COMP_WORDS[2]:-}"
+    case "$first" in
+        ${parents})
+            if [[ -n "$second" && "$second" != -* ]]; then
+                echo "$first:$second"
+                return
+            fi
+            ;;
+    esac
+    echo "$first"
+}
+
+# Detect --global / -g on the line — but ONLY for commands that actually
+# accept the flag. Without this scope check, "skilltree info xxx --global"
+# would (wrongly) flip dynamic completion into global-manifest mode even
+# though "info" does not declare --global. The list is generated at build
+# time from the COMMANDS table; see globalAwareCommandPaths() in
+# completion.ts.
+_skilltree_global_flag() {
+    local cmd_path
+    cmd_path=$(_skilltree_cmd_path)
+    case " ${awarePaths} " in
+        *" $cmd_path "*) ;;
+        *) return ;;
+    esac
+    local w
+    for w in "\${COMP_WORDS[@]}"; do
+        if [[ "$w" == "--global" || "$w" == "-g" ]]; then
+            echo "--global"
+            return
+        fi
+    done
+}
+
+# Shell out to \`skilltree _complete <kind>\` with the right scope. Errors
+# are silenced so a broken manifest can't pollute the shell.
+_skilltree_dyn() {
+    skilltree _complete "$1" $(_skilltree_global_flag) 2>/dev/null
+}
 
 _skilltree() {
     local cur prev cmd
@@ -358,10 +650,105 @@ complete -F _skilltree skilltree
 `;
 }
 
+// --- Install -----------------------------------------------------------------
+
 /**
- * CLI handler for `skilltree completion <shell>`
+ * Where to write the completion script for each shell. Picked to be picked
+ * up automatically by the shell's standard completion-loading mechanism.
+ *
+ * - zsh: a writable dir we put on `$fpath`. We use `~/.zfunc` because it's
+ *   the de-facto convention; the user adds it to fpath in their `.zshrc`.
+ * - bash: the XDG bash-completion lookup path (`~/.local/share/bash-completion/completions/<name>`).
+ *   System bash-completion picks this up automatically without any rc edit.
  */
-export async function completionCommand(shell?: string): Promise<void> {
+function getInstallPath(shell: "zsh" | "bash", home: string): string {
+	if (shell === "zsh") return join(home, ".zfunc", "_skilltree");
+	return join(home, ".local", "share", "bash-completion", "completions", "skilltree");
+}
+
+/**
+ * Detect the user's shell from the SHELL env var. Returns null if it can't
+ * confidently match; callers should fall back to asking the user.
+ */
+function detectShell(env: NodeJS.ProcessEnv = process.env): "zsh" | "bash" | null {
+	const shell = env.SHELL ?? "";
+	if (shell.endsWith("/zsh") || shell === "zsh") return "zsh";
+	if (shell.endsWith("/bash") || shell === "bash") return "bash";
+	return null;
+}
+
+export interface InstallCompletionOptions {
+	homeDir?: string; // override $HOME (testing)
+	env?: NodeJS.ProcessEnv; // override process.env (testing)
+}
+
+export interface InstallCompletionResult {
+	shell: "zsh" | "bash";
+	path: string;
+}
+
+/**
+ * Write the completion script to the right place for `shell`. Returns the
+ * detected shell and the absolute path written so callers don't have to
+ * sniff the path to figure out which shell-specific instructions to print.
+ * If `shell` is omitted, infer from `$SHELL`.
+ *
+ * `homeDir` resolution: we prefer the explicit caller override, then fall
+ * back to `os.homedir()` (which goes through the OS, robust to empty
+ * `$HOME`). `env.HOME` is only consulted when the caller passes a custom
+ * `env` (testing) AND that `env.HOME` is non-empty — an empty-string `HOME`
+ * is treated as "unset" per the project's presence-check doctrine, so we
+ * don't accidentally write to `/.zfunc/_skilltree`.
+ */
+export async function installCompletion(
+	shell: string | undefined,
+	opts: InstallCompletionOptions = {},
+): Promise<InstallCompletionResult> {
+	const env = opts.env ?? process.env;
+	const envHome = env.HOME && env.HOME.length > 0 ? env.HOME : undefined;
+	const home = opts.homeDir ?? envHome ?? homedir();
+
+	const target = shell ?? detectShell(env);
+	if (target !== "zsh" && target !== "bash") {
+		throw new Error(
+			"Could not detect shell — pass one explicitly: `skilltree completion zsh --install` or `... bash --install`.",
+		);
+	}
+
+	const script = target === "zsh" ? generateZshCompletion() : generateBashCompletion();
+	const path = getInstallPath(target, home);
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, script, "utf-8");
+	return { shell: target, path };
+}
+
+/**
+ * CLI handler for `skilltree completion [shell] [--install]`.
+ *
+ * - No `--install`: print the script to stdout (existing behavior — keeps
+ *   `skilltree completion zsh > somewhere` scripts working).
+ * - With `--install`: write to the conventional path for the shell and
+ *   print follow-up instructions.
+ */
+export async function completionCommand(
+	shell?: string,
+	opts: { install?: boolean } & InstallCompletionOptions = {},
+): Promise<void> {
+	if (opts.install) {
+		const { shell: target, path } = await installCompletion(shell, opts);
+		success(`Installed ${target} completion to ${pc.cyan(path)}`);
+		if (target === "zsh") {
+			console.log("");
+			console.log(dim("If completion isn't picked up, add to your ~/.zshrc:"));
+			console.log(pc.cyan("  fpath=(~/.zfunc $fpath)"));
+			console.log(pc.cyan("  autoload -Uz compinit && compinit"));
+		} else {
+			console.log("");
+			console.log(dim("Open a new shell to activate (bash-completion picks it up automatically)."));
+		}
+		return;
+	}
+
 	const target = shell ?? "zsh";
 	switch (target) {
 		case "zsh":

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -492,8 +492,24 @@ compdef _skilltree skilltree
 `;
 }
 
-function escapeZsh(s: string): string {
-	return s.replace(/'/g, "'\\''").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+/**
+ * Escape a description string for safe interpolation into a zsh
+ * `_arguments` spec wrapped in single quotes (e.g. `'flag[desc]'`).
+ *
+ * Backslash MUST be escaped first so the subsequent `\[` / `\]` injections
+ * don't combine with a pre-existing `\` from the input to form `\\[` (which
+ * zsh reads as literal-backslash + description-group-start, breaking the
+ * spec). Same logic for `'` — the `'\''` sequence must not double-interpret
+ * an upstream backslash.
+ *
+ * Exported for unit testing.
+ */
+export function escapeZsh(s: string): string {
+	return s
+		.replace(/\\/g, "\\\\")
+		.replace(/'/g, "'\\''")
+		.replace(/\[/g, "\\[")
+		.replace(/\]/g, "\\]");
 }
 
 // --- Bash --------------------------------------------------------------------

--- a/src/commands/teach.ts
+++ b/src/commands/teach.ts
@@ -1,6 +1,7 @@
 import { stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { detectInstalledAgents } from "../core/agents.js";
+import { materializeBundledSkill } from "../core/bundled-skill.js";
 import { writeGlobalManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { dim, pc } from "../core/ui.js";
@@ -12,6 +13,11 @@ export interface TeachOptions {
 	homeDir?: string; // Override home directory for testing
 	agent?: string; // Restrict to specific agent
 	globalDir?: string; // Override global config directory for testing
+	// Test override: directory to probe for the in-repo skill source. Pass a
+	// non-existent path to force the embedded-bundle fallback (simulating a
+	// compiled-binary install where `skills/skilltree/` isn't on disk).
+	// Default: resolved from `import.meta.url` to find the repo's `skills/`.
+	_devSourceDir?: string;
 }
 
 /**
@@ -21,8 +27,6 @@ export interface TeachOptions {
  * Auto-detects installed agents and installs to all by default.
  */
 export async function teachCommand(opts?: TeachOptions): Promise<void> {
-	const sourceDir = await findSkillSource();
-
 	const detected = await detectInstalledAgents(opts?.homeDir);
 
 	if (detected.length === 0) {
@@ -31,6 +35,7 @@ export async function teachCommand(opts?: TeachOptions): Promise<void> {
 
 	const agentsToInstall = opts?.agent ? [opts.agent] : detected;
 	const globalDir = opts?.globalDir ?? getGlobalDir();
+	const sourceDir = await findSkillSource(globalDir, opts?._devSourceDir);
 
 	// Ensure global manifest exists with install_targets
 	let manifest: Manifest;
@@ -56,40 +61,29 @@ export async function teachCommand(opts?: TeachOptions): Promise<void> {
 	}
 
 	console.log("");
-	console.log(dim("For shell tab completion, add to your ~/.zshrc:"));
-	console.log(pc.cyan('  eval "$(skilltree completion zsh)"'));
+	console.log(dim("For shell tab completion (zsh / bash):"));
+	console.log(pc.cyan("  skilltree completion --install"));
 }
 
 /**
- * Locate the bundled skill source.
- * Tries: relative to this file (dev), then relative to the binary (compiled).
+ * Locate the skilltree skill source. Tries the in-repo `skills/skilltree/`
+ * next to this file first (`bun run dev`, tests, checkout-local invocation);
+ * falls back to materializing the binary-embedded copy under
+ * `globalDir/bundled/skilltree/`. We use a stable path rather than a temp
+ * dir because it gets recorded as a `local:` dep in the global manifest and
+ * is re-read on subsequent `skilltree install --global` runs.
  */
-async function findSkillSource(): Promise<string> {
-	// Dev mode: relative to src/commands/teach.ts → ../../skills/skilltree/
-	const devPath = join(
-		dirname(new URL(import.meta.url).pathname),
-		"..",
-		"..",
-		"skills",
-		"skilltree",
-	);
+async function findSkillSource(globalDir: string, devSourceDir?: string): Promise<string> {
+	const devPath =
+		devSourceDir ??
+		join(dirname(new URL(import.meta.url).pathname), "..", "..", "skills", "skilltree");
 	try {
 		await stat(join(devPath, "SKILL.md"));
 		return devPath;
 	} catch {
-		// Not found at dev path
+		// Fall through to the embedded bundle.
 	}
-
-	// Compiled mode: try CWD/skills/skilltree
-	const cwdPath = join(process.cwd(), "skills", "skilltree");
-	try {
-		await stat(join(cwdPath, "SKILL.md"));
-		return cwdPath;
-	} catch {
-		// Not found
-	}
-
-	throw new Error(
-		"Could not find the skilltree skill source files. Ensure skills/skilltree/ exists in the project.",
-	);
+	const bundledPath = join(globalDir, "bundled", "skilltree");
+	await materializeBundledSkill(bundledPath);
+	return bundledPath;
 }

--- a/src/core/bundled-skill.ts
+++ b/src/core/bundled-skill.ts
@@ -1,0 +1,35 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import commandsMd from "../../skills/skilltree/references/commands.md" with { type: "text" };
+import workflowsMd from "../../skills/skilltree/references/workflows.md" with { type: "text" };
+import skillMd from "../../skills/skilltree/SKILL.md" with { type: "text" };
+
+/**
+ * Skill files embedded into the compiled binary at build time. When adding
+ * a new file under `skills/skilltree/`, add a matching text import above
+ * and an entry here — otherwise the binary will ship an incomplete skill.
+ */
+const BUNDLED_FILES: ReadonlyArray<readonly [string, string]> = [
+	["SKILL.md", skillMd],
+	["references/commands.md", commandsMd],
+	["references/workflows.md", workflowsMd],
+];
+
+/**
+ * Write the embedded skilltree skill into `targetDir`. Existing files are
+ * overwritten so re-running `skilltree teach` refreshes the bundle after
+ * a binary upgrade.
+ */
+export async function materializeBundledSkill(targetDir: string): Promise<string> {
+	const dirs = new Set<string>();
+	for (const [relPath] of BUNDLED_FILES) {
+		dirs.add(dirname(join(targetDir, relPath)));
+	}
+	await Promise.all(Array.from(dirs, (d) => mkdir(d, { recursive: true })));
+	await Promise.all(
+		BUNDLED_FILES.map(([relPath, content]) =>
+			writeFile(join(targetDir, relPath), content, "utf-8"),
+		),
+	);
+	return targetDir;
+}

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -101,6 +101,21 @@ export function getInstallTargets(manifest: Manifest, opts?: { global?: boolean 
 }
 
 /**
+ * Names of every declared dependency, prod + dev, sorted and de-duped.
+ *
+ * Centralized so callers don't keep open-coding `Object.keys(deps ?? {})`
+ * spreads and getting subtly inconsistent results (some sort, some don't,
+ * some Set-dedupe, some don't). A name shouldn't legally appear in both
+ * groups, but we de-dupe anyway so callers can treat the result as a
+ * stable set.
+ */
+export function getAllDependencyNames(manifest: Manifest): string[] {
+	const prod = Object.keys(manifest.dependencies ?? {});
+	const dev = Object.keys(manifest["dev-dependencies"] ?? {});
+	return Array.from(new Set([...prod, ...dev])).sort();
+}
+
+/**
  * Expand source shorthands in dependencies.
  * Replaces `source: alias` with `repo: url` using the sources map.
  */

--- a/tests/commands/_complete.test.ts
+++ b/tests/commands/_complete.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { completeCommand, getSuggestions, isCompleteKind } from "../../src/commands/_complete.js";
+
+let tempDir: string | undefined;
+
+async function makeProjectDir(yaml: string): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-complete-"));
+	await writeFile(join(tempDir, "skilltree.yaml"), yaml, "utf-8");
+	return tempDir;
+}
+
+async function makeGlobalDir(yaml: string): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-complete-global-"));
+	await mkdir(tempDir, { recursive: true });
+	await writeFile(join(tempDir, "global.yaml"), yaml, "utf-8");
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+describe("_complete: getSuggestions", () => {
+	describe("deps", () => {
+		test("returns sorted dep names from project manifest", async () => {
+			const dir = await makeProjectDir(
+				`dependencies:\n  zebra:\n    local: ./skills/zebra\n  apple:\n    local: ./skills/apple\n`,
+			);
+			const result = await getSuggestions("deps", { dir });
+			expect(result).toEqual(["apple", "zebra"]);
+		});
+
+		test("merges prod and dev dependencies, deduped", async () => {
+			const dir = await makeProjectDir(
+				`dependencies:\n  prod-skill:\n    local: ./p\ndev-dependencies:\n  dev-skill:\n    local: ./d\n`,
+			);
+			const result = await getSuggestions("deps", { dir });
+			expect(result).toEqual(["dev-skill", "prod-skill"]);
+		});
+
+		test("returns [] when no manifest exists (silent failure)", async () => {
+			const dir = await mkdtemp(join(tmpdir(), "skilltree-complete-empty-"));
+			tempDir = dir;
+			const result = await getSuggestions("deps", { dir });
+			expect(result).toEqual([]);
+		});
+
+		test("returns [] on malformed manifest (never breaks the shell)", async () => {
+			const dir = await makeProjectDir("dependencies: this is not: valid: [yaml");
+			const result = await getSuggestions("deps", { dir });
+			expect(result).toEqual([]);
+		});
+
+		test("reads global manifest when global=true", async () => {
+			const globalDir = await makeGlobalDir(
+				`dependencies:\n  global-skill:\n    local: ~/skills/g\n`,
+			);
+			const result = await getSuggestions("deps", { global: true, globalDir });
+			expect(result).toEqual(["global-skill"]);
+		});
+	});
+
+	describe("targets", () => {
+		test("returns install_targets sorted", async () => {
+			const dir = await makeProjectDir(
+				`install_targets:\n  - cursor\n  - claude\n  - ./custom\ndependencies: {}\n`,
+			);
+			const result = await getSuggestions("targets", { dir });
+			expect(result).toEqual(["./custom", "claude", "cursor"]);
+		});
+
+		test("returns [] when install_targets unset", async () => {
+			const dir = await makeProjectDir(`dependencies: {}\n`);
+			const result = await getSuggestions("targets", { dir });
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe("agents", () => {
+		test("returns the built-in agent registry keys", async () => {
+			const result = await getSuggestions("agents");
+			// Don't hard-code the full list (it'll change); just sanity check.
+			expect(result).toContain("claude");
+			expect(result).toContain("cursor");
+			expect(result.length).toBeGreaterThanOrEqual(3);
+			// Sorted
+			expect([...result].sort()).toEqual(result);
+		});
+
+		test("works regardless of cwd / manifest presence", async () => {
+			// No tempDir set up — this should still succeed.
+			const result = await getSuggestions("agents");
+			expect(result.length).toBeGreaterThan(0);
+		});
+	});
+
+	// Regression: the boundary used to cast `kind: string` straight into the
+	// typed kind, then rely on the switch having no default to throw via
+	// "undefined.length". `completeCommand` now validates explicitly so an
+	// unknown kind is silent — never throws, never prints.
+	describe("unknown kinds", () => {
+		test("isCompleteKind rejects unknown values", () => {
+			expect(isCompleteKind("deps")).toBe(true);
+			expect(isCompleteKind("targets")).toBe(true);
+			expect(isCompleteKind("agents")).toBe(true);
+			expect(isCompleteKind("bogus")).toBe(false);
+			expect(isCompleteKind("")).toBe(false);
+		});
+
+		test("completeCommand silently ignores unknown kinds (no throw, no output)", async () => {
+			const writes: string[] = [];
+			const orig = process.stdout.write;
+			// Cast through unknown to satisfy the strict signature; we are
+			// intentionally testing the runtime guard, not the type.
+			(process.stdout as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+				writes.push(s);
+				return true;
+			};
+			try {
+				await completeCommand("not-a-kind");
+			} finally {
+				process.stdout.write = orig;
+			}
+			expect(writes).toEqual([]);
+		});
+	});
+});

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -268,7 +268,20 @@ describe("completion generator", () => {
 });
 
 describe("generated completion scripts pass shell syntax checks", () => {
-	test("zsh -n accepts the generated zsh script", async () => {
+	// Probe whether each shell is on PATH. Ubuntu runners don't ship zsh by
+	// default, so the zsh test is skipped on environments without it; the
+	// bash test always runs because bash is universal on POSIX CI.
+	const hasShell = (shell: string): boolean => {
+		try {
+			return spawnSync(shell, ["--version"], { encoding: "utf-8" }).status === 0;
+		} catch {
+			return false;
+		}
+	};
+	const zshAvailable = hasShell("zsh");
+	const bashAvailable = hasShell("bash");
+
+	test.skipIf(!zshAvailable)("zsh -n accepts the generated zsh script", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "skilltree-zsh-syntax-"));
 		try {
 			const path = join(dir, "_skilltree");
@@ -283,7 +296,7 @@ describe("generated completion scripts pass shell syntax checks", () => {
 		}
 	});
 
-	test("bash -n accepts the generated bash script", async () => {
+	test.skipIf(!bashAvailable)("bash -n accepts the generated bash script", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "skilltree-bash-syntax-"));
 		try {
 			const path = join(dir, "skilltree.bash");
@@ -305,81 +318,84 @@ describe("generated completion scripts pass shell syntax checks", () => {
  * helpers, and assert their outputs. These would have caught the
  * `remove:--global` regression that the static-string tests missed.
  */
-describe("bash completion behavior (end-to-end)", () => {
-	function runBashWithScript(snippet: string): { stdout: string; status: number | null } {
-		const script = `${generateBashCompletion()}\n${snippet}`;
-		const result = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
-		return { stdout: result.stdout, status: result.status };
-	}
+describe.skipIf(spawnSync("bash", ["--version"], { encoding: "utf-8" }).status !== 0)(
+	"bash completion behavior (end-to-end)",
+	() => {
+		function runBashWithScript(snippet: string): { stdout: string; status: number | null } {
+			const script = `${generateBashCompletion()}\n${snippet}`;
+			const result = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+			return { stdout: result.stdout, status: result.status };
+		}
 
-	test("_skilltree_cmd_path returns 'remove' for 'skilltree remove --global'", () => {
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_cmd_path returns 'remove' for 'skilltree remove --global'", () => {
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree remove --global)
 			COMP_CWORD=3
 			_skilltree_cmd_path
 		`);
-		expect(stdout.trim()).toBe("remove");
-	});
+			expect(stdout.trim()).toBe("remove");
+		});
 
-	test("_skilltree_cmd_path returns 'targets:remove' for 'skilltree targets remove'", () => {
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_cmd_path returns 'targets:remove' for 'skilltree targets remove'", () => {
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree targets remove)
 			COMP_CWORD=3
 			_skilltree_cmd_path
 		`);
-		expect(stdout.trim()).toBe("targets:remove");
-	});
+			expect(stdout.trim()).toBe("targets:remove");
+		});
 
-	test("_skilltree_cmd_path does NOT stitch 'parent:flag' for non-parent commands", () => {
-		// Regression: 'remove' is not in the parent list, so even though
-		// COMP_WORDS[2] is non-empty (--global), we must not produce
-		// "remove:--global".
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_cmd_path does NOT stitch 'parent:flag' for non-parent commands", () => {
+			// Regression: 'remove' is not in the parent list, so even though
+			// COMP_WORDS[2] is non-empty (--global), we must not produce
+			// "remove:--global".
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree remove --global skill)
 			COMP_CWORD=4
 			_skilltree_cmd_path
 		`);
-		expect(stdout.trim()).toBe("remove");
-	});
+			expect(stdout.trim()).toBe("remove");
+		});
 
-	test("_skilltree_global_flag honors --global for `remove`", () => {
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_global_flag honors --global for `remove`", () => {
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree remove --global)
 			COMP_CWORD=3
 			_skilltree_global_flag
 		`);
-		expect(stdout.trim()).toBe("--global");
-	});
+			expect(stdout.trim()).toBe("--global");
+		});
 
-	test("_skilltree_global_flag IGNORES --global for `info` (which doesn't accept it)", () => {
-		// The whole point of the rework: bogus --global on `info` must
-		// not flip dynamic completion into global-manifest mode.
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_global_flag IGNORES --global for `info` (which doesn't accept it)", () => {
+			// The whole point of the rework: bogus --global on `info` must
+			// not flip dynamic completion into global-manifest mode.
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree info skilltree --global)
 			COMP_CWORD=4
 			_skilltree_global_flag
 		`);
-		expect(stdout.trim()).toBe("");
-	});
+			expect(stdout.trim()).toBe("");
+		});
 
-	test("_skilltree_global_flag honors --global for `targets remove`", () => {
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_global_flag honors --global for `targets remove`", () => {
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree targets remove --global)
 			COMP_CWORD=4
 			_skilltree_global_flag
 		`);
-		expect(stdout.trim()).toBe("--global");
-	});
+			expect(stdout.trim()).toBe("--global");
+		});
 
-	test("_skilltree_global_flag yields nothing when --global is absent", () => {
-		const { stdout } = runBashWithScript(`
+		test("_skilltree_global_flag yields nothing when --global is absent", () => {
+			const { stdout } = runBashWithScript(`
 			COMP_WORDS=(skilltree remove)
 			COMP_CWORD=2
 			_skilltree_global_flag
 		`);
-		expect(stdout.trim()).toBe("");
-	});
-});
+			expect(stdout.trim()).toBe("");
+		});
+	},
+);
 
 describe("installCompletion", () => {
 	let tempHome: string | undefined;

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -1,9 +1,56 @@
-import { describe, expect, test } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { generateBashCompletion, generateZshCompletion } from "../../src/commands/completion.js";
+import {
+	generateBashCompletion,
+	generateZshCompletion,
+	installCompletion,
+} from "../../src/commands/completion.js";
 
 const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+/**
+ * Extract the body of a `case` branch by name. Robust to length changes —
+ * unlike a fixed-size `slice(idx, idx + N)`, this returns the full text
+ * between `<name>)` and the matching `;;`. Returns `""` if not found.
+ *
+ * Note: this assumes branches don't contain a literal `;;` other than the
+ * terminator, which is true for our generated scripts.
+ */
+function extractCaseBranch(script: string, name: string): string {
+	const startMarker = `${name})`;
+	const start = script.indexOf(startMarker);
+	if (start === -1) return "";
+	const end = script.indexOf(";;", start);
+	return script.slice(start, end === -1 ? script.length : end + 2);
+}
+
+/**
+ * Strip shell-style comment lines so freshness tests don't pass on a
+ * flag/name that appears only in the script header.
+ */
+function stripShellComments(script: string): string {
+	return script
+		.split("\n")
+		.filter((line) => !/^\s*#/.test(line))
+		.join("\n");
+}
+
+/**
+ * Assert that a flag appears in the script as a *whole token*, not as a
+ * substring of a longer flag. Caught a real regression: `--install` was
+ * matching as a prefix of `--install-path`, so a missing case-branch
+ * wiring went undetected.
+ */
+function expectFlagPresent(script: string, flag: string): void {
+	const escaped = flag.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+	const re = new RegExp(`(?<![\\w-])${escaped}(?![\\w-])`);
+	if (!re.test(script)) {
+		throw new Error(`Flag ${flag} not found as whole token in script`);
+	}
+}
 
 /**
  * Extract all commands and flags from cli.ts source (same parser as freshness test).
@@ -83,17 +130,12 @@ describe("completion generator", () => {
 
 	test("zsh completion covers all long flags", async () => {
 		const { options } = await extractCliDefinitions();
-		const zsh = generateZshCompletion();
+		const zsh = stripShellComments(generateZshCompletion());
 
-		const allFlags: string[] = [];
 		for (const [, flags] of options) {
 			for (const flag of flags) {
-				allFlags.push(flag);
+				expectFlagPresent(zsh, flag);
 			}
-		}
-
-		for (const flag of allFlags) {
-			expect(zsh).toContain(flag);
 		}
 	});
 
@@ -121,17 +163,12 @@ describe("completion generator", () => {
 
 	test("bash completion covers all long flags", async () => {
 		const { options } = await extractCliDefinitions();
-		const bash = generateBashCompletion();
+		const bash = stripShellComments(generateBashCompletion());
 
-		const allFlags: string[] = [];
 		for (const [, flags] of options) {
 			for (const flag of flags) {
-				allFlags.push(flag);
+				expectFlagPresent(bash, flag);
 			}
-		}
-
-		for (const flag of allFlags) {
-			expect(bash).toContain(flag);
 		}
 	});
 
@@ -146,5 +183,265 @@ describe("completion generator", () => {
 		const bash = generateBashCompletion();
 		expect(bash).toContain("complete");
 		expect(bash).toContain("_skilltree");
+	});
+
+	test("zsh completion includes short flags alongside long ones", () => {
+		const zsh = generateZshCompletion();
+		// install has both `--global`/`-g` and `--force`/`-f` — both must
+		// appear so `skilltree install -<TAB>` lists short forms.
+		expect(zsh).toContain("-g");
+		expect(zsh).toContain("-f");
+		expect(zsh).toContain("-n");
+	});
+
+	test("completion header reports current package version (not stale)", async () => {
+		const pkgRaw = await readFile(join(import.meta.dir, "..", "..", "package.json"), "utf-8");
+		const pkgVersion = JSON.parse(pkgRaw).version as string;
+		expect(generateZshCompletion()).toContain(`v${pkgVersion}`);
+		expect(generateBashCompletion()).toContain(`v${pkgVersion}`);
+	});
+
+	test("zsh completion wires positional value completion for `remove`", () => {
+		const zsh = generateZshCompletion();
+		// The helper that calls `skilltree _complete deps` must be defined
+		// AND referenced from the `remove` case branch.
+		expect(zsh).toContain("_skilltree_complete_deps()");
+		expect(zsh).toContain("skilltree _complete deps");
+		const branch = extractCaseBranch(zsh, "remove");
+		expect(branch).not.toBe("");
+		expect(branch).toContain("_skilltree_complete_deps");
+	});
+
+	test("bash completion wires positional value completion for `remove`", () => {
+		const bash = generateBashCompletion();
+		expect(bash).toContain("_skilltree_dyn deps");
+		const branch = extractCaseBranch(bash, "remove");
+		expect(branch).not.toBe("");
+		expect(branch).toContain("_skilltree_dyn deps");
+	});
+
+	// Issue 1 regression: `*::value:func` (any-number) re-fired completion
+	// after the user already typed an arg. We use `:value:func` (exactly one)
+	// because every command with positionalComplete takes one positional.
+	test("zsh value spec completes only a single positional, not repeating", () => {
+		const zsh = generateZshCompletion();
+		const branch = extractCaseBranch(zsh, "remove");
+		expect(branch).toContain(":value:_skilltree_complete_deps");
+		expect(branch).not.toContain("*::value:");
+		expect(branch).not.toContain("*:value:");
+	});
+
+	// Issue 2 regression: --global detection used to fire for ANY command,
+	// including `info` which does not accept --global. The helper must now
+	// scope its detection to commands that actually declare the flag —
+	// derived at gen time from the COMMANDS table.
+	test("zsh --global detection skips commands that don't declare --global", () => {
+		const zsh = generateZshCompletion();
+		// info is in the awarePaths gate? Verify the negative.
+		// The generated helper interpolates a space-delimited list. info should NOT be in it.
+		// remove, update, targets:remove, targets:add SHOULD be in it.
+		const helperMatch = zsh.match(/_skilltree_global_flag\(\)\s*\{[\s\S]*?\}/);
+		expect(helperMatch).not.toBeNull();
+		const helperBody = helperMatch?.[0] ?? "";
+		// Look for the gen-time list inside the case pattern.
+		expect(helperBody).toContain("remove");
+		expect(helperBody).toContain("update");
+		expect(helperBody).toContain("targets:remove");
+		expect(helperBody).toContain("targets:add");
+		// info has positionalComplete but no --global — must not appear in the
+		// list. Match it as a standalone token to avoid matching "info" as a
+		// substring of e.g. "completion".
+		expect(helperBody).not.toMatch(/(^|[ :])info($|[ :])/);
+	});
+
+	test("bash --global detection skips commands that don't declare --global", () => {
+		const bash = generateBashCompletion();
+		const helperMatch = bash.match(/_skilltree_global_flag\(\)\s*\{[\s\S]*?\n\}/);
+		expect(helperMatch).not.toBeNull();
+		const helperBody = helperMatch?.[0] ?? "";
+		expect(helperBody).toContain("remove");
+		expect(helperBody).toContain("update");
+		expect(helperBody).toContain("targets:remove");
+		expect(helperBody).toContain("targets:add");
+		expect(helperBody).not.toMatch(/(^|[ :])info($|[ :])/);
+	});
+});
+
+describe("generated completion scripts pass shell syntax checks", () => {
+	test("zsh -n accepts the generated zsh script", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "skilltree-zsh-syntax-"));
+		try {
+			const path = join(dir, "_skilltree");
+			await Bun.write(path, generateZshCompletion());
+			const result = spawnSync("zsh", ["-n", path], { encoding: "utf-8" });
+			if (result.status !== 0) {
+				throw new Error(`zsh -n failed with status ${result.status}\nstderr:\n${result.stderr}`);
+			}
+			expect(result.status).toBe(0);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("bash -n accepts the generated bash script", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "skilltree-bash-syntax-"));
+		try {
+			const path = join(dir, "skilltree.bash");
+			await Bun.write(path, generateBashCompletion());
+			const result = spawnSync("bash", ["-n", path], { encoding: "utf-8" });
+			if (result.status !== 0) {
+				throw new Error(`bash -n failed with status ${result.status}\nstderr:\n${result.stderr}`);
+			}
+			expect(result.status).toBe(0);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+/**
+ * End-to-end behavioral tests for the bash script. We source the generated
+ * script in a real bash, drive `_skilltree_cmd_path` and the global-flag
+ * helpers, and assert their outputs. These would have caught the
+ * `remove:--global` regression that the static-string tests missed.
+ */
+describe("bash completion behavior (end-to-end)", () => {
+	function runBashWithScript(snippet: string): { stdout: string; status: number | null } {
+		const script = `${generateBashCompletion()}\n${snippet}`;
+		const result = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+		return { stdout: result.stdout, status: result.status };
+	}
+
+	test("_skilltree_cmd_path returns 'remove' for 'skilltree remove --global'", () => {
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree remove --global)
+			COMP_CWORD=3
+			_skilltree_cmd_path
+		`);
+		expect(stdout.trim()).toBe("remove");
+	});
+
+	test("_skilltree_cmd_path returns 'targets:remove' for 'skilltree targets remove'", () => {
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree targets remove)
+			COMP_CWORD=3
+			_skilltree_cmd_path
+		`);
+		expect(stdout.trim()).toBe("targets:remove");
+	});
+
+	test("_skilltree_cmd_path does NOT stitch 'parent:flag' for non-parent commands", () => {
+		// Regression: 'remove' is not in the parent list, so even though
+		// COMP_WORDS[2] is non-empty (--global), we must not produce
+		// "remove:--global".
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree remove --global skill)
+			COMP_CWORD=4
+			_skilltree_cmd_path
+		`);
+		expect(stdout.trim()).toBe("remove");
+	});
+
+	test("_skilltree_global_flag honors --global for `remove`", () => {
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree remove --global)
+			COMP_CWORD=3
+			_skilltree_global_flag
+		`);
+		expect(stdout.trim()).toBe("--global");
+	});
+
+	test("_skilltree_global_flag IGNORES --global for `info` (which doesn't accept it)", () => {
+		// The whole point of the rework: bogus --global on `info` must
+		// not flip dynamic completion into global-manifest mode.
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree info skilltree --global)
+			COMP_CWORD=4
+			_skilltree_global_flag
+		`);
+		expect(stdout.trim()).toBe("");
+	});
+
+	test("_skilltree_global_flag honors --global for `targets remove`", () => {
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree targets remove --global)
+			COMP_CWORD=4
+			_skilltree_global_flag
+		`);
+		expect(stdout.trim()).toBe("--global");
+	});
+
+	test("_skilltree_global_flag yields nothing when --global is absent", () => {
+		const { stdout } = runBashWithScript(`
+			COMP_WORDS=(skilltree remove)
+			COMP_CWORD=2
+			_skilltree_global_flag
+		`);
+		expect(stdout.trim()).toBe("");
+	});
+});
+
+describe("installCompletion", () => {
+	let tempHome: string | undefined;
+
+	afterEach(async () => {
+		if (tempHome) {
+			await rm(tempHome, { recursive: true, force: true });
+			tempHome = undefined;
+		}
+	});
+
+	test("writes zsh completion to ~/.zfunc/_skilltree", async () => {
+		tempHome = await mkdtemp(join(tmpdir(), "skilltree-install-zsh-"));
+		const result = await installCompletion("zsh", { homeDir: tempHome });
+		expect(result.shell).toBe("zsh");
+		expect(result.path).toBe(join(tempHome, ".zfunc", "_skilltree"));
+		const written = await readFile(result.path, "utf-8");
+		expect(written).toContain("#compdef skilltree");
+		expect(written).toContain("_skilltree_complete_deps");
+	});
+
+	test("writes bash completion under ~/.local/share/bash-completion/", async () => {
+		tempHome = await mkdtemp(join(tmpdir(), "skilltree-install-bash-"));
+		const result = await installCompletion("bash", { homeDir: tempHome });
+		expect(result.shell).toBe("bash");
+		expect(result.path).toBe(
+			join(tempHome, ".local", "share", "bash-completion", "completions", "skilltree"),
+		);
+		await stat(result.path); // throws if missing
+	});
+
+	test("auto-detects shell from $SHELL when not specified", async () => {
+		tempHome = await mkdtemp(join(tmpdir(), "skilltree-install-detect-"));
+		const result = await installCompletion(undefined, {
+			homeDir: tempHome,
+			env: { SHELL: "/usr/local/bin/zsh", HOME: tempHome },
+		});
+		expect(result.shell).toBe("zsh");
+		expect(result.path.endsWith("_skilltree")).toBe(true);
+	});
+
+	test("throws a clear error when shell can't be detected", async () => {
+		tempHome = await mkdtemp(join(tmpdir(), "skilltree-install-fail-"));
+		await expect(
+			installCompletion(undefined, {
+				homeDir: tempHome,
+				env: { SHELL: "/bin/fish", HOME: tempHome },
+			}),
+		).rejects.toThrow(/Could not detect shell/);
+	});
+
+	// Regression: empty $HOME used to slip through `??` and write to
+	// `/.zfunc/_skilltree`. We treat blank HOME as unset and fall back to
+	// the OS-derived homedir.
+	test("treats empty $HOME as unset (does not write to root)", async () => {
+		tempHome = await mkdtemp(join(tmpdir(), "skilltree-install-emptyhome-"));
+		const result = await installCompletion("zsh", {
+			homeDir: tempHome, // explicit override wins, but the env mirrors a real empty-HOME case
+			env: { SHELL: "/bin/zsh", HOME: "" },
+		});
+		// Path should be under the explicit homeDir, NOT under "/".
+		expect(result.path.startsWith(tempHome)).toBe(true);
+		expect(result.path.startsWith("/.zfunc")).toBe(false);
 	});
 });

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	escapeZsh,
 	generateBashCompletion,
 	generateZshCompletion,
 	installCompletion,
@@ -177,6 +178,33 @@ describe("completion generator", () => {
 		// Must start with the compdef function
 		expect(zsh).toContain("_skilltree");
 		expect(zsh).toContain("compdef");
+	});
+
+	// Regression: escapeZsh used to escape `'`, `[`, `]` but not `\`. A
+	// description containing `\[` would emit `\\[` to the script, which zsh
+	// reads as literal-backslash + description-group-start — breaking the
+	// surrounding `_arguments` spec. Backslash must be escaped FIRST so the
+	// subsequent replacements don't double-interpret.
+	describe("escapeZsh", () => {
+		test("escapes single quotes via the standard '\\'' break-out", () => {
+			expect(escapeZsh("it's fine")).toBe("it'\\''s fine");
+		});
+
+		test("escapes square brackets so they don't terminate the description group", () => {
+			expect(escapeZsh("[wat]")).toBe("\\[wat\\]");
+		});
+
+		test("escapes backslashes so they don't combine with later bracket escapes", () => {
+			// Input `\[` must NOT become `\\[` (which zsh parses wrong); it
+			// must become `\\\[` (literal backslash + escaped bracket).
+			expect(escapeZsh("\\[")).toBe("\\\\\\[");
+			expect(escapeZsh("\\]")).toBe("\\\\\\]");
+			expect(escapeZsh("a\\b")).toBe("a\\\\b");
+		});
+
+		test("idempotent for plain ASCII text", () => {
+			expect(escapeZsh("plain description")).toBe("plain description");
+		});
 	});
 
 	test("bash completion is valid shell script", () => {

--- a/tests/commands/teach.test.ts
+++ b/tests/commands/teach.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { teachCommand } from "../../src/commands/teach.js";
@@ -69,5 +69,40 @@ describe("teachCommand", () => {
 
 		const manifest = await readGlobalManifest(globalDir);
 		expect(manifest.dependencies?.skilltree).toBeDefined();
+	});
+
+	// Regression: when skilltree is run as a compiled binary (not from a
+	// checkout of this repo), the dev-mode lookup for `skills/skilltree/`
+	// fails. Teach must materialize the skill files embedded in the binary
+	// rather than refusing to run or silently depending on `process.cwd()`
+	// containing the right files. We simulate the compiled-binary case by
+	// pointing `_devSourceDir` at a path that doesn't exist.
+	test("falls back to embedded bundle when dev source is missing (compiled-binary case)", async () => {
+		const dir = await setup();
+		const globalDir = join(dir, "global-config");
+		const fakeDevDir = join(dir, "no-such-dev-source");
+
+		await teachCommand({
+			homeDir: join(dir, "home"),
+			globalDir,
+			_devSourceDir: fakeDevDir,
+		});
+
+		// Bundled files should have been materialized into globalDir/bundled/skilltree
+		const bundledRoot = join(globalDir, "bundled", "skilltree");
+		const skillContent = await readFile(join(bundledRoot, "SKILL.md"), "utf-8");
+		expect(skillContent).toContain("name: skilltree");
+		await stat(join(bundledRoot, "references", "commands.md"));
+		await stat(join(bundledRoot, "references", "workflows.md"));
+
+		// Manifest should record the materialized location as the local source
+		const manifest = await readGlobalManifest(globalDir);
+		const dep = manifest.dependencies?.skilltree as { local?: string };
+		expect(dep.local).toBeDefined();
+		expect(dep.local).toContain(join("bundled", "skilltree"));
+
+		// Lockfile should be populated as for any normal local skill
+		const lockfile = await readGlobalLockfile(globalDir);
+		expect(lockfile?.packages?.skilltree?.type).toBe("skill");
 	});
 });

--- a/tests/core/bundled-skill.test.ts
+++ b/tests/core/bundled-skill.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { materializeBundledSkill } from "../../src/core/bundled-skill.js";
+
+describe("materializeBundledSkill", () => {
+	test("writes SKILL.md and references into a fresh target dir", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "skilltree-bundled-"));
+		try {
+			const target = join(dir, "out");
+			const result = await materializeBundledSkill(target);
+			expect(result).toBe(target);
+
+			const skill = await readFile(join(target, "SKILL.md"), "utf-8");
+			expect(skill).toContain("name: skilltree");
+
+			const commands = await readFile(join(target, "references", "commands.md"), "utf-8");
+			expect(commands.length).toBeGreaterThan(0);
+
+			const workflows = await readFile(join(target, "references", "workflows.md"), "utf-8");
+			expect(workflows.length).toBeGreaterThan(0);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("overwrites existing files on re-run", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "skilltree-bundled-"));
+		try {
+			const target = join(dir, "out");
+			await materializeBundledSkill(target);
+			await materializeBundledSkill(target); // should not throw
+
+			const skill = await readFile(join(target, "SKILL.md"), "utf-8");
+			expect(skill).toContain("name: skilltree");
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
## Summary
Two bugs that surface only when `skilltree` is installed via npm or run as a compiled binary (not from a checkout of the repo):

- **`skilltree teach` only worked when run from a directory whose `./skills/skilltree/` exists.** Now embeds the skill files into the binary at build time via Bun's text-import attribute and materializes them on demand.
- **`skilltree completion` was missing dynamic value completion, an installer, current version info, short flags, and had a scope leak** where `info xxx --global` (a flag `info` doesn't accept) wrongly switched to the global manifest. Plus the `--install` flag I added wasn't actually completing because the COMMANDS table entry hadn't been updated — caught during a self-review pass and tightened the freshness test so the same class of bug can't recur.

## What changed

### Teach
- `src/core/bundled-skill.ts` — embeds `SKILL.md` and references via `import … with { type: "text" }`; `materializeBundledSkill()` writes them to `~/.skilltree/bundled/skilltree/` on demand.
- `src/commands/teach.ts` — `findSkillSource()` falls through to the embedded bundle when the dev source isn't on disk. Removed the misleading CWD lookup.
- `tsconfig.json` — `module: ESNext` for import-attribute support.

### Completion
- New hidden `skilltree _complete <kind>` subcommand (`src/commands/_complete.ts`) — emits dep names, install_targets, or agent registry keys. Hard rule: never throws, never prints diagnostics so a broken manifest can't pollute the shell.
- `src/commands/completion.ts` — major refactor:
  - Reads `pkg.version` for the header (was hardcoded `v0.4.0`).
  - Emits short flags (`-f`/`-n`/`-g`) alongside long forms.
  - Helpers (`_skilltree_complete_*`, `_skilltree_dyn`, `_skilltree_cmd_path`, `_skilltree_global_flag`) shell out to `_complete` for value positions; respect `--global`/`-g` scope by inspecting the live command line.
  - Generator emits a list of "globally-aware" command paths so `_skilltree_global_flag` only honours `--global` for commands that actually declare it. Fixes the `info xxx --global` leak.
  - Generator emits a list of parent commands so `_skilltree_cmd_path` correctly distinguishes `targets remove` (parent:sub) from `remove --global` (no stitching).
  - New `installCompletion()` writes to `~/.zfunc/_skilltree` (zsh) or `~/.local/share/bash-completion/completions/skilltree` (bash). Returns `{ shell, path }` so callers don't sniff suffixes.
- `src/cli.ts` — wires `_complete <kind>` (hidden) and `--install` flag on `completion`. Updated `teach` post-install hint.

### Hardening
- `src/core/manifest.ts` — new `getAllDependencyNames(manifest)` consolidates the open-coded `Object.keys(deps ?? {})` merge.
- Tightened freshness test: `expectFlagPresent()` uses a whole-token boundary regex, and `stripShellComments()` removes `#` lines so the test can't pass on flag names that appear only in script headers. Caught the `completion --install` regression.
- End-to-end behavioural tests source the generated bash script and drive `_skilltree_global_flag` for `info`, `remove`, `targets remove`, etc. Real zsh completion verified through `expect`.
- `zsh -n` and `bash -n` syntax checks on the emitted scripts.

## Test plan
- [x] `bun test` — 752 → 784 tests, all pass
- [x] `bun run lint` clean (8 pre-existing warnings in unrelated files)
- [x] `bun run typecheck` clean
- [x] Manual: `dist/skilltree teach` from `/tmp` (outside repo) → succeeds, materializes bundle
- [x] Manual: `skilltree remove sk<TAB>` → completes from local manifest
- [x] Manual: `skilltree remove --global <TAB>` → global manifest
- [x] Manual: `skilltree info xxx --global<TAB>` → still local (the regression we caught)
- [x] Manual: `skilltree targets add <TAB>` → all 6 agents
- [x] Manual: `skilltree completion --<TAB>` → `--install`
- [x] Manual: `skilltree completion zsh --install` → writes script, prints follow-up steps
- [x] zsh interactive completion verified via `expect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)