### PR TITLE
feat(manifest): make .yml the default extension

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,6 +1,7 @@
 import { stat } from "node:fs/promises";
 import semver from "semver";
 import { canonicalSource } from "../core/deps.js";
+import { MANIFEST_NEW } from "../core/filenames.js";
 import { loadManifestOrThrow, writeGlobalManifest, writeManifest } from "../core/manifest.js";
 import { collapseTilde, expandTilde, getGlobalDir } from "../core/paths.js";
 import { readRegistryIndex } from "../core/registry-cache.js";
@@ -100,7 +101,7 @@ async function buildDependency(name: string, opts: AddOptions, dir: string): Pro
 	}
 
 	// R13: `--path` is optional when `--repo` or `--source` is given. The
-	// resolver infers the path at install time from origin's skilltree.yaml
+	// resolver infers the path at install time from origin's skilltree.yml
 	// or the conventional probe. If neither works, install emits a clear R9
 	// error. We deliberately do not pre-resolve at add-time to keep `add`
 	// network-free and fast.
@@ -203,7 +204,7 @@ function checkOtherGroup(
 	const otherDeps = manifest[otherGroup] ?? {};
 	if (name in otherDeps) {
 		throw new Error(
-			`"${name}" already exists in ${otherGroup}. Remove it first, or edit skilltree.yaml directly.`,
+			`"${name}" already exists in ${otherGroup}. Remove it first, or edit ${MANIFEST_NEW} directly.`,
 		);
 	}
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,12 @@ import { writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { detectInstalledAgents } from "../core/agents.js";
-import { globalManifestExists, MANIFEST_NEW, manifestExists } from "../core/filenames.js";
+import {
+	GLOBAL_MANIFEST,
+	globalManifestExists,
+	MANIFEST_NEW,
+	manifestExists,
+} from "../core/filenames.js";
 import { addGitignoreEntries, getSkillAgentIgnoreEntries } from "../core/gitignore.js";
 import { serializeManifest, writeGlobalManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
@@ -94,7 +99,7 @@ async function initGlobal(globalDirOverride?: string): Promise<void> {
 	const globalDir = globalDirOverride ?? getGlobalDir();
 
 	if (globalManifestExists(globalDir)) {
-		warn(`${globalDir}/global.yaml already exists. No changes made.`);
+		warn(`${globalDir}/${GLOBAL_MANIFEST} already exists. No changes made.`);
 		return;
 	}
 
@@ -103,7 +108,7 @@ async function initGlobal(globalDirOverride?: string): Promise<void> {
 	};
 
 	await writeGlobalManifest(manifest, globalDir);
-	success(`Created ${globalDir}/global.yaml`);
+	success(`Created ${globalDir}/${GLOBAL_MANIFEST}`);
 }
 
 /**

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,10 +3,10 @@ import { basename } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { detectInstalledAgents } from "../core/agents.js";
 import {
+	findExistingGlobalManifest,
+	findExistingManifest,
 	GLOBAL_MANIFEST,
-	globalManifestExists,
 	MANIFEST_NEW,
-	manifestExists,
 } from "../core/filenames.js";
 import { addGitignoreEntries, getSkillAgentIgnoreEntries } from "../core/gitignore.js";
 import { serializeManifest, writeGlobalManifest } from "../core/manifest.js";
@@ -36,9 +36,12 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 
 	const manifestPath = `${dir}/${MANIFEST_NEW}`;
 
-	// Guard: refuse to overwrite existing manifest
-	if (manifestExists(dir)) {
-		throw new Error(`${MANIFEST_NEW} already exists. Remove it first or edit it directly.`);
+	// Guard: refuse to overwrite existing manifest. Report the actual on-disk
+	// name so a project on the legacy .yaml extension doesn't get a misleading
+	// "skilltree.yml already exists" — they don't have one.
+	const existing = findExistingManifest(dir);
+	if (existing) {
+		throw new Error(`${existing} already exists. Remove it first or edit it directly.`);
 	}
 
 	// Auto-detect installed agents
@@ -98,8 +101,9 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 async function initGlobal(globalDirOverride?: string): Promise<void> {
 	const globalDir = globalDirOverride ?? getGlobalDir();
 
-	if (globalManifestExists(globalDir)) {
-		warn(`${globalDir}/${GLOBAL_MANIFEST} already exists. No changes made.`);
+	const existing = findExistingGlobalManifest(globalDir);
+	if (existing) {
+		warn(`${globalDir}/${existing} already exists. No changes made.`);
 		return;
 	}
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,4 @@
-import { manifestExists } from "../core/filenames.js";
+import { MANIFEST_NEW, manifestExists } from "../core/filenames.js";
 import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
@@ -18,7 +18,7 @@ export async function listCommand(dir: string, opts?: ListOptions): Promise<void
 	const lockfile = isGlobal ? await readGlobalLockfile(globalDir) : await readLockfile(dir);
 
 	if (!isGlobal && !manifestExists(dir)) {
-		throw new Error("No skilltree.yaml found. Run `skilltree init` first.");
+		throw new Error(`No ${MANIFEST_NEW} found. Run \`skilltree init\` first.`);
 	}
 
 	if (!lockfile || Object.keys(lockfile.packages).length === 0) {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,6 +1,7 @@
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
+import { GLOBAL_MANIFEST, MANIFEST_NEW } from "../core/filenames.js";
 import { getTargetPath } from "../core/installer.js";
 import {
 	readGlobalLockfile,
@@ -47,7 +48,7 @@ export async function removeCommand(
 	} else {
 		await writeManifest(dir, manifest);
 	}
-	success(`Removed ${name} from ${isGlobal ? "global.yaml" : "skilltree.yaml"}`);
+	success(`Removed ${name} from ${isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW}`);
 
 	const installBase = isGlobal ? getGlobalInstallBase() : join(dir, getDevInstallPath(manifest));
 
@@ -78,7 +79,7 @@ function validateRemoveTarget(
 		!isGlobal && manifest["dev-dependencies"] && name in manifest["dev-dependencies"];
 
 	if (!inDeps && !inDevDeps) {
-		const manifestName = isGlobal ? "global.yaml" : "skilltree.yaml";
+		const manifestName = isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW;
 		if (lockfile?.packages[name]) {
 			throw new Error(
 				`"${name}" is not in ${manifestName}. It is a transitive dependency. To stop installing it, remove or modify the parent dependency instead.`,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,5 @@
 import { rm } from "node:fs/promises";
-import { resolveGlobalLockfilePath } from "../core/filenames.js";
+import { GLOBAL_MANIFEST, MANIFEST_NEW, resolveGlobalLockfilePath } from "../core/filenames.js";
 import {
 	readGlobalLockfile,
 	readLockfile,
@@ -86,7 +86,7 @@ async function selectiveUpdate(
 	const allDeps = { ...expanded.dependencies, ...expanded["dev-dependencies"] };
 	const dep = allDeps[name];
 	if (!dep) {
-		throw new Error(`"${name}" is not in ${isGlobal ? "global.yaml" : "skilltree.yaml"}.`);
+		throw new Error(`"${name}" is not in ${isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW}.`);
 	}
 
 	// Clear lockfile entries for this dep (and same-repo siblings)

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -1,5 +1,6 @@
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
+import { MANIFEST_NEW } from "../core/filenames.js";
 import {
 	addGitignoreEntries,
 	getSkillAgentIgnoreEntries,
@@ -105,7 +106,7 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 	// Set vendor: true in manifest
 	manifest.vendor = true;
 	await writeManifest(dir, manifest);
-	console.log(dim("Updated skilltree.yaml (vendor: true)"));
+	console.log(dim(`Updated ${MANIFEST_NEW} (vendor: true)`));
 
 	// Update .gitignore: remove skill/agent ignore entries so they can be committed
 	const ignoreEntries = getSkillAgentIgnoreEntries(devInstallPath);
@@ -141,7 +142,7 @@ export async function unvendorCommand(dir: string, options?: { force?: boolean }
 
 	delete manifest.vendor;
 	await writeManifest(dir, manifest);
-	console.log(dim("Updated skilltree.yaml (vendor: false)"));
+	console.log(dim(`Updated ${MANIFEST_NEW} (vendor: false)`));
 
 	const ignoreEntries = getSkillAgentIgnoreEntries(devInstallPath);
 	const added = await addGitignoreEntries(dir, ignoreEntries);

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { GLOBAL_MANIFEST, MANIFEST_NEW } from "../core/filenames.js";
 import { resolveAll } from "../core/graph.js";
 import type { VerifyStatus } from "../core/installer.js";
 import { verifyInstalled } from "../core/installer.js";
@@ -89,7 +90,7 @@ function printVerifyDiagnostics(
 	}
 	if (broken.length > 0) {
 		warn(
-			`${broken.length} symlink is broken. Check source paths in ${isGlobal ? "global.yaml" : "skilltree.yaml"}.`,
+			`${broken.length} symlink is broken. Check source paths in ${isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW}.`,
 		);
 	}
 	if (stale.length > 0) {

--- a/src/core/filenames.ts
+++ b/src/core/filenames.ts
@@ -2,24 +2,41 @@ import { existsSync } from "node:fs";
 import pc from "picocolors";
 import { getGlobalDir } from "./paths.js";
 
-export const MANIFEST_NEW = "skilltree.yaml";
-export const MANIFEST_NEW_ALT = "skilltree.yml";
+// .yml is the canonical extension; .yaml is still accepted on read with a
+// deprecation warning so existing projects keep working without changes.
+export const MANIFEST_NEW = "skilltree.yml";
+export const MANIFEST_NEW_ALT = "skilltree.yaml";
 export const MANIFEST_LEGACY = "skillkit.yaml";
 export const LOCKFILE_NEW = "skilltree.lock";
 export const LOCKFILE_LEGACY = "skillkit.lock";
-export const GLOBAL_MANIFEST = "global.yaml";
-export const GLOBAL_MANIFEST_ALT = "global.yml";
+export const GLOBAL_MANIFEST = "global.yml";
+export const GLOBAL_MANIFEST_ALT = "global.yaml";
 export const GLOBAL_LOCKFILE = "global.lock";
 
 const DEPRECATION_PREFIX = pc.yellow("[DEPRECATION]");
 
-let manifestWarned = false;
-let lockfileWarned = false;
+// Once-per-process gate for deprecation warnings, keyed by a stable string
+// so callers don't accumulate sibling boolean flags as new deprecations land.
+const warnedOnce = new Set<string>();
+
+function warnOnce(key: string, message: string): void {
+	if (warnedOnce.has(key)) return;
+	warnedOnce.add(key);
+	console.warn(message);
+}
+
+/**
+ * Test-only helper: reset the warn-once gate so each test that wants to
+ * assert on a deprecation warning sees it fire. Not part of the public CLI API.
+ */
+export function _resetDeprecationWarningsForTests(): void {
+	warnedOnce.clear();
+}
 
 /**
  * Resolve the manifest filename in a directory.
- * Accepts skilltree.yaml or skilltree.yml; refuses if both exist.
- * Falls back to skillkit.yaml with a deprecation warning.
+ * Accepts skilltree.yml (canonical) or skilltree.yaml (deprecated default);
+ * refuses if both exist. Falls back to skillkit.yaml with a deprecation warning.
  */
 export function resolveManifestPath(dir: string): { path: string; filename: string } {
 	const newPath = `${dir}/${MANIFEST_NEW}`;
@@ -36,17 +53,19 @@ export function resolveManifestPath(dir: string): { path: string; filename: stri
 		return { path: newPath, filename: MANIFEST_NEW };
 	}
 	if (altExists) {
+		warnOnce(
+			"manifest-yaml-ext",
+			`${DEPRECATION_PREFIX} Found ${MANIFEST_NEW_ALT} — \`.yml\` is now the default extension. Rename to ${MANIFEST_NEW} when convenient; ${MANIFEST_NEW_ALT} is still accepted.`,
+		);
 		return { path: altPath, filename: MANIFEST_NEW_ALT };
 	}
 
 	const legacyPath = `${dir}/${MANIFEST_LEGACY}`;
 	if (existsSync(legacyPath)) {
-		if (!manifestWarned) {
-			console.warn(
-				`${DEPRECATION_PREFIX} Found ${MANIFEST_LEGACY} — please rename to ${MANIFEST_NEW}. Support for ${MANIFEST_LEGACY} will be removed in a future version.`,
-			);
-			manifestWarned = true;
-		}
+		warnOnce(
+			"manifest-legacy",
+			`${DEPRECATION_PREFIX} Found ${MANIFEST_LEGACY} — please rename to ${MANIFEST_NEW}. Support for ${MANIFEST_LEGACY} will be removed in a future version.`,
+		);
 		return { path: legacyPath, filename: MANIFEST_LEGACY };
 	}
 
@@ -66,12 +85,10 @@ export function resolveLockfilePath(dir: string): { path: string; filename: stri
 
 	const legacyPath = `${dir}/${LOCKFILE_LEGACY}`;
 	if (existsSync(legacyPath)) {
-		if (!lockfileWarned) {
-			console.warn(
-				`${DEPRECATION_PREFIX} Found ${LOCKFILE_LEGACY} — please rename to ${LOCKFILE_NEW}. Support for ${LOCKFILE_LEGACY} will be removed in a future version.`,
-			);
-			lockfileWarned = true;
-		}
+		warnOnce(
+			"lockfile-legacy",
+			`${DEPRECATION_PREFIX} Found ${LOCKFILE_LEGACY} — please rename to ${LOCKFILE_NEW}. Support for ${LOCKFILE_LEGACY} will be removed in a future version.`,
+		);
 		return { path: legacyPath, filename: LOCKFILE_LEGACY };
 	}
 
@@ -100,7 +117,7 @@ export const LOCKFILE_DISPLAY = LOCKFILE_NEW;
 // --- Global paths ---
 
 /**
- * Resolve the global manifest path: ~/.skilltree/global.yaml (or .yml).
+ * Resolve the global manifest path: ~/.skilltree/global.yml (or legacy .yaml).
  * Refuses if both extensions are present.
  */
 export function resolveGlobalManifestPath(globalDir?: string): {
@@ -108,20 +125,24 @@ export function resolveGlobalManifestPath(globalDir?: string): {
 	filename: string;
 } {
 	const dir = globalDir ?? getGlobalDir();
-	const yamlPath = `${dir}/${GLOBAL_MANIFEST}`;
-	const ymlPath = `${dir}/${GLOBAL_MANIFEST_ALT}`;
-	const yamlExists = existsSync(yamlPath);
+	const ymlPath = `${dir}/${GLOBAL_MANIFEST}`;
+	const yamlPath = `${dir}/${GLOBAL_MANIFEST_ALT}`;
 	const ymlExists = existsSync(ymlPath);
+	const yamlExists = existsSync(yamlPath);
 
-	if (yamlExists && ymlExists) {
+	if (ymlExists && yamlExists) {
 		throw new Error(
 			`Both ${GLOBAL_MANIFEST} and ${GLOBAL_MANIFEST_ALT} exist in ${dir}. Keep only one — they're the same format under different extensions.`,
 		);
 	}
-	if (ymlExists && !yamlExists) {
-		return { path: ymlPath, filename: GLOBAL_MANIFEST_ALT };
+	if (yamlExists && !ymlExists) {
+		warnOnce(
+			"global-manifest-yaml-ext",
+			`${DEPRECATION_PREFIX} Found ${GLOBAL_MANIFEST_ALT} in ${dir} — \`.yml\` is now the default extension. Rename to ${GLOBAL_MANIFEST} when convenient; ${GLOBAL_MANIFEST_ALT} is still accepted.`,
+		);
+		return { path: yamlPath, filename: GLOBAL_MANIFEST_ALT };
 	}
-	return { path: yamlPath, filename: GLOBAL_MANIFEST };
+	return { path: ymlPath, filename: GLOBAL_MANIFEST };
 }
 
 /**

--- a/src/core/filenames.ts
+++ b/src/core/filenames.ts
@@ -97,14 +97,24 @@ export function resolveLockfilePath(dir: string): { path: string; filename: stri
 }
 
 /**
- * Check if a manifest exists (skilltree.yaml, skilltree.yml, or legacy skillkit.yaml).
+ * Return the filename of whichever manifest actually exists in `dir`, or
+ * null if none do. Unlike `resolveManifestPath`, this never emits a
+ * deprecation warning — use it from code paths that just need to report
+ * the on-disk name (e.g. the init "already exists" guard) without
+ * arming the warn-once gate.
+ */
+export function findExistingManifest(dir: string): string | null {
+	if (existsSync(`${dir}/${MANIFEST_NEW}`)) return MANIFEST_NEW;
+	if (existsSync(`${dir}/${MANIFEST_NEW_ALT}`)) return MANIFEST_NEW_ALT;
+	if (existsSync(`${dir}/${MANIFEST_LEGACY}`)) return MANIFEST_LEGACY;
+	return null;
+}
+
+/**
+ * Check if a manifest exists (skilltree.yml, skilltree.yaml, or legacy skillkit.yaml).
  */
 export function manifestExists(dir: string): boolean {
-	return (
-		existsSync(`${dir}/${MANIFEST_NEW}`) ||
-		existsSync(`${dir}/${MANIFEST_NEW_ALT}`) ||
-		existsSync(`${dir}/${MANIFEST_LEGACY}`)
-	);
+	return findExistingManifest(dir) !== null;
 }
 
 /**
@@ -157,9 +167,20 @@ export function resolveGlobalLockfilePath(globalDir?: string): {
 }
 
 /**
- * Check if a global manifest exists (.yaml or .yml).
+ * Return the filename of whichever global manifest actually exists in
+ * `globalDir`, or null if none do. Same warning-free semantics as
+ * `findExistingManifest`.
+ */
+export function findExistingGlobalManifest(globalDir?: string): string | null {
+	const dir = globalDir ?? getGlobalDir();
+	if (existsSync(`${dir}/${GLOBAL_MANIFEST}`)) return GLOBAL_MANIFEST;
+	if (existsSync(`${dir}/${GLOBAL_MANIFEST_ALT}`)) return GLOBAL_MANIFEST_ALT;
+	return null;
+}
+
+/**
+ * Check if a global manifest exists (.yml or legacy .yaml).
  */
 export function globalManifestExists(globalDir?: string): boolean {
-	const dir = globalDir ?? getGlobalDir();
-	return existsSync(`${dir}/${GLOBAL_MANIFEST}`) || existsSync(`${dir}/${GLOBAL_MANIFEST_ALT}`);
+	return findExistingGlobalManifest(globalDir) !== null;
 }

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -145,7 +145,7 @@ export function toGitCloneUrl(repo: string): string {
  * If the directory exists but is not a valid bare repo (e.g., empty dir
  * from a failed previous clone), it is removed and re-cloned. If the
  * cached repo's `origin` URL differs from `repoUrl` (user edited the
- * source in skilltree.yaml or config.yaml), the cache is invalidated
+ * source in skilltree.yml or config.yaml), the cache is invalidated
  * and re-cloned against the new URL — a plain fetch would silently
  * pull from the stale remote.
  */

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -160,7 +160,7 @@ async function resolveOneRepo(
 			await addTaglessRepoResolution(repo, cachePath, state);
 		} catch {
 			state.errors.push(
-				`Error: Git operation failed\n\n  Failed to fetch ${repo}\n  Underlying error: ${errMsg}\n\nFix: Check the repo URL in skilltree.yaml and your git access (SSH keys, GITHUB_TOKEN).`,
+				`Error: Git operation failed\n\n  Failed to fetch ${repo}\n  Underlying error: ${errMsg}\n\nFix: Check the repo URL in ${MANIFEST_NEW} and your git access (SSH keys, GITHUB_TOKEN).`,
 			);
 		}
 	}
@@ -347,7 +347,7 @@ async function resolveRemoteEntity(
 		const inferred = await inferDirectDepPath(entityName, dep.repo, resolution, state);
 		if (!inferred) {
 			state.errors.push(
-				`Error: "${entityName}" (from ${dep.repo}) has no path, and the resolver could not infer one from:\n       - origin's skilltree.yaml dependencies (${dep.repo})\n       - conventional paths in ${dep.repo}\n\n     Fix: add \`path:\` to your skilltree.yaml entry, or have origin declare "${entityName}" under \`dependencies:\` in its skilltree.yaml.`,
+				`Error: "${entityName}" (from ${dep.repo}) has no path, and the resolver could not infer one from:\n       - origin's ${MANIFEST_NEW} dependencies (${dep.repo})\n       - conventional paths in ${dep.repo}\n\n     Fix: add \`path:\` to your ${MANIFEST_NEW} entry, or have origin declare "${entityName}" under \`dependencies:\` in its ${MANIFEST_NEW}.`,
 			);
 			return;
 		}
@@ -481,10 +481,11 @@ async function tryResolveFromLocalSource(
 }
 
 /**
- * Read an origin manifest at a git ref, accepting either skilltree.yaml or
- * skilltree.yml. Throws if neither exists. Prefers .yaml when both are present
- * at the ref (the local resolver is the right place to flag the dual-extension
- * mistake — upstreams can't see this code path).
+ * Read an origin manifest at a git ref, accepting either skilltree.yml or
+ * skilltree.yaml. Throws if neither exists. Prefers .yml (the canonical
+ * extension) when both are present at the ref (the local resolver is the
+ * right place to flag the dual-extension mistake — upstreams can't see
+ * this code path).
  */
 async function readOriginManifestAtRef(cachePath: string, ref: string): Promise<string> {
 	try {
@@ -640,19 +641,19 @@ function formatPathWarning(
 	if (mismatch.kind === "redundant") {
 		return [
 			`Warning: \`${entityName}\` declares path "${consumerPath}", which is the`,
-			`  same path origin's skilltree.yaml declares for this name (${originRepo}).`,
+			`  same path origin's ${MANIFEST_NEW} declares for this name (${originRepo}).`,
 			`  You can omit \`path:\` — it will be inferred.`,
 		].join("\n");
 	}
 	return [
 		`Warning: \`${entityName}\` declares path "${consumerPath}", but origin's`,
-		`  skilltree.yaml declares this name at "${mismatch.originPath}" (${originRepo}).`,
+		`  ${MANIFEST_NEW} declares this name at "${mismatch.originPath}" (${originRepo}).`,
 		`  If this override is intentional, set \`force_path: true\` to silence this warning.`,
 	].join("\n");
 }
 
 /**
- * For every resolved remote repo, check whether origin's `skilltree.yaml` is
+ * For every resolved remote repo, check whether origin's `skilltree.yml` is
  * present at the resolved tag. If absent at the tag but present on the
  * default branch, emit a single warning — origin authored a manifest but
  * never cut a tag that contains it, so consumers lose R9/R10 signals they
@@ -680,24 +681,24 @@ async function checkStaleTagManifests(state: ResolutionState): Promise<void> {
 		try {
 			await readOriginManifestAtRef(resolution.cachePath, defaultBranch);
 		} catch {
-			// Not on default branch either — origin simply doesn't use skilltree.yaml.
+			// Not on default branch either — origin simply doesn't use skilltree.yml.
 			continue;
 		}
 
 		const tagLabel = resolution.tag ?? `commit ${resolution.commit.slice(0, 8)}`;
 		state.warnings.push(
 			[
-				`Warning: origin \`${repo}\` has a skilltree.yaml on \`${defaultBranch}\` but not at the`,
+				`Warning: origin \`${repo}\` has a ${MANIFEST_NEW} on \`${defaultBranch}\` but not at the`,
 				`  resolved tag (${tagLabel}). Consumers resolve to the tag, so origin's manifest`,
 				`  is invisible to them — R9 path inference and R10 path warnings are skipped.`,
-				`  Fix: cut a new tag from \`${defaultBranch}\` that includes skilltree.yaml.`,
+				`  Fix: cut a new tag from \`${defaultBranch}\` that includes ${MANIFEST_NEW}.`,
 			].join("\n"),
 		);
 	}
 }
 
 /**
- * Infer a direct dep's missing `path:` by consulting origin's skilltree.yaml,
+ * Infer a direct dep's missing `path:` by consulting origin's skilltree.yml,
  * then falling back to conventional paths. Returns the inferred entity path
  * (suitable for inferTypeFromGit), or null if nothing works. See R9.
  */
@@ -763,7 +764,7 @@ async function ensureRepoResolvedLazy(
 		if (!existing.version) return true;
 		if (semver.satisfies(existing.version, constraint)) return true;
 		state.errors.push(
-			`Error: Cross-repo transitive constraint conflict\n\n  Origin ${originRepo} declares ${repo} with constraint "${constraint}",\n  but ${repo} is already resolved to ${existing.version}${existing.tag ? ` (tag ${existing.tag})` : ""} from another chain.\n\nFix: Align constraints by declaring ${repo} explicitly in your skilltree.yaml.`,
+			`Error: Cross-repo transitive constraint conflict\n\n  Origin ${originRepo} declares ${repo} with constraint "${constraint}",\n  but ${repo} is already resolved to ${existing.version}${existing.tag ? ` (tag ${existing.tag})` : ""} from another chain.\n\nFix: Align constraints by declaring ${repo} explicitly in your ${MANIFEST_NEW}.`,
 		);
 		return false;
 	}
@@ -822,12 +823,12 @@ function addUnresolvedError(
 	const lines = [
 		`${parentName} (${parentSource}) declares dependency "${depName}",`,
 		`     not found in:`,
-		`       - your skilltree.yaml`,
+		`       - your ${MANIFEST_NEW}`,
 		`       - already-resolved dependencies`,
 	];
 
 	if (parentEntity?.repo) {
-		lines.push(`       - origin's skilltree.yaml dependencies (${parentEntity.repo})`);
+		lines.push(`       - origin's ${MANIFEST_NEW} dependencies (${parentEntity.repo})`);
 		lines.push(`       - conventional paths in ${parentEntity.repo}`);
 	} else {
 		lines.push(`       - local filesystem`);
@@ -840,7 +841,7 @@ function addUnresolvedError(
 		);
 		lines.push(`     dev-dependencies are not exposed to downstream consumers.`);
 		lines.push(
-			`     Fix: upstream should move it to \`dependencies\`, or declare ${depName} explicitly in your own skilltree.yaml.`,
+			`     Fix: upstream should move it to \`dependencies\`, or declare ${depName} explicitly in your own ${MANIFEST_NEW}.`,
 		);
 	} else {
 		lines.push("");

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -4,7 +4,7 @@ import YAML from "yaml";
 import type { Dependency, EntityType, LocalDependency, Manifest } from "../types.js";
 import { isSourceDependency } from "../types.js";
 import { resolveGlobalTarget, resolveTarget } from "./agents.js";
-import { resolveGlobalManifestPath, resolveManifestPath } from "./filenames.js";
+import { MANIFEST_NEW, resolveGlobalManifestPath, resolveManifestPath } from "./filenames.js";
 import { expandTilde, isLocalSource } from "./paths.js";
 import { error, warn } from "./ui.js";
 
@@ -204,7 +204,7 @@ export function validateManifest(manifest: Manifest): string[] {
 			}
 
 			// `path:` is optional for remote/source deps (R9). When missing, the
-			// resolver infers it from the origin repo's skilltree.yaml or the
+			// resolver infers it from the origin repo's skilltree.yml or the
 			// conventional probe. See origin_manifest_resolution.md §R9.
 		}
 	}
@@ -266,7 +266,7 @@ export async function loadManifestOrThrow(
 		throw new Error(
 			isGlobal
 				? "No global manifest found. Run `skilltree init --global` first."
-				: "No skilltree.yaml found. Run `skilltree init` first.",
+				: `No ${MANIFEST_NEW} found. Run \`skilltree init\` first.`,
 		);
 	}
 }

--- a/src/core/repo-scanner.ts
+++ b/src/core/repo-scanner.ts
@@ -8,7 +8,7 @@ import { SKIP_MD_FILES } from "./registry-scanner.js";
 /**
  * A discovered skill or agent in the local filesystem.
  * Mirrors IndexEntry's shape but `path` is always POSIX-style relative
- * to the scan root (so it can be written into skilltree.yaml as-is).
+ * to the scan root (so it can be written into skilltree.yml as-is).
  */
 export interface LocalEntry {
 	name: string;

--- a/tests/commands/add-registry.test.ts
+++ b/tests/commands/add-registry.test.ts
@@ -63,7 +63,7 @@ async function setupWithRegistry(dir: string): Promise<{ configPath: string; cac
 }
 
 async function readManifestRaw(dir: string): Promise<Manifest> {
-	const content = await readFile(join(dir, "skilltree.yaml"), "utf-8");
+	const content = await readFile(join(dir, "skilltree.yml"), "utf-8");
 	return YAML.parse(content) as Manifest;
 }
 

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { addCommand } from "../../src/commands/add.js";
 import { initCommand } from "../../src/commands/init.js";
+import { _resetDeprecationWarningsForTests } from "../../src/core/filenames.js";
 import { readManifest } from "../../src/core/manifest.js";
 
 let tempDir: string;
@@ -41,7 +43,7 @@ describe("addCommand", () => {
 		const dir = await setup();
 		// Write a manifest with sources
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\nsources:\n  vibes: github.com/company/vibes\ndependencies: {}\ndev-dependencies: {}\n",
 		);
 
@@ -144,7 +146,7 @@ describe("addCommand", () => {
 		// change on re-add; orthogonal metadata survives because the CLI has
 		// no way to explicitly set them.
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			[
 				"name: test",
 				"dependencies:",
@@ -185,7 +187,7 @@ describe("addCommand", () => {
 		// Seed manifest with an entry that has force_path: true,
 		// plus sibling state we expect to survive the overwrite.
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			[
 				"name: test",
 				"sources:",
@@ -231,7 +233,7 @@ describe("addCommand", () => {
 		// Seed manifest with an existing entry `foo: {local: ~/skills-root/foo}`,
 		// plus a sources: map where `mine: ~/skills-root` resolves to the same place.
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			[
 				"name: test",
 				"sources:",
@@ -271,7 +273,7 @@ describe("addCommand", () => {
 		// Seed manifest with a remote entry via `repo:` and a `sources:` map
 		// where the alias resolves to the same URL.
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			[
 				"name: test",
 				"sources:",
@@ -300,7 +302,7 @@ describe("addCommand", () => {
 	test("R13: adds source-aliased dependency without --path", async () => {
 		const dir = await setup();
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\nsources:\n  vibes: github.com/company/vibes\ndependencies: {}\ndev-dependencies: {}\n",
 		);
 
@@ -473,5 +475,57 @@ describe("addCommand", () => {
 
 		const joined = logs.join("\n");
 		expect(joined).toContain("skilltree install --global");
+	});
+});
+
+// Backward-compat: existing projects still on .yaml continue to work without
+// the migration silently splitting their state across two files.
+describe("addCommand on a legacy .yaml manifest", () => {
+	let yamlDir: string;
+
+	beforeEach(async () => {
+		_resetDeprecationWarningsForTests();
+		yamlDir = await mkdtemp(join(tmpdir(), "skilltree-add-yaml-"));
+		await writeFile(
+			join(yamlDir, "skilltree.yaml"),
+			"name: legacy\ninstall_targets: [claude]\ndependencies: {}\ndev-dependencies: {}\n",
+		);
+	});
+
+	afterEach(async () => {
+		if (yamlDir) await rm(yamlDir, { recursive: true, force: true });
+	});
+
+	test("writes back to skilltree.yaml without creating a sibling skilltree.yml", async () => {
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+		try {
+			await addCommand(
+				"task-builder",
+				{ repo: "github.com/company/skills", path: "skills/task-builder", version: "^2.0.0" },
+				yamlDir,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		expect(existsSync(join(yamlDir, "skilltree.yaml"))).toBe(true);
+		expect(existsSync(join(yamlDir, "skilltree.yml"))).toBe(false);
+
+		const content = await readFile(join(yamlDir, "skilltree.yaml"), "utf-8");
+		expect(content).toContain("task-builder");
+
+		const manifest = await readManifest(yamlDir);
+		expect(manifest.dependencies?.["task-builder"]).toEqual({
+			repo: "github.com/company/skills",
+			path: "skills/task-builder",
+			version: "^2.0.0",
+		});
+
+		// Deprecation warning surfaces so the user knows they're on the old extension.
+		expect(warnings.some((w) => /skilltree\.yml/i.test(w) && /default extension/i.test(w))).toBe(
+			true,
+		);
 	});
 });

--- a/tests/commands/deps-tree.test.ts
+++ b/tests/commands/deps-tree.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 });
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 async function makeBareClone(repoDir: string, baseDir: string, name: string): Promise<string> {

--- a/tests/commands/dual-install.test.ts
+++ b/tests/commands/dual-install.test.ts
@@ -31,7 +31,7 @@ async function createLocalSkill(dir: string, name: string): Promise<void> {
 }
 
 async function writeManifestRaw(dir: string, manifest: Manifest): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), serializeManifest(manifest), "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), serializeManifest(manifest), "utf-8");
 }
 
 // --- Backward compatibility ---
@@ -56,7 +56,7 @@ describe("install_path backward compat", () => {
 		await createLocalSkill(dir, "my-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndev_install_path: .custom-dev\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 
@@ -74,7 +74,7 @@ describe("src_install_path dual install", () => {
 		await createLocalSkill(dir, "prod-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndev_install_path: .claude\nsrc_install_path: src\ndependencies:\n  prod-skill:\n    local: ./skills/prod-skill\n",
 		);
 
@@ -91,7 +91,7 @@ describe("src_install_path dual install", () => {
 		await createLocalSkill(dir, "prod-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndev_install_path: .claude\nsrc_install_path: src\ndependencies:\n  prod-skill:\n    local: ./skills/prod-skill\ndev-dependencies:\n  dev-skill:\n    local: ./skills/dev-skill\n",
 		);
 
@@ -112,7 +112,7 @@ describe("src_install_path dual install", () => {
 		await createLocalSkill(dir, "dev-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndev_install_path: .claude\nsrc_install_path: src\ndependencies:\n  prod-skill:\n    local: ./skills/prod-skill\ndev-dependencies:\n  dev-skill:\n    local: ./skills/dev-skill\n",
 		);
 
@@ -132,7 +132,7 @@ describe("src_install_path dual install", () => {
 		await createLocalSkill(dir, "my-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 
@@ -148,7 +148,7 @@ describe("src_install_path dual install", () => {
 		await createLocalSkill(dir, "my-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndev_install_path: .claude\nsrc_install_path: src\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -20,14 +20,14 @@ afterEach(async () => {
 });
 
 describe("initCommand", () => {
-	test("creates skilltree.yaml with project name from directory", async () => {
+	test("creates skilltree.yml with project name from directory", async () => {
 		const dir = await makeTempDir();
 		// Create a fake home with no agents — should default to claude
 		const fakeHome = join(dir, "empty-home");
 		await mkdir(fakeHome, { recursive: true });
 		await initCommand(dir, { homeDir: fakeHome });
 
-		const content = await readFile(join(dir, "skilltree.yaml"), "utf-8");
+		const content = await readFile(join(dir, "skilltree.yml"), "utf-8");
 		expect(content).toContain("name:");
 		expect(content).toContain("install_targets");
 		expect(content).toContain("claude");
@@ -59,7 +59,7 @@ describe("initCommand", () => {
 		expect(content).toContain(".claude/agents/");
 	});
 
-	test("refuses to overwrite existing skilltree.yaml", async () => {
+	test("refuses to overwrite existing skilltree.yml", async () => {
 		const dir = await makeTempDir();
 		const fakeHome = join(dir, "empty-home");
 		await mkdir(fakeHome, { recursive: true });
@@ -216,22 +216,22 @@ describe("initCommand", () => {
 	});
 
 	describe("--global", () => {
-		test("creates a new global.yaml when none exists", async () => {
+		test("creates a new global.yml when none exists", async () => {
 			const dir = await makeTempDir();
 			const globalDir = join(dir, "global-home");
 
 			await initCommand(dir, { global: true, globalDir });
 
-			const content = await readFile(join(globalDir, "global.yaml"), "utf-8");
+			const content = await readFile(join(globalDir, "global.yml"), "utf-8");
 			expect(content).toContain("dependencies");
 		});
 
-		test("warns and leaves the file untouched when global.yaml already exists", async () => {
+		test("warns and leaves the file untouched when global.yml already exists", async () => {
 			const dir = await makeTempDir();
 			const globalDir = join(dir, "global-home");
 			await mkdir(globalDir, { recursive: true });
 			const existing = "dependencies:\n  preexisting:\n    local: ./x\n";
-			await writeFile(join(globalDir, "global.yaml"), existing);
+			await writeFile(join(globalDir, "global.yml"), existing);
 
 			const warnings: string[] = [];
 			const originalWarn = console.warn;
@@ -244,7 +244,7 @@ describe("initCommand", () => {
 
 			expect(warnings.some((w) => w.includes("already exists"))).toBe(true);
 			// File must be byte-for-byte unchanged — no clobber of the user's deps.
-			const after = await readFile(join(globalDir, "global.yaml"), "utf-8");
+			const after = await readFile(join(globalDir, "global.yml"), "utf-8");
 			expect(after).toBe(existing);
 		});
 	});

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -67,6 +67,25 @@ describe("initCommand", () => {
 		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow("already exists");
 	});
 
+	test("error message names the actual existing file (.yaml, not .yml)", async () => {
+		// Regression: init used to hardcode MANIFEST_NEW in the "already exists"
+		// error, so a project on the legacy .yaml extension got told `.yml`
+		// already existed when in fact `.yaml` did.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+		await writeFile(join(dir, "skilltree.yaml"), "name: legacy\ndependencies: {}\n");
+		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(/skilltree\.yaml/);
+	});
+
+	test("error message names skillkit.yaml when only the older legacy manifest exists", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+		await writeFile(join(dir, "skillkit.yaml"), "name: ancient\ndependencies: {}\n");
+		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(/skillkit\.yaml/);
+	});
+
 	test("--scan with --yes registers discovered skills and agents as local deps", async () => {
 		const dir = await makeTempDir();
 		const fakeHome = join(dir, "empty-home");
@@ -224,6 +243,28 @@ describe("initCommand", () => {
 
 			const content = await readFile(join(globalDir, "global.yml"), "utf-8");
 			expect(content).toContain("dependencies");
+		});
+
+		test("warning names the actual existing global file (.yaml, not .yml)", async () => {
+			// Same regression as project init: --global used to hardcode
+			// GLOBAL_MANIFEST in the message regardless of which file existed.
+			const dir = await makeTempDir();
+			const globalDir = join(dir, "global-home");
+			await mkdir(globalDir, { recursive: true });
+			await writeFile(join(globalDir, "global.yaml"), "dependencies: {}\n");
+
+			const warnings: string[] = [];
+			const originalWarn = console.warn;
+			console.warn = (msg: string) => warnings.push(msg);
+			try {
+				await initCommand(dir, { global: true, globalDir });
+			} finally {
+				console.warn = originalWarn;
+			}
+
+			expect(warnings.some((w) => w.includes("global.yaml") && w.includes("already exists"))).toBe(
+				true,
+			);
 		});
 
 		test("warns and leaves the file untouched when global.yml already exists", async () => {

--- a/tests/commands/install-lockfile.test.ts
+++ b/tests/commands/install-lockfile.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 });
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 async function writeLockfile(dir: string, content: string): Promise<void> {

--- a/tests/commands/list-extended.test.ts
+++ b/tests/commands/list-extended.test.ts
@@ -40,7 +40,7 @@ packages:
 describe("listCommand extended", () => {
 	test("--json outputs JSON array", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await writeFile(join(tempDir, "skilltree.yaml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
 		await writeFile(join(tempDir, "skilltree.lock"), LOCKFILE_WITH_DEPS);
 
 		const { logs, restore } = captureConsole();
@@ -58,7 +58,7 @@ describe("listCommand extended", () => {
 
 	test("--json with empty lockfile outputs empty array", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await writeFile(join(tempDir, "skilltree.yaml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
 
 		const { logs, restore } = captureConsole();
 		try {
@@ -105,7 +105,7 @@ describe("listCommand extended", () => {
 
 	test("project list shows Group column", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await writeFile(join(tempDir, "skilltree.yaml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
 		await writeFile(join(tempDir, "skilltree.lock"), LOCKFILE_WITH_DEPS);
 
 		const { logs, restore } = captureConsole();
@@ -119,7 +119,7 @@ describe("listCommand extended", () => {
 
 	test("shows remote dep version and source", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await writeFile(join(tempDir, "skilltree.yaml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
 		await writeFile(
 			join(tempDir, "skilltree.lock"),
 			"lockfile_version: 1\npackages:\n  remote-skill:\n    type: skill\n    group: prod\n    repo: github.com/org/skills\n    path: skills/remote-skill\n    version: 2.1.3\n    commit: abc123\n    integrity: sha256-xyz\n    dependencies: []\n",

--- a/tests/commands/list.test.ts
+++ b/tests/commands/list.test.ts
@@ -13,14 +13,14 @@ afterEach(async () => {
 });
 
 describe("listCommand", () => {
-	test("throws when no skilltree.yaml exists", async () => {
+	test("throws when no skilltree.yml exists", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await expect(listCommand(tempDir)).rejects.toThrow("No skilltree.yaml");
+		await expect(listCommand(tempDir)).rejects.toThrow("No skilltree.yml");
 	});
 
 	test("shows empty message when manifest exists but no lockfile", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await writeFile(join(tempDir, "skilltree.yaml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
 
 		const logs: string[] = [];
 		const originalLog = console.log;
@@ -35,7 +35,7 @@ describe("listCommand", () => {
 
 	test("lists installed dependencies from lockfile", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
-		await writeFile(join(tempDir, "skilltree.yaml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
 		await writeFile(
 			join(tempDir, "skilltree.lock"),
 			"lockfile_version: 1\npackages:\n  my-skill:\n    type: skill\n    group: prod\n    source: local\n    path: ./skills/my-skill\n    commit: HEAD\n    dependencies: []\n",

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -37,7 +37,7 @@ describe("removeCommand", () => {
 		const dir = await setup();
 
 		await expect(removeCommand("nonexistent", dir, { force: true })).rejects.toThrow(
-			"not in skilltree.yaml",
+			"not in skilltree.yml",
 		);
 	});
 

--- a/tests/commands/search-roundtrip.test.ts
+++ b/tests/commands/search-roundtrip.test.ts
@@ -53,9 +53,9 @@ async function setupRegistry(
 	};
 	await writeRegistryIndex(index, cacheDir);
 
-	// Create a minimal skilltree.yaml in the project dir
+	// Create a minimal skilltree.yml in the project dir
 	const { writeFile } = await import("node:fs/promises");
-	await writeFile(join(projectDir, "skilltree.yaml"), "dependencies: {}\n");
+	await writeFile(join(projectDir, "skilltree.yml"), "dependencies: {}\n");
 
 	return { configPath, cacheDir, projectDir };
 }
@@ -128,7 +128,7 @@ async function executeAndVerify(
 		projectDir,
 	);
 
-	const manifest = parse(await readFile(join(projectDir, "skilltree.yaml"), "utf-8"));
+	const manifest = parse(await readFile(join(projectDir, "skilltree.yml"), "utf-8"));
 	const dep = manifest.dependencies[cmd.name];
 	expect(dep).toBeDefined();
 	expect(dep.repo).toBe(cmd.repo);
@@ -254,7 +254,7 @@ describe("info suggestion roundtrip", () => {
 		await mkdir(projectDir, { recursive: true });
 
 		const { writeFile } = await import("node:fs/promises");
-		await writeFile(join(projectDir, "skilltree.yaml"), "dependencies: {}\n");
+		await writeFile(join(projectDir, "skilltree.yml"), "dependencies: {}\n");
 
 		await writeConfig(
 			{
@@ -300,7 +300,7 @@ describe("info suggestion roundtrip", () => {
 		for (let i = 0; i < cmds.length; i++) {
 			const subProject = join(dir, `project-${i}`);
 			await mkdir(subProject, { recursive: true });
-			await writeFile(join(subProject, "skilltree.yaml"), "dependencies: {}\n");
+			await writeFile(join(subProject, "skilltree.yml"), "dependencies: {}\n");
 			await executeAndVerify(cmds[i] as AddCmd, subProject, configPath, cacheDir);
 		}
 	});

--- a/tests/commands/targets.test.ts
+++ b/tests/commands/targets.test.ts
@@ -18,7 +18,7 @@ async function makeTempDir(): Promise<string> {
 }
 
 async function writeManifestFile(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 afterEach(async () => {

--- a/tests/commands/update-extended.test.ts
+++ b/tests/commands/update-extended.test.ts
@@ -25,7 +25,7 @@ describe("updateCommand extended", () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await installCommand(dir, {});
@@ -43,19 +43,19 @@ describe("updateCommand extended", () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await installCommand(dir, {});
 
-		await expect(updateCommand(dir, "nonexistent", {})).rejects.toThrow("not in skilltree.yaml");
+		await expect(updateCommand(dir, "nonexistent", {})).rejects.toThrow("not in skilltree.yml");
 	});
 
 	test("selective update on local dep re-reads from filesystem", async () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await installCommand(dir, {});
@@ -78,7 +78,7 @@ describe("updateCommand extended", () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 

--- a/tests/commands/ux-fixes.test.ts
+++ b/tests/commands/ux-fixes.test.ts
@@ -31,13 +31,13 @@ afterEach(async () => {
 	}
 });
 
-// --- Fix #1: init should not overwrite existing skilltree.yaml ---
+// --- Fix #1: init should not overwrite existing skilltree.yml ---
 describe("Fix #1: init overwrite guard", () => {
-	test("init refuses to overwrite existing skilltree.yaml", async () => {
+	test("init refuses to overwrite existing skilltree.yml", async () => {
 		const dir = await setup();
 		await initCommand(dir);
 		// Add a dependency manually
-		const manifestPath = join(dir, "skilltree.yaml");
+		const manifestPath = join(dir, "skilltree.yml");
 		const content = await readFile(manifestPath, "utf-8");
 		await writeFile(
 			manifestPath,

--- a/tests/commands/verify.test.ts
+++ b/tests/commands/verify.test.ts
@@ -37,12 +37,12 @@ function captureConsole(): { logs: string[]; restore: () => void } {
 describe("verifyCommand", () => {
 	test("throws when no manifest exists", async () => {
 		const dir = await makeTempDir();
-		await expect(verifyCommand(dir)).rejects.toThrow("No skilltree.yaml");
+		await expect(verifyCommand(dir)).rejects.toThrow("No skilltree.yml");
 	});
 
 	test("throws when no lockfile exists", async () => {
 		const dir = await makeTempDir();
-		await writeFile(join(dir, "skilltree.yaml"), "dependencies: {}\n");
+		await writeFile(join(dir, "skilltree.yml"), "dependencies: {}\n");
 		await expect(verifyCommand(dir)).rejects.toThrow("No lockfile");
 	});
 
@@ -50,7 +50,7 @@ describe("verifyCommand", () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await installCommand(dir, {});
@@ -68,7 +68,7 @@ describe("verifyCommand", () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 
@@ -86,7 +86,7 @@ describe("verifyCommand", () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await installCommand(dir, {});
@@ -109,7 +109,7 @@ describe("verifyCommand", () => {
 		await createLocalSkill(join(dir, "skills"), "skill-a");
 		await createLocalSkill(join(dir, "skills"), "skill-b");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"dependencies:\n  skill-a:\n    local: ./skills/skill-a\n  skill-b:\n    local: ./skills/skill-b\n",
 		);
 		await installCommand(dir, {});

--- a/tests/core/filenames.test.ts
+++ b/tests/core/filenames.test.ts
@@ -1,12 +1,15 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	_resetDeprecationWarningsForTests,
 	GLOBAL_MANIFEST,
+	GLOBAL_MANIFEST_ALT,
 	globalManifestExists,
 	MANIFEST_LEGACY,
 	MANIFEST_NEW,
+	MANIFEST_NEW_ALT,
 	manifestExists,
 	resolveGlobalManifestPath,
 	resolveManifestPath,
@@ -21,27 +24,84 @@ afterEach(async () => {
 	}
 });
 
+beforeEach(() => {
+	_resetDeprecationWarningsForTests();
+});
+
 async function makeTmp(): Promise<string> {
 	const dir = await mkdtemp(join(tmpdir(), "skilltree-filenames-"));
 	cleanups.push(dir);
 	return dir;
 }
 
+function captureWarnings(fn: () => void): string[] {
+	const warnings: string[] = [];
+	const original = console.warn;
+	console.warn = (msg: string) => {
+		warnings.push(msg);
+	};
+	try {
+		fn();
+	} finally {
+		console.warn = original;
+	}
+	return warnings;
+}
+
+describe("default manifest extension", () => {
+	test("MANIFEST_NEW is skilltree.yml (.yml is canonical)", () => {
+		expect(MANIFEST_NEW).toBe("skilltree.yml");
+	});
+
+	test("MANIFEST_NEW_ALT is skilltree.yaml (deprecated default)", () => {
+		expect(MANIFEST_NEW_ALT).toBe("skilltree.yaml");
+	});
+
+	test("GLOBAL_MANIFEST is global.yml (.yml is canonical)", () => {
+		expect(GLOBAL_MANIFEST).toBe("global.yml");
+	});
+
+	test("GLOBAL_MANIFEST_ALT is global.yaml (deprecated default)", () => {
+		expect(GLOBAL_MANIFEST_ALT).toBe("global.yaml");
+	});
+});
+
 describe("resolveManifestPath — .yaml / .yml support", () => {
 	test("returns skilltree.yaml when only .yaml exists", async () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "skilltree.yaml"), "");
-		const { path, filename } = resolveManifestPath(dir);
-		expect(filename).toBe("skilltree.yaml");
-		expect(path).toBe(join(dir, "skilltree.yaml"));
+		const warnings = captureWarnings(() => {
+			const { path, filename } = resolveManifestPath(dir);
+			expect(filename).toBe("skilltree.yaml");
+			expect(path).toBe(join(dir, "skilltree.yaml"));
+		});
+		// Side-effect: emits a deprecation warning steering users toward .yml
+		expect(warnings.some((w) => /\.yml.*default|skilltree\.yml/i.test(w))).toBe(true);
 	});
 
 	test("returns skilltree.yml when only .yml exists", async () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "skilltree.yml"), "");
-		const { path, filename } = resolveManifestPath(dir);
-		expect(filename).toBe("skilltree.yml");
-		expect(path).toBe(join(dir, "skilltree.yml"));
+		const warnings = captureWarnings(() => {
+			const { path, filename } = resolveManifestPath(dir);
+			expect(filename).toBe("skilltree.yml");
+			expect(path).toBe(join(dir, "skilltree.yml"));
+		});
+		// .yml is the new canonical default — no warning expected.
+		expect(warnings).toEqual([]);
+	});
+
+	test("emits deprecation warning at most once per process for .yaml", async () => {
+		const dirA = await makeTmp();
+		const dirB = await makeTmp();
+		await writeFile(join(dirA, "skilltree.yaml"), "");
+		await writeFile(join(dirB, "skilltree.yaml"), "");
+		const warnings = captureWarnings(() => {
+			resolveManifestPath(dirA);
+			resolveManifestPath(dirB);
+		});
+		const yamlWarnings = warnings.filter((w) => /skilltree\.yml/i.test(w));
+		expect(yamlWarnings.length).toBe(1);
 	});
 
 	test("throws when both skilltree.yaml and skilltree.yml exist", async () => {
@@ -69,16 +129,18 @@ describe("resolveManifestPath — .yaml / .yml support", () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "skilltree.yaml"), "");
 		await writeFile(join(dir, "skillkit.yaml"), "");
-		const { filename } = resolveManifestPath(dir);
-		expect(filename).toBe(MANIFEST_NEW);
+		captureWarnings(() => {
+			const { filename } = resolveManifestPath(dir);
+			expect(filename).toBe("skilltree.yaml");
+		});
 	});
 
-	test("prefers skilltree.yml over legacy skillkit.yaml when only .yml + legacy exist", async () => {
+	test("prefers skilltree.yml over legacy skillkit.yaml when both exist", async () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "skilltree.yml"), "");
 		await writeFile(join(dir, "skillkit.yaml"), "");
 		const { filename } = resolveManifestPath(dir);
-		expect(filename).toBe("skilltree.yml");
+		expect(filename).toBe(MANIFEST_NEW);
 	});
 });
 
@@ -108,18 +170,24 @@ describe("manifestExists — .yaml / .yml support", () => {
 });
 
 describe("resolveGlobalManifestPath — .yaml / .yml support", () => {
-	test("returns global.yaml when only .yaml exists", async () => {
+	test("returns global.yaml when only .yaml exists, and warns", async () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "global.yaml"), "");
-		const { filename } = resolveGlobalManifestPath(dir);
-		expect(filename).toBe("global.yaml");
+		const warnings = captureWarnings(() => {
+			const { filename } = resolveGlobalManifestPath(dir);
+			expect(filename).toBe("global.yaml");
+		});
+		expect(warnings.some((w) => /global\.yml/i.test(w))).toBe(true);
 	});
 
-	test("returns global.yml when only .yml exists", async () => {
+	test("returns global.yml when only .yml exists, no warning", async () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "global.yml"), "");
-		const { filename } = resolveGlobalManifestPath(dir);
-		expect(filename).toBe("global.yml");
+		const warnings = captureWarnings(() => {
+			const { filename } = resolveGlobalManifestPath(dir);
+			expect(filename).toBe("global.yml");
+		});
+		expect(warnings).toEqual([]);
 	});
 
 	test("throws when both global.yaml and global.yml exist", async () => {
@@ -153,5 +221,75 @@ describe("globalManifestExists — .yaml / .yml support", () => {
 	test("false when none exist", async () => {
 		const dir = await makeTmp();
 		expect(globalManifestExists(dir)).toBe(false);
+	});
+});
+
+// The warn-once gate is keyed per deprecation category so silencing one
+// (e.g. project .yaml) doesn't silence unrelated deprecations the user
+// actually needs to see. Regression guard for the Set-based warnOnce helper.
+describe("warnOnce gate is independent across deprecation categories", () => {
+	test("project .yaml warning does not suppress legacy skillkit.yaml warning", async () => {
+		const dirA = await makeTmp();
+		const dirB = await makeTmp();
+		await writeFile(join(dirA, "skilltree.yaml"), "");
+		await writeFile(join(dirB, "skillkit.yaml"), "");
+
+		const warnings = captureWarnings(() => {
+			resolveManifestPath(dirA); // emits .yaml deprecation
+			resolveManifestPath(dirB); // emits skillkit.yaml deprecation
+		});
+
+		expect(warnings.some((w) => /skilltree\.yml/i.test(w) && !/skillkit/i.test(w))).toBe(true);
+		expect(warnings.some((w) => /skillkit\.yaml/i.test(w))).toBe(true);
+	});
+
+	test("project .yaml warning does not suppress global .yaml warning", async () => {
+		const projectDir = await makeTmp();
+		const globalDir = await makeTmp();
+		await writeFile(join(projectDir, "skilltree.yaml"), "");
+		await writeFile(join(globalDir, "global.yaml"), "");
+
+		const warnings = captureWarnings(() => {
+			resolveManifestPath(projectDir);
+			resolveGlobalManifestPath(globalDir);
+		});
+
+		expect(warnings.some((w) => /skilltree\.yml/i.test(w))).toBe(true);
+		expect(warnings.some((w) => /global\.yml/i.test(w))).toBe(true);
+	});
+
+	test("_resetDeprecationWarningsForTests clears every category, not just one", async () => {
+		const projectDir = await makeTmp();
+		const legacyDir = await makeTmp();
+		const globalDir = await makeTmp();
+		await writeFile(join(projectDir, "skilltree.yaml"), "");
+		await writeFile(join(legacyDir, "skillkit.yaml"), "");
+		await writeFile(join(globalDir, "global.yaml"), "");
+
+		// First pass arms all three gates.
+		captureWarnings(() => {
+			resolveManifestPath(projectDir);
+			resolveManifestPath(legacyDir);
+			resolveGlobalManifestPath(globalDir);
+		});
+
+		// Second pass without reset is silent — confirms the gates are armed.
+		const silent = captureWarnings(() => {
+			resolveManifestPath(projectDir);
+			resolveManifestPath(legacyDir);
+			resolveGlobalManifestPath(globalDir);
+		});
+		expect(silent).toEqual([]);
+
+		// Reset, then re-trigger — every category must warn again.
+		_resetDeprecationWarningsForTests();
+		const after = captureWarnings(() => {
+			resolveManifestPath(projectDir);
+			resolveManifestPath(legacyDir);
+			resolveGlobalManifestPath(globalDir);
+		});
+		expect(after.some((w) => /skilltree\.yml/i.test(w) && !/skillkit/i.test(w))).toBe(true);
+		expect(after.some((w) => /skillkit\.yaml/i.test(w))).toBe(true);
+		expect(after.some((w) => /global\.yml/i.test(w))).toBe(true);
 	});
 });

--- a/tests/e2e/edge-cases-e2e.test.ts
+++ b/tests/e2e/edge-cases-e2e.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 });
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 async function makeBareClone(repoDir: string, baseDir: string, name: string): Promise<string> {

--- a/tests/e2e/frozen-e2e.test.ts
+++ b/tests/e2e/frozen-e2e.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 });
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 describe("frozen mode edge cases", () => {

--- a/tests/e2e/install-e2e.test.ts
+++ b/tests/e2e/install-e2e.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 });
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 /**

--- a/tests/e2e/lifecycle-e2e.test.ts
+++ b/tests/e2e/lifecycle-e2e.test.ts
@@ -38,8 +38,8 @@ describe("e2e lifecycle: init → add → install → verify → update → remo
 		// ── STEP 1: init ──
 		await initCommand(dir);
 
-		// Verify skilltree.yaml created
-		const manifest = await readFile(join(dir, "skilltree.yaml"), "utf-8");
+		// Verify skilltree.yml created
+		const manifest = await readFile(join(dir, "skilltree.yml"), "utf-8");
 		expect(manifest).toContain("dependencies:");
 		expect(manifest).toContain("dev-dependencies:");
 
@@ -85,7 +85,7 @@ describe("e2e lifecycle: init → add → install → verify → update → remo
 		);
 
 		// Verify manifest has entries
-		const manifestAfterAdd = await readFile(join(dir, "skilltree.yaml"), "utf-8");
+		const manifestAfterAdd = await readFile(join(dir, "skilltree.yml"), "utf-8");
 		expect(manifestAfterAdd).toContain("top-skill");
 		expect(manifestAfterAdd).toContain("local-skill");
 
@@ -139,7 +139,7 @@ describe("e2e lifecycle: init → add → install → verify → update → remo
 		await removeCommand("local-skill", dir, { force: true });
 
 		// Verify removed from manifest
-		const manifestAfterRemove = await readFile(join(dir, "skilltree.yaml"), "utf-8");
+		const manifestAfterRemove = await readFile(join(dir, "skilltree.yml"), "utf-8");
 		expect(manifestAfterRemove).not.toContain("local-skill");
 
 		// Verify removed from lockfile

--- a/tests/e2e/multi-target-e2e.test.ts
+++ b/tests/e2e/multi-target-e2e.test.ts
@@ -15,7 +15,7 @@ async function makeTempDir(): Promise<string> {
 }
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 afterEach(async () => {

--- a/tests/e2e/update-e2e.test.ts
+++ b/tests/e2e/update-e2e.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 });
 
 async function writeManifest(dir: string, content: string): Promise<void> {
-	await writeFile(join(dir, "skilltree.yaml"), content, "utf-8");
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
 }
 
 async function makeBareClone(repoDir: string, baseDir: string, name: string): Promise<string> {
@@ -211,7 +211,7 @@ describe("e2e update: non-existent dep", () => {
 		await installCommand(dir, {});
 
 		await expect(updateCommand(dir, "nonexistent")).rejects.toThrow(
-			'"nonexistent" is not in skilltree.yaml',
+			'"nonexistent" is not in skilltree.yml',
 		);
 	});
 });

--- a/tests/e2e/vendor-e2e.test.ts
+++ b/tests/e2e/vendor-e2e.test.ts
@@ -22,9 +22,9 @@ afterEach(async () => {
 });
 
 async function setupProject(dir: string): Promise<void> {
-	// Create skilltree.yaml
+	// Create skilltree.yml
 	await writeFile(
-		join(dir, "skilltree.yaml"),
+		join(dir, "skilltree.yml"),
 		`name: test-project
 dev_install_path: .claude
 dependencies:
@@ -268,7 +268,7 @@ describe("vendor e2e", () => {
 		await writeFile(join(agentDir, "my-agent.md"), "---\nname: my-agent\n---\n\n# My Agent\n");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			`name: test-project
 dev_install_path: .claude
 dependencies:
@@ -309,7 +309,7 @@ dependencies:
 		);
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			`name: test-project
 dev_install_path: .claude
 dependencies:
@@ -352,7 +352,7 @@ dependencies:
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"install_targets:\n  - claude\n  - codex\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
@@ -364,7 +364,7 @@ dependencies:
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"install_targets:\n  - claude\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
 		);
 		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");

--- a/tests/e2e/vendor-unhappy-e2e.test.ts
+++ b/tests/e2e/vendor-unhappy-e2e.test.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 
 async function setupProject(dir: string): Promise<void> {
 	await writeFile(
-		join(dir, "skilltree.yaml"),
+		join(dir, "skilltree.yml"),
 		`name: test-project
 dev_install_path: .claude
 dependencies:
@@ -111,7 +111,7 @@ describe("vendor with dev-dependencies includes them", () => {
 		await createLocalSkill(join(dir, "skills"), "dev-skill");
 
 		await writeFile(
-			join(dir, "skilltree.yaml"),
+			join(dir, "skilltree.yml"),
 			"name: test\ndependencies:\n  prod-skill:\n    local: ./skills/prod-skill\ndev-dependencies:\n  dev-skill:\n    local: ./skills/dev-skill\n",
 		);
 		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");

--- a/tests/helpers/git-fixtures.ts
+++ b/tests/helpers/git-fixtures.ts
@@ -55,7 +55,7 @@ export async function createTestRepo(
 	}
 
 	if (manifestYaml !== undefined) {
-		await writeFile(join(repoDir, "skilltree.yaml"), manifestYaml);
+		await writeFile(join(repoDir, "skilltree.yml"), manifestYaml);
 	}
 
 	await git.add(".");


### PR DESCRIPTION
## Summary

- Flips `MANIFEST_NEW` / `GLOBAL_MANIFEST` so `skilltree init` writes `skilltree.yml` and `skilltree init --global` writes `global.yml`.
- `.yaml` is still accepted on read with a one-shot `[DEPRECATION]` warning — existing projects keep working with zero migration.
- User-facing strings across `src/commands/*` and `src/core/*` now reference the `MANIFEST_NEW` / `GLOBAL_MANIFEST` constants instead of hardcoded literals, so the extension lives in one place.
- Internals: collapses four parallel warn-once booleans into one `Set<string>` keyed by deprecation kind, via a `warnOnce(key, message)` helper. `_resetDeprecationWarningsForTests()` is now a single `clear()` that resets every category.

Closes #9.

## Behavior

- `skilltree init` → writes `skilltree.yml` (was `skilltree.yaml`)
- `skilltree init --global` → writes `~/.skilltree/global.yml` (was `global.yaml`)
- Running any command on an existing `.yaml` project still works, with one deprecation warning per process:

  ```
  [DEPRECATION] Found skilltree.yaml — `.yml` is now the default extension. Rename to skilltree.yml when convenient; skilltree.yaml is still accepted.
  ```

- Both extensions present (`skilltree.yml` AND `skilltree.yaml`) still throws — refuses to guess which one is canonical. Same for global.

## Test plan

- [x] `MANIFEST_NEW === "skilltree.yml"`, `GLOBAL_MANIFEST === "global.yml"` regression guards
- [x] `.yaml` resolution emits deprecation warning; `.yml` does not
- [x] Warning fires at most once per process
- [x] Warn-once gates are independent across deprecation categories (`.yaml` vs `skillkit.yaml` vs `global.yaml`) — silencing one doesn't silence the others
- [x] `_resetDeprecationWarningsForTests` clears every gate, not just one
- [x] Backward-compat: `addCommand` against an existing `skilltree.yaml` writes back to `.yaml` without spawning a sibling `.yml` file, and surfaces the deprecation warning
- [x] `bun run typecheck` clean
- [x] `bun test` → 797 pass / 0 fail (was 793 before the +4 new tests)
- [x] Manual smoke test: `init` produces `.yml`; `install`/`verify`/etc. on a `.yaml` project prints the deprecation warning once

## Follow-ups (not in this PR — deferred per the discussion in #9)

- README, `docs/specs/{spec,reference,decisions,global,vendor,registries,multi-agent,origin_manifest_resolution}.md`, `skills/skilltree/SKILL.md` and `skills/skilltree/references/*.md` still narrate `.yaml` as canonical. A separate docs PR should sweep those (~89 mentions across specs alone).
- `docs/specs/decisions.md` should get a new entry recording this flip and superseding the original `.yaml`-default decision.
- `CLAUDE.md` "Global vs Project vs Vendor" table also still says `skilltree.yaml`.
- Two stale labels in `tests/e2e/global-{e2e,unhappy-e2e}.test.ts` (the test names mention `global.yaml` but the assertions go through the constant-driven writer; defensible either way, leaving as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)