### PR TITLE
feat(commands): add slash commands as a third resource type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 
-Dependency-aware package manager for AI agent skills (SKILL.md) and agents. Uses git repos as the registry, resolves transitive dependencies, supports semver version pinning via git tags, and produces lockfiles for reproducible installs.
+Dependency-aware package manager for AI agent skills (SKILL.md), agents, and Claude Code slash commands. Uses git repos as the registry, resolves transitive dependencies, supports semver version pinning via git tags, and produces lockfiles for reproducible installs.
 
 ## Docs
 
@@ -32,7 +32,7 @@ skilltree/
 │   ├── cli.ts              # CLI entry point (commander)
 │   ├── commands/            # One file per command
 │   ├── core/
-│   │   ├── manifest.ts      # skilltree.yaml parsing/writing
+│   │   ├── manifest.ts      # skilltree.yml parsing/writing
 │   │   ├── lockfile.ts      # skilltree.lock parsing/writing
 │   │   ├── resolver.ts      # Version resolution (semver constraints)
 │   │   ├── graph.ts         # Dependency graph + topological sort
@@ -63,7 +63,7 @@ bun build --compile src/cli.ts --outfile dist/skilltree
 ## Key Design Decisions
 
 1. Git is the registry -- no server, no database
-2. `skilltree.yaml` + `skilltree.lock` -- only two state files
+2. `skilltree.yml` + `skilltree.lock` -- only two state files
 3. Lockfile-first for remote deps, always-fresh for local deps (Cargo/npm pattern)
 4. Name aliasing for same-name skill/agent collisions -- **marked as hard, needs thorough testing**
 5. Kahn's algorithm for topological sort
@@ -75,11 +75,11 @@ bun build --compile src/cli.ts --outfile dist/skilltree
 
 | Need | Mechanism | Who uses it |
 |------|-----------|-------------|
-| Project needs a skill | `skilltree.yaml` (project dep) | Everyone on the team |
+| Project needs a skill | `skilltree.yml` (project dep) | Everyone on the team |
 | You want a skill everywhere | `~/.skilltree/global.yaml` (global dep) | Just you |
 | Ship skills without upstream access | `skilltree vendor` | Consumers of your repo |
 
-**Global deps are a convenience.** If you want `python-coding` in every project without adding it to each `skilltree.yaml`, put it in your global manifest. But if the project *requires* it, define it in the project's `skilltree.yaml` — that's the contract teammates and CI rely on.
+**Global deps are a convenience.** If you want `python-coding` in every project without adding it to each `skilltree.yml`, put it in your global manifest. But if the project *requires* it, define it in the project's `skilltree.yml` — that's the contract teammates and CI rely on.
 
 **Vendor is for distribution.** When skills come from a private repo and you need others to use them without access, `skilltree vendor` copies everything into `.claude/` as committed files. Consumers `git clone` and it works — no `skilltree install` needed. The maintainer can `skilltree unvendor` to go back to normal development.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license](https://img.shields.io/npm/l/skilltree-pm)](https://github.com/imarios/skilltree/blob/main/LICENSE)
 [![node](https://img.shields.io/node/v/skilltree-pm)](https://nodejs.org)
 
-Dependency manager for AI agent skills and agents. Uses git repos as the registry, resolves transitive dependencies, supports semver version pinning via git tags, and produces lockfiles for reproducible installs.
+Dependency manager for AI agent skills, agents, and slash commands. Uses git repos as the registry, resolves transitive dependencies, supports semver version pinning via git tags, and produces lockfiles for reproducible installs.
 
 [![demo](https://imarios.github.io/skilltree/demo.gif)](https://imarios.github.io/skilltree/demo.mp4)
 
@@ -14,7 +14,7 @@ Dependency manager for AI agent skills and agents. Uses git repos as the registr
 
 AI agent skills ([SKILL.md](https://agentskills.io/specification)) are the open standard for giving coding agents reusable instructions. Existing tools treat skills as independent files — copy to a directory, done. But real-world skill ecosystems develop dependency graphs: a `code-review` skill depends on `testing`, `linting`, and `language-support`. An agent depends on 5 skills spread across 3 repos.
 
-skilltree is `npm` for skills: declare what you need in `skilltree.yaml`, run `skilltree install`, and get a resolved, version-pinned, reproducible dependency tree in `skilltree.lock`.
+skilltree is `npm` for skills: declare what you need in `skilltree.yml`, run `skilltree install`, and get a resolved, version-pinned, reproducible dependency tree in `skilltree.lock`.
 
 ### How it compares
 
@@ -60,6 +60,9 @@ skilltree add python-coding
 skilltree add code-review --repo github.com/org/skills --path skills/code-review --version "^2.0.0"
 skilltree add my-style --local ./skills/my-style
 
+# Slash commands (Claude Code) — installed to .claude/commands/
+skilltree add review --repo github.com/org/cmds --path commands/review.md --type command
+
 # Resolve and install
 skilltree install
 ```
@@ -70,13 +73,13 @@ skilltree install
 
 Two files manage all state:
 
-- **`skilltree.yaml`** — what you want (repo URLs, version constraints, local paths)
+- **`skilltree.yml`** — what you want (repo URLs, version constraints, local paths)
 - **`skilltree.lock`** — what you got (resolved versions, exact commits, integrity hashes)
 
 Skills declare their own dependencies in SKILL.md frontmatter. skilltree resolves the full transitive graph, pins versions via git tags, and installs in topological order. Teammates get identical versions from the lockfile.
 
 ```yaml
-# skilltree.yaml
+# skilltree.yml
 dependencies:
   code-review:
     repo: github.com/org/skills
@@ -96,14 +99,14 @@ dependencies:
 
 skilltree resolves `code-review`, discovers it needs `testing` and `linting`, resolves those too, and installs all three.
 
-**Origin-manifest resolution.** When the upstream repo ships its own `skilltree.yaml`, skilltree uses it as the authoritative map of what lives where. Two consequences for consumers:
+**Origin-manifest resolution.** When the upstream repo ships its own `skilltree.yml`, skilltree uses it as the authoritative map of what lives where. Two consequences for consumers:
 
 - **`path:` is optional.** If origin declares the name, skilltree fills in the path at install time.
   ```yaml
   dependencies:
     task-builder:
       repo: github.com/org/some-repo
-      # path: inferred from origin's skilltree.yaml
+      # path: inferred from origin's skilltree.yml
   ```
 - **Unconventional layouts still work.** Transitive deps resolve even when the upstream repo organizes skills at non-standard paths like `skills/source/<name>/`. Cross-repo transitive deps (where origin's manifest references a third-party repo) are cloned on demand.
 
@@ -122,7 +125,7 @@ skilltree install    # symlinks .claude/skills/my-style → ./skills/my-style
 
 ### Global Dependencies
 
-Skills you want available in every project without adding them to each `skilltree.yaml`.
+Skills you want available in every project without adding them to each `skilltree.yml`.
 
 ```bash
 skilltree init --global
@@ -152,7 +155,7 @@ Bulk-add everything from a source directory:
 skilltree add --global --source mine --discover
 ```
 
-**When to use global:** Personal productivity skills you want everywhere — `python-coding`, `general-coding`, `my-style`. If the *project* needs a skill, put it in the project's `skilltree.yaml` — that's the contract teammates and CI rely on.
+**When to use global:** Personal productivity skills you want everywhere — `python-coding`, `general-coding`, `my-style`. If the *project* needs a skill, put it in the project's `skilltree.yml` — that's the contract teammates and CI rely on.
 
 ### Vendor Mode
 
@@ -161,7 +164,7 @@ Ship skills to consumers who don't have access to your upstream repos. Vendor co
 ```bash
 # Maintainer: enter vendor mode
 skilltree vendor                # copies all deps to .claude/, removes from .gitignore
-git add .claude/ skilltree.yaml
+git add .claude/ skilltree.yml
 git commit -m "vendor skills"
 
 # Consumer: just clone
@@ -193,7 +196,7 @@ skilltree info python-coding                   # detailed info
 skilltree add python-coding                    # resolves repo + path from registry
 ```
 
-Registries are authoring-time tools — they help you find and add skills. They are never in the install path. `skilltree.yaml` always records explicit `repo:` + `path:`, so teammates don't need the same registries configured.
+Registries are authoring-time tools — they help you find and add skills. They are never in the install path. `skilltree.yml` always records explicit `repo:` + `path:`, so teammates don't need the same registries configured.
 
 ### Dev/Prod Separation
 
@@ -267,7 +270,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 
 | Need | Mechanism | Who benefits |
 |------|-----------|--------------|
-| Project needs a skill | `skilltree.yaml` dependency | Everyone on the team |
+| Project needs a skill | `skilltree.yml` dependency | Everyone on the team |
 | You want a skill everywhere | `skilltree add --global` | Just you |
 | Ship skills without upstream access | `skilltree vendor` | Consumers of your repo |
 | Find skills by name | `skilltree search` via registries | Skill discovery |
@@ -276,7 +279,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 
 | Command | Description |
 |---------|-------------|
-| `skilltree init` | Create `skilltree.yaml` and update `.gitignore` |
+| `skilltree init` | Create `skilltree.yml` and update `.gitignore` |
 | `skilltree add <name>` | Add a dependency (remote, local, or dev) |
 | `skilltree install` | Resolve dependencies and install |
 | `skilltree update [name]` | Update to latest versions |

--- a/docs/specs/decisions.md
+++ b/docs/specs/decisions.md
@@ -12,20 +12,20 @@ Remote deps: if lockfile exists and is consistent with manifest, install from lo
 `local:` deps are symlinked for instant feedback during development. Copied (not symlinked) during `--prod --install-path` for Docker builds. Optional `version:` field serves consumers who reference the same entity via `repo:`. Local agents (single `.md` files) are file-symlinked; local skills (directories) are directory-symlinked. Local deps bypass the lockfile for resolution -- the working tree is the source of truth.
 
 ### 4. Transitive resolution uses a growing context
-Once an entity is resolved (by any method), it becomes available to all subsequent resolution lookups. Priority: resolution context -> consumer manifest -> local-source probe -> origin-manifest lookup -> same-repo conventional probe -> error. Prevents order-dependent resolution failures. Entities registered under actual name + type (not YAML alias). Declaration order (top to bottom, `dependencies` before `dev-dependencies`) is the tiebreaker for same-name entities in different repos. See `origin_manifest_resolution.md` for the origin-manifest lookup tier (reads the parent repo's `skilltree.yaml` at the pinned ref; only `dependencies` are exposed to downstream consumers).
+Once an entity is resolved (by any method), it becomes available to all subsequent resolution lookups. Priority: resolution context -> consumer manifest -> local-source probe -> origin-manifest lookup -> same-repo conventional probe -> error. Prevents order-dependent resolution failures. Entities registered under actual name + type (not YAML alias). Declaration order (top to bottom, `dependencies` before `dev-dependencies`) is the tiebreaker for same-name entities in different repos. See `origin_manifest_resolution.md` for the origin-manifest lookup tier (reads the parent repo's `skilltree.yml` at the pinned ref; only `dependencies` are exposed to downstream consumers).
 
 ### 5. Modification safety
 `skilltree install` checks integrity of existing installed files before overwriting. Modified files trigger a warning; `--force` required to overwrite. Prevents accidental loss of local experiments.
 
 ### 6. Type inference
-Presence of `SKILL.md` in the path = skill. Single `.md` file = agent. Can be overridden with explicit `type:` in manifest. Path is always required for remote deps (no guessing).
+Directory containing `SKILL.md` = skill. A single `.md` file under any `commands/` segment = command (Claude Code slash command). Any other `.md` file = agent. Can be overridden with explicit `type:` in manifest. Path is always required for remote deps (no guessing).
 
 ### 7. Name aliasing (follows Cargo `package` rename)
 **Marked as hard -- needs thorough testing during implementation.**
 
 YAML keys must be unique, but a skill and agent can share a name (e.g., `workflow-builder`). The YAML key serves as a local alias; the `name:` field specifies the actual entity name for installation. If `name:` is omitted, the key IS the name.
 
-- No filesystem collision: skills install to `skills/`, agents to `agents/`
+- No filesystem collision: skills install to `skills/`, agents to `agents/`, commands to `commands/`
 - Frontmatter `dependencies` use actual names, not aliases
 - Disambiguation in frontmatter: `dependencies: [workflow-builder]` **always resolves to the skill** when both skill and agent share the name. Skills can only depend on skills (type constraint forces it). Agents default to skill (common pattern).
 - **Known limitation:** There is no frontmatter syntax to target a same-name agent. If an agent needs to depend on another agent that shares a name with a skill, the agent must be renamed to have a unique name. This is an acceptable constraint -- the collision is rare (1 in 42 entities in the real codebase), and renaming is a one-time fix.
@@ -48,7 +48,7 @@ The `sources:` map defines repo URL aliases. `source: vibes` expands to `repo:` 
 `.claude/skills/` is gitignored -- pre-commit file patterns never match installed files. The `skilltree-scan` hook is for skill authoring repos with tracked `skills/` directories. Consumer repos use only `skilltree-validate`.
 
 ### 10. Installed files are never checked in
-Only `skilltree.yaml` and `skilltree.lock` go into git. `.claude/skills/` and `.claude/agents/` are gitignored. `skilltree init` sets this up.
+Only `skilltree.yml` and `skilltree.lock` go into git. `.claude/skills/` and `.claude/agents/` are gitignored. `skilltree init` sets this up.
 
 ### 11. Group assignment
 If a transitive dependency is reachable from both `dependencies` and `dev-dependencies`, it is `group: prod`. `--prod` must include it.
@@ -57,7 +57,7 @@ If a transitive dependency is reachable from both `dependencies` and `dev-depend
 Resolution does NOT halt on the first error. It continues through the entire graph, collecting all unresolvable dependencies, incompatible constraints, type violations, and cycle paths, then reports them all at once. This lets users fix all issues in one pass instead of iterating through install-fail-fix cycles. Follows the same pattern as TypeScript compiler errors (collect all, report all).
 
 ### 13. Lockfile merge conflicts
-Resolution strategy (follows npm/yarn convention): resolve `skilltree.yaml` conflicts first, delete conflicted `skilltree.lock`, run `skilltree install` to regenerate. Lockfile uses sorted YAML keys to minimize conflicts.
+Resolution strategy (follows npm/yarn convention): resolve `skilltree.yml` conflicts first, delete conflicted `skilltree.lock`, run `skilltree install` to regenerate. Lockfile uses sorted YAML keys to minimize conflicts.
 
 ## Deferred Decisions
 
@@ -88,12 +88,12 @@ Decisions that came up during spec review but were explicitly deferred.
 | Breaking transitive dep additions | Accepted as-is | New cross-repo dep in frontmatter breaks consumers on update. Error is clear. Could warn in `outdated` later. |
 
 ### 14. Registries are discovery-only
-Registries help find and add skills but are never in the install or resolution path. `skilltree add <name>` (without `--repo`) consults registries to resolve the full coordinates, then writes the **full explicit form** (`repo:` + `path:`) to `skilltree.yaml`. The manifest stays self-contained and auditable. See [registries.md](registries.md).
+Registries help find and add skills but are never in the install or resolution path. `skilltree add <name>` (without `--repo`) consults registries to resolve the full coordinates, then writes the **full explicit form** (`repo:` + `path:`) to `skilltree.yml`. The manifest stays self-contained and auditable. See [registries.md](registries.md).
 
 **Rejected alternative:** npm-style shorthand (`python-coding: "^2.0.0"`) where the manifest depends on a global registry for resolution. Rejected because it makes the manifest non-self-contained, creates "works on my machine" from registry ordering when names collide across registries, and breaks `skilltree update` for teammates without the same registries configured. The UX win (shorter YAML) was not worth the implicit external state.
 
 ### 15. `sources:` and registries are separate concepts
-`sources:` in `skilltree.yaml` are project-scoped URL aliases used during resolution. Registries in `~/.skilltree/config.yaml` are user-scoped discovery tools. They can point to the same git repo. They don't interact. Rationale: merging them creates a conceptual mess — "is this a source or a registry? is it searchable? does it affect install?" Keeping them separate means each concept has one purpose.
+`sources:` in `skilltree.yml` are project-scoped URL aliases used during resolution. Registries in `~/.skilltree/config.yaml` are user-scoped discovery tools. They can point to the same git repo. They don't interact. Rationale: merging them creates a conceptual mess — "is this a source or a registry? is it searchable? does it affect install?" Keeping them separate means each concept has one purpose.
 
 ### 16. Dual install paths: `dev_install_path` + `src_install_path`
 Skills serve two purposes: helping developers write code (dev) and powering the product's AI features at runtime (source). Most users only need the first. The `src_install_path` field is optional — when absent, behavior is exactly like before (everything goes to `.claude/`). When set, `dependencies` install to both paths and `dev-dependencies` install to `dev_install_path` only.

--- a/docs/specs/global.md
+++ b/docs/specs/global.md
@@ -8,7 +8,7 @@ Global deps install once, available in every project. Project-scoped deps remain
 ## The Problem
 
 A developer has skills they want everywhere — `python-coding`, `general-coding`, `my-style`. Today they either:
-1. Add them to every project's `skilltree.yaml` (duplication)
+1. Add them to every project's `skilltree.yml` (duplication)
 2. Manually copy/symlink into `~/.claude/skills/` (unmanaged)
 
 Both break down. Option 1 means 15+ identical entries across 20 projects. Option 2 means no version tracking, no transitive resolution, no lockfile.
@@ -17,7 +17,7 @@ Both break down. Option 1 means 15+ identical entries across 20 projects. Option
 
 **Global deps are a personal convenience, never a project dependency.**
 
-If a project needs a skill, it goes in `skilltree.yaml`. Global is "I always want this available." Teammates don't need your global deps — the project's `skilltree.yaml` is self-contained.
+If a project needs a skill, it goes in `skilltree.yml`. Global is "I always want this available." Teammates don't need your global deps — the project's `skilltree.yml` is self-contained.
 
 This follows the npm model: `npm install -g` is for CLI tools you use personally. Project deps go in `package.json`.
 
@@ -27,7 +27,7 @@ This follows the npm model: `npm install -g` is for CLI tools you use personally
 
 | | Project | Global |
 |---|---|---|
-| Manifest | `./skilltree.yaml` | `~/.skilltree/global.yaml` |
+| Manifest | `./skilltree.yml` | `~/.skilltree/global.yaml` |
 | Lockfile | `./skilltree.lock` | `~/.skilltree/global.lock` |
 | Install path | `.claude/` (or `src_install_path`) | `~/.claude/` |
 | Checked into git | Yes | No (personal) |
@@ -151,7 +151,7 @@ If `~/Projects/my-skills/` moves to `~/Skills/my-skills/`, update one line in `s
 
 ### Local sources in project manifests: reproducibility warning
 
-Local sources also work in project manifests. However, entries with `~/` or absolute paths in a committed `skilltree.yaml` create a "works on my machine" problem — teammates with different directory structures will get errors.
+Local sources also work in project manifests. However, entries with `~/` or absolute paths in a committed `skilltree.yml` create a "works on my machine" problem — teammates with different directory structures will get errors.
 
 **Safe:** `./` relative paths (resolve within the project tree, portable):
 ```yaml
@@ -521,7 +521,7 @@ Fix: Check the source path in ~/.skilltree/global.yaml, or clone the source repo
 
 ### No cross-resolution
 
-Global and project manifests are resolved independently. If project `skilltree.yaml` has `python-coding` and `~/.skilltree/global.yaml` also has `python-coding`, they resolve separately with potentially different versions.
+Global and project manifests are resolved independently. If project `skilltree.yml` has `python-coding` and `~/.skilltree/global.yaml` also has `python-coding`, they resolve separately with potentially different versions.
 
 At runtime, Claude Code loads project's `.claude/skills/python-coding` and ignores global's `~/.claude/skills/python-coding` (project shadows global).
 
@@ -529,13 +529,13 @@ At runtime, Claude Code loads project's `.claude/skills/python-coding` and ignor
 
 ```
 ~/Projects/my-skills/          ← you're here, authoring skills
-├── skilltree.yaml             ← this repo's project-level deps
+├── skilltree.yml             ← this repo's project-level deps
 ├── skills/
 │   ├── python-coding/SKILL.md ← source skill
 │   └── general-coding/SKILL.md
 ```
 
-This repo has its OWN `skilltree.yaml` (project-level deps it needs for development). Those same skills are ALSO referenced in `~/.skilltree/global.yaml`.
+This repo has its OWN `skilltree.yml` (project-level deps it needs for development). Those same skills are ALSO referenced in `~/.skilltree/global.yaml`.
 
 Both work independently:
 - `skilltree install` → installs this project's deps to `.claude/`
@@ -568,7 +568,7 @@ When Claude Code runs here, project `.claude/` takes precedence. The global syml
 
 **Decided:** Global and project manifests never cross-resolve. A global skill cannot satisfy a project's transitive dep.
 
-**Why:** Cross-resolution makes project builds depend on the developer's personal setup. Teammate clones the repo → transitive dep missing → "works on my machine." The whole point of `skilltree.yaml` + `skilltree.lock` is reproducibility. Global deps must not compromise that.
+**Why:** Cross-resolution makes project builds depend on the developer's personal setup. Teammate clones the repo → transitive dep missing → "works on my machine." The whole point of `skilltree.yml` + `skilltree.lock` is reproducibility. Global deps must not compromise that.
 
 **Alternative rejected:** "Fall through to global" — if a project transitive dep can't be resolved from the project manifest, check global. Rejected because it makes project installs non-deterministic across machines.
 

--- a/docs/specs/multi-agent.md
+++ b/docs/specs/multi-agent.md
@@ -67,7 +67,7 @@ skilltree installs skills to a single directory (default `.claude/`). Users who 
 ### `skilltree targets` Subcommand
 
 - **R11**: `skilltree targets list` shows all known agents with two indicators: detected on system, and present in `install_targets`. Also shows custom paths from `install_targets`.
-- **R12**: `skilltree targets add <name|path>` adds a target to `install_targets` in `skilltree.yaml`
+- **R12**: `skilltree targets add <name|path>` adds a target to `install_targets` in `skilltree.yml`
 - **R13**: `skilltree targets remove <name|path>` removes a target from `install_targets`
 - **R14**: `skilltree targets detect` scans for installed agents and adds any missing ones to `install_targets`
 - **R15**: `skilltree targets migrate` converts `dev_install_path` → `install_targets` and removes `dev_install_path` from the manifest. Known paths are reverse-looked-up to agent names (`.claude` → `claude`); unknown paths become literal (`./custom` → `./custom`)
@@ -84,7 +84,7 @@ skilltree installs skills to a single directory (default `.claude/`). Users who 
 
 ### `skilltree init`
 
-- **R20**: `skilltree init` auto-detects agents and pre-populates `install_targets` in the new `skilltree.yaml`. Falls back to `[claude]` if none detected.
+- **R20**: `skilltree init` auto-detects agents and pre-populates `install_targets` in the new `skilltree.yml`. Falls back to `[claude]` if none detected.
 
 ### `skilltree teach`
 
@@ -177,7 +177,7 @@ Run: skilltree targets migrate
 
 $ skilltree targets migrate
 Migrated dev_install_path: .claude → install_targets: [claude]
-Removed dev_install_path from skilltree.yaml.
+Removed dev_install_path from skilltree.yml.
 ```
 
 ## Constraints

--- a/docs/specs/origin_manifest_resolution.md
+++ b/docs/specs/origin_manifest_resolution.md
@@ -23,7 +23,7 @@ summary = "Extended to direct deps (R9). Consumers can omit path: and inherit it
 
 ## Problem Statement
 
-Origin repos that ship a `skilltree.yaml` already declare, authoritatively, where every skill and agent they own lives. Transitive resolution (v1.x of this spec) leveraged that manifest to auto-resolve dependencies that downstream consumers didn't declare themselves. But for **direct** deps, consumers still have to specify `path:` explicitly — duplicating information origin already provided.
+Origin repos that ship a `skilltree.yml` already declare, authoritatively, where every skill and agent they own lives. Transitive resolution (v1.x of this spec) leveraged that manifest to auto-resolve dependencies that downstream consumers didn't declare themselves. But for **direct** deps, consumers still have to specify `path:` explicitly — duplicating information origin already provided.
 
 Concrete friction: a consumer writes
 
@@ -58,7 +58,7 @@ Every entry repeats a path the origin already told the world about. If origin re
 
 ### Carried forward from v1.x (transitive resolution)
 
-- **R1**: When a transitive dep cannot be found in the consumer's manifest, the already-resolved context, or the parent's local source, the resolver MUST consult the origin repo's `skilltree.yaml` (read at the parent's pinned git ref) before falling back to the conventional path probe.
+- **R1**: When a transitive dep cannot be found in the consumer's manifest, the already-resolved context, or the parent's local source, the resolver MUST consult the origin repo's `skilltree.yml` (read at the parent's pinned git ref) before falling back to the conventional path probe.
 - **R2**: If the origin manifest declares the dep name under `dependencies:` with a `local:` entry, the resolver MUST synthesize a same-repo remote dep (`{repo: parentRepo, path: stripDotSlash(local)}`) pinned to the parent's resolved tag and resolve it.
 - **R3**: If the origin manifest is missing, unreadable, or malformed, the resolver MUST silently fall through to the conventional probe.
 - **R4**: The resolver MUST NOT expose `dev-dependencies` declared in the origin manifest. Transitive deps only in origin's `dev-dependencies` fail with an informative error (R5).
@@ -69,7 +69,7 @@ Every entry repeats a path the origin already told the world about. If origin re
 
 ### New in v2.0 (direct deps)
 
-- **R9**: A direct dep with `repo:` (or `source:`-expanded-to-`repo:`) MAY omit `path:`. When omitted, the resolver MUST look up the actual entity name in the origin repo's `skilltree.yaml`:
+- **R9**: A direct dep with `repo:` (or `source:`-expanded-to-`repo:`) MAY omit `path:`. When omitted, the resolver MUST look up the actual entity name in the origin repo's `skilltree.yml`:
   - If origin declares the name under `dependencies:` with a `local:` entry whose path is relative, use that path within the consumer-declared repo.
   - If origin declares the name under `dependencies:` with a `repo:` entry pointing at the **same** repo the consumer declared, use origin's path.
   - If origin declares the name under `dependencies:` with a `repo:` entry pointing at a **different** repo, fall through (do not redirect — consumer's `repo:` wins).
@@ -81,7 +81,7 @@ Every entry repeats a path the origin already told the world about. If origin re
 - **R11**: A dependency entry MAY include `force_path: true` to silence R10 warnings for that entry. `force_path` has no other effect on resolution.
 - **R12**: Manifest validation (`validateManifest`) MUST NOT require `path:` on remote dependencies. The existing requirement that `repo:`/`source:` and `local:` are mutually exclusive stays.
 - **R13**: `skilltree add --repo <url>` (and `--source <alias>`) MUST accept an omitted `--path`. If the origin manifest resolves the path at add-time, it MAY be written into the consumer's manifest; otherwise the manifest is written with no `path:` and resolution happens at install-time.
-- **R14 (stale-tag manifest)**: For each resolved remote repo, the resolver MUST check whether `skilltree.yaml` exists at the resolved tag. If it is absent at the tag but present on the default branch, the resolver MUST emit a single warning per repo that names the repo, the resolved tag, the default branch, and recommends cutting a new tag. This guards the common case where an author commits a manifest to `main` without tagging a release, so consumers silently lose R9/R10 signals.
+- **R14 (stale-tag manifest)**: For each resolved remote repo, the resolver MUST check whether `skilltree.yml` exists at the resolved tag. If it is absent at the tag but present on the default branch, the resolver MUST emit a single warning per repo that names the repo, the resolved tag, the default branch, and recommends cutting a new tag. This guards the common case where an author commits a manifest to `main` without tagging a release, so consumers silently lose R9/R10 signals.
 
 ## Constraints
 
@@ -91,7 +91,7 @@ Today: `resolveRemoteEntity()` requires `dep.path` and calls `pathExistsAtRef()`
 
 After R9: when `dep.path` is missing, the resolver runs a path-inference tier **before** validation:
 
-1. **Origin-manifest lookup** — read origin's `skilltree.yaml` at the resolved tag, look up the entity name in `dependencies`, use its declared path (subject to R9 rules).
+1. **Origin-manifest lookup** — read origin's `skilltree.yml` at the resolved tag, look up the entity name in `dependencies`, use its declared path (subject to R9 rules).
 2. **Conventional probe** — try `skills/<name>/SKILL.md`, `agents/<name>.md`, `<name>/SKILL.md` at the consumer's declared repo.
 3. **Error** — missing path + no origin lookup + no probe match → clear error naming every location checked.
 
@@ -117,7 +117,7 @@ Let `C` be consumer's declared `path:`, `O` be origin's declared path (`stripDot
 
 ### `force_path` schema
 
-New optional boolean field on `RemoteDependency` and `SourceDependency`. Defaults to `false`. Serialized in `skilltree.yaml` but NOT in `skilltree.lock` (warnings are authoring-time, not install-path).
+New optional boolean field on `RemoteDependency` and `SourceDependency`. Defaults to `false`. Serialized in `skilltree.yml` but NOT in `skilltree.lock` (warnings are authoring-time, not install-path).
 
 ## Error Handling
 
@@ -130,7 +130,7 @@ New optional boolean field on `RemoteDependency` and `SourceDependency`. Default
 | Origin declares name, different `repo:` | Fall through; if convention probe fails → error |
 | Origin doesn't declare name, convention probe hits | Path inferred (matches today's transitive behavior), no error |
 | Origin doesn't declare name, convention probe misses | Clear error with list of checked locations |
-| Origin `skilltree.yaml` missing, convention probe misses | Clear error |
+| Origin `skilltree.yml` missing, convention probe misses | Clear error |
 | Origin declares name only in `dev-dependencies` | Fall through to convention probe; if still missing → error that names the dev-dep location |
 
 Example error (R9 all tiers failed):
@@ -138,11 +138,11 @@ Example error (R9 all tiers failed):
 ```
 Error: "task-builder" (from github.com/org/repo) has no path, and the resolver
   could not infer one from:
-    - origin's skilltree.yaml dependencies (github.com/org/repo)
+    - origin's skilltree.yml dependencies (github.com/org/repo)
     - conventional paths in github.com/org/repo
 
-  Fix: add `path:` to your skilltree.yaml entry, or have origin declare
-       "task-builder" under `dependencies:` in its skilltree.yaml.
+  Fix: add `path:` to your skilltree.yml entry, or have origin declare
+       "task-builder" under `dependencies:` in its skilltree.yml.
 ```
 
 ### R10 — warnings
@@ -150,14 +150,14 @@ Error: "task-builder" (from github.com/org/repo) has no path, and the resolver
 Redundant:
 ```
 Warning: `task-builder` declares path "skills/source/task-builder", which is the
-  same path origin's skilltree.yaml declares for this name (file://...).
+  same path origin's skilltree.yml declares for this name (file://...).
   You can omit `path:` — it will be inferred.
 ```
 
 Override:
 ```
 Warning: `task-builder` declares path "skills/alt/task-builder", but origin's
-  skilltree.yaml declares this name at "skills/source/task-builder" (file://...).
+  skilltree.yml declares this name at "skills/source/task-builder" (file://...).
   If this override is intentional, set `force_path: true` to silence this warning.
 ```
 
@@ -176,8 +176,8 @@ Warning: `task-builder` declares path "skills/alt/task-builder", but origin's
 - [ ] Origin declares name with `local:` absolute path → fall through, convention probe.
 - [ ] Origin doesn't declare name, convention probe hits → inferred.
 - [ ] Origin doesn't declare name, convention probe misses → error naming all checked locations.
-- [ ] Origin `skilltree.yaml` missing → convention probe.
-- [ ] Origin `skilltree.yaml` malformed → convention probe.
+- [ ] Origin `skilltree.yml` missing → convention probe.
+- [ ] Origin `skilltree.yml` malformed → convention probe.
 - [ ] Origin declares name only in `dev-dependencies` → fall through; convention probe or error.
 - [ ] Aliased YAML key (`name:` differs from key) → lookup uses actual name, not key.
 - [ ] Agent direct dep, no path, origin declares agent → inferred with `type: agent`.
@@ -218,5 +218,5 @@ None. Decisions locked:
 
 - **Origin-manifest-driven `name:` inference for aliases.** Not motivated.
 - **Transitive lockfile provenance.** `skilltree deps tree` should annotate origin-manifest-sourced deps.
-- **`skilltree validate` for origin authors.** Lint origin's own `skilltree.yaml` for broken paths / dev-deps transitively exposed / cross-repo constraints.
+- **`skilltree validate` for origin authors.** Lint origin's own `skilltree.yml` for broken paths / dev-deps transitively exposed / cross-repo constraints.
 - **`skilltree explain <dep>`.** Show every constraint on a dep and who placed it (post-R7 useful for debugging deep chains).

--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -2,7 +2,7 @@
 
 ## File Formats
 
-### skilltree.yaml (Manifest)
+### skilltree.yml (Manifest)
 
 ```yaml
 name: my-project                  # Project name (informational)
@@ -37,6 +37,12 @@ dependencies:
   my-style:
     local: ./skills/my-style
 
+  # Slash command (Claude Code) -- single .md file under commands/
+  review:
+    repo: github.com/org/cmds
+    path: commands/review.md
+    type: command                 # Required if path doesn't sit under a `commands/` segment
+
   # Name aliasing (when skill and agent share a name)
   workflow-builder:
     local: ./skills/workflow-builder
@@ -66,10 +72,10 @@ dev-dependencies:
 | `local:` | Yes (local) | Filesystem path. Relative (`./`) for project manifests, `~/` or absolute for global manifests. Mutually exclusive with `repo:`. |
 | `path:` | Yes (remote and local-source) | Path within the repo or local source directory. Use `.` for root. Required when using `source:` (both remote and local). Not used with standalone `local:`. |
 | `version:` | No | Semver constraint (`^2.0.0`, `>=1.0`, `*`). Default `"*"`. Not used for local deps during install. |
-| `type:` | No | `skill` or `agent`. Inferred from content if omitted. |
+| `type:` | No | `skill`, `agent`, or `command`. Inferred from content if omitted (see "Type inference" below). |
 | `name:` | No | Actual entity name when YAML key is an alias. Default: YAML key. |
 
-**Type inference:** `SKILL.md` present at path = skill. Single `.md` file at path = agent.
+**Type inference:** Directory containing `SKILL.md` = skill. A single `.md` file under any `commands/` segment = command (Claude Code slash command). Any other `.md` file = agent. Override with explicit `type:` when the path doesn't reflect the intended layout.
 
 **Versioning:** Git tags (`v1.0.0` or `1.0.0`). One repo = one version -- all entities from the same repo share a tag. Multiple constraints on the same repo are intersected.
 
@@ -153,13 +159,13 @@ dependencies:
 ---
 ```
 
-Name-only list. Resolution details (repo, version) come from the consumer's `skilltree.yaml`. Keeps skills portable.
+Name-only list. Resolution details (repo, version) come from the consumer's `skilltree.yml`. Keeps skills portable.
 
 ## Resolution Algorithm
 
 ### Phase 1: Graph Construction
 
-1. Read `skilltree.yaml` to get direct dependencies (remote and local)
+1. Read `skilltree.yml` to get direct dependencies (remote and local)
 2. For each remote dep, fetch content from git (or local cache). For local deps, read from filesystem.
 3. Parse SKILL.md frontmatter to discover transitive dependencies
 4. Add resolved entities to the **resolution context** (available to all subsequent lookups)
@@ -168,18 +174,18 @@ Name-only list. Resolution details (repo, version) come from the consumer's `ski
 
 **Transitive resolution priority:**
 1. Resolution context (already resolved by another chain)
-2. Manifest lookup (consumer's `skilltree.yaml`, either group)
+2. Manifest lookup (consumer's `skilltree.yml`, either group)
 3. Local-source probe (when the parent is a local dep, look inside its source dir)
-4. Origin-manifest lookup (when the parent is a remote dep, read the origin repo's `skilltree.yaml` at the pinned ref and look up `dependencies[name]`; `dev-dependencies` are NOT exposed to downstream consumers)
-5. Same-repo conventional probe (`skills/<name>/SKILL.md`, `agents/<name>.md`, `<name>/SKILL.md`)
+4. Origin-manifest lookup (when the parent is a remote dep, read the origin repo's `skilltree.yml` at the pinned ref and look up `dependencies[name]`; `dev-dependencies` are NOT exposed to downstream consumers)
+5. Same-repo conventional probe (`skills/<name>/SKILL.md`, `agents/<name>.md`, `commands/<name>.md`, `<name>/SKILL.md`)
 6. Error (with actionable fix message)
 
 **Origin-manifest lookup for direct deps (R9):**
-- A direct dep `{repo: X, version: Y}` (no `path:`) triggers path inference. Read origin's `skilltree.yaml` at the resolved tag; look up the entity's actual name in `dependencies` (never `dev-dependencies`).
+- A direct dep `{repo: X, version: Y}` (no `path:`) triggers path inference. Read origin's `skilltree.yml` at the resolved tag; look up the entity's actual name in `dependencies` (never `dev-dependencies`).
 - If origin's entry is `local:` relative → use that path.
 - If origin's entry is `repo:` pointing at the consumer-declared repo → use origin's `path`.
 - If origin's entry points at a **different** repo → fall through to the conventional probe (do not redirect the consumer's `repo:` silently).
-- If origin doesn't declare the name, or has no manifest, or the manifest is malformed → fall through to the conventional probe (`skills/<name>/SKILL.md`, `agents/<name>.md`, `<name>/SKILL.md`).
+- If origin doesn't declare the name, or has no manifest, or the manifest is malformed → fall through to the conventional probe (`skills/<name>/SKILL.md`, `agents/<name>.md`, `commands/<name>.md`, `<name>/SKILL.md`).
 - If no tier resolves, error with a message listing every location checked.
 
 **Path warnings (R10):**
@@ -194,7 +200,7 @@ Name-only list. Resolution details (repo, version) come from the consumer's `ski
 - If origin's entry is `local: ./path/in/repo`, it is treated as a same-repo dep pinned to the parent's tag. This lets authors organize skills at any path (e.g., `skills/source/<name>/`) while keeping auto-resolution for consumers.
 - If origin's entry is `repo:` or `source:` (cross-repo), the target repo is cloned and resolved on-demand under origin's declared constraint. Already-resolved repos are reused; a constraint conflict produces a `Cross-repo transitive constraint conflict` error.
 - If origin's `local:` path is absolute (e.g., from a `source:` alias expanding to a filesystem path on origin's author's machine), the entry is skipped silently since consumers cannot use such paths.
-- If origin's `skilltree.yaml` is missing, malformed, or doesn't declare the name, resolution falls through silently to the conventional probe.
+- If origin's `skilltree.yml` is missing, malformed, or doesn't declare the name, resolution falls through silently to the conventional probe.
 - If origin declared the name only under `dev-dependencies`, the error message includes a specific hint pointing at the upstream author.
 
 **Declaration order:** Manifest entries processed top to bottom, `dependencies` before `dev-dependencies`. First resolution of a name wins for same-name entities in different repos.
@@ -233,7 +239,7 @@ If any errors were collected, block install and report all of them together.
 ### Phase 5: Installation
 
 1. **Remote deps already installed**: Check integrity hash against lockfile. If modified, warn + require `--force`.
-2. **Local deps**: Symlink from `{install_path}/skills/{name}` or `{install_path}/agents/{name}.md` to local path. No chmod, no integrity hash.
+2. **Local deps**: Symlink from `{install_path}/skills/{name}`, `{install_path}/agents/{name}.md`, or `{install_path}/commands/{name}.md` to local path. No chmod, no integrity hash.
 3. **Remote deps**: Copy from git cache. Set `chmod 444` for files (directories keep default permissions for manageability).
 4. **`--prod --install-path`**: Local deps **copied** (not symlinked). Copies get `chmod 444` for files and integrity hash (they're production artifacts).
 5. Compute SHA-256 integrity hash (remote + prod copies).
@@ -330,7 +336,7 @@ Error: Broken dependency chain
   api-development depends on testing, but testing has a broken dependency:
     testing declares dependency "python-coding" which is not resolvable.
 
-Fix: Ensure python-coding is in skilltree.yaml and its repo is accessible.
+Fix: Ensure python-coding is in skilltree.yml and its repo is accessible.
 ```
 
 ```
@@ -366,15 +372,15 @@ Error: Git operation failed
   Failed to fetch github.com/company/private-skills
   Underlying error: repository not found (or permission denied)
 
-Fix: Check the repo URL in skilltree.yaml and your git access (SSH keys, GITHUB_TOKEN).
+Fix: Check the repo URL in skilltree.yml and your git access (SSH keys, GITHUB_TOKEN).
 ```
 
 ```
 Error: Invalid manifest
 
-  skilltree.yaml: line 12: mapping values are not allowed here
+  skilltree.yml: line 12: mapping values are not allowed here
 
-Fix: Check YAML syntax in skilltree.yaml.
+Fix: Check YAML syntax in skilltree.yml.
 ```
 
 ```
@@ -383,7 +389,7 @@ Error: Local dependency path not found
   my-style: ./skills/my-stlye
   Path does not exist.
 
-Fix: Check the `local:` path in skilltree.yaml.
+Fix: Check the `local:` path in skilltree.yml.
 ```
 
 ```
@@ -431,7 +437,7 @@ Malformed frontmatter errors are collected in the batch error pattern (not fail-
 - **`--prod` filtering is at install time, not resolution time.** All deps (both groups) are resolved from the full manifest. `--prod` only controls which `group: dev` entries are skipped during the installation step. This ensures Decision #11 works correctly: a dev-dep that is also a transitive prod dep gets `group: prod` and IS installed by `--prod`.
 - **`--frozen` does not write the lockfile.** It is read-only (like `npm ci`). Integrity hashes for prod-copied local deps are computed for in-memory verification but not persisted to the lockfile.
 - **Failed install leaves lockfile unchanged.** A failed install (cycle, missing deps, etc.) does NOT write a partial lockfile. The previous lockfile is preserved. The next `skilltree install` uses the preserved lockfile according to normal lockfile behavior rules (not "full resolution from scratch").
-- **`skilltree remove` on a transitive-only dep:** If `<name>` is not a direct manifest entry, `remove` errors: "`<name>` is not in skilltree.yaml. It is a transitive dependency of `<parent>`. To stop installing it, remove or modify `<parent>` instead."
+- **`skilltree remove` on a transitive-only dep:** If `<name>` is not a direct manifest entry, `remove` errors: "`<name>` is not in skilltree.yml. It is a transitive dependency of `<parent>`. To stop installing it, remove or modify `<parent>` instead."
 - **Aliased entries in `deps tree`:** Shown as `actual-name@version (type, source)`. The alias is not displayed in the tree -- the tree uses installed names. The lockfile and `skilltree list` show the alias-to-name mapping.
 - **Integrity hash and line endings:** The hash is computed on content as retrieved from git's internal storage (remote deps) or as-is from the filesystem (local dep copies). For cross-platform determinism, skill repos should use `.gitattributes` with `* text=auto` to ensure consistent line endings. skilltree does not normalize line endings before hashing.
 - **`scan --check` pass/fail criteria:** Exit 1 if regex detects body references to skills not declared in frontmatter `dependencies`. Exit 0 if all body references are declared (or no body references found). Files with frontmatter but no `dependencies` field are treated as having an empty list. Declared-but-not-referenced deps are OK (exit 0).
@@ -443,7 +449,7 @@ Malformed frontmatter errors are collected in the batch error pattern (not fail-
 - **Failed install (cycle, missing deps, etc.):** Does NOT write a partial lockfile. The next `skilltree install` runs full resolution from scratch. If a lockfile existed before the failed run, it is left unchanged.
 - **`remove --keep-files` then `install`:** Leftover files from `--keep-files` are ignored by `install` (they have no lockfile entry). If the same dep is re-added later, `install` overwrites the leftover files.
 - **`skilltree scan --check` on a non-skill file:** Skips files that have no YAML frontmatter (exit 0). Only validates files that look like skills or agents (contain `---` frontmatter).
-- **Install path creation:** `skilltree install` creates the install path and its `skills/`/`agents/` subdirectories if they don't exist (`mkdir -p` behavior). Applies to both the default `.claude/` path and `--install-path` overrides.
+- **Install path creation:** `skilltree install` creates the install path and its `skills/`, `agents/`, and `commands/` subdirectories if they don't exist (`mkdir -p` behavior). Applies to both the default `.claude/` path and `--install-path` overrides.
 
 ### Warnings
 
@@ -463,7 +469,7 @@ Run `skilltree install --force` to overwrite, or `skilltree verify` for details.
 ### Lockfile Merge Conflicts
 
 Resolution strategy:
-1. Resolve conflicts in `skilltree.yaml` first
+1. Resolve conflicts in `skilltree.yml` first
 2. Delete the conflicted `skilltree.lock`
 3. Run `skilltree install` to regenerate
 4. Commit both files

--- a/docs/specs/registries.md
+++ b/docs/specs/registries.md
@@ -22,7 +22,7 @@ There is no way to search for a skill by name, browse what's available in a repo
 A registry helps you at `skilltree add` time. After that, the manifest is self-contained. This follows `go get` — it resolves module paths at add time, but `go.mod` records the full path. It does NOT follow npm's model where the manifest says `"lodash": "^4.0.0"` and a global registry is needed to resolve it.
 
 This means:
-- `skilltree.yaml` always contains explicit `repo:` + `path:` for remote deps
+- `skilltree.yml` always contains explicit `repo:` + `path:` for remote deps
 - `skilltree install` never consults registries
 - `skilltree update` never consults registries
 - A teammate without registries configured can still install, update, and develop
@@ -314,7 +314,7 @@ $ skilltree add python-coding
   Resolved from registry 'shared-skills': github.com/org/shared-skills/skills/python-coding
   Added python-coding to dependencies (version: "*")
 
-# What gets written to skilltree.yaml:
+# What gets written to skilltree.yml:
 # python-coding:
 #   repo: github.com/org/shared-skills
 #   path: skills/python-coding
@@ -339,7 +339,7 @@ $ skilltree add nonexistent-skill
   Or specify --repo and --path explicitly
 ```
 
-**Important:** The enhanced `add` always writes the **full explicit form** to `skilltree.yaml`. The registry is consulted once, at add time, and then forgotten. The manifest never depends on registry state.
+**Important:** The enhanced `add` always writes the **full explicit form** to `skilltree.yml`. The registry is consulted once, at add time, and then forgotten. The manifest never depends on registry state.
 
 **Flag interaction:**
 - `--repo` or `--source` or `--local` → existing behavior, registries not consulted
@@ -375,7 +375,7 @@ $ skilltree index --check
 
 ## What This Does NOT Change
 
-- **`skilltree.yaml` format** — no new fields, no shorthand syntax. Remote deps still require `repo:` + `path:`.
+- **`skilltree.yml` format** — no new fields, no shorthand syntax. Remote deps still require `repo:` + `path:`.
 - **`skilltree.lock` format** — unchanged.
 - **`skilltree install`** — never consults registries. Lockfile-first behavior unchanged.
 - **`skilltree update`** — resolves from manifest `repo:` URLs, not registries.
@@ -388,7 +388,7 @@ $ skilltree index --check
 
 | | `sources:` | Registries |
 |---|---|---|
-| **Scope** | Project (`skilltree.yaml`) | User (`~/.skilltree/config.yaml`) |
+| **Scope** | Project (`skilltree.yml`) | User (`~/.skilltree/config.yaml`) |
 | **Purpose** | URL alias (avoid repeating `repo:` URLs) | Discovery (find skills you don't know about) |
 | **Used by** | `skilltree install`, `skilltree update` | `skilltree search`, `skilltree add` (without `--repo`) |
 | **Required for install?** | Yes (expanded during resolution) | No (never consulted) |

--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -3,7 +3,7 @@
 **Version**: 1.0 (spec)
 **Date**: 2026-03-29
 
-Two files (`skilltree.yaml` + `skilltree.lock`), one command (`skilltree install`), git repos as the registry. Resolves transitive dependencies, pins versions via git tags, produces lockfiles for reproducibility, handles dev/prod separation, and supports local (symlinked) dependencies for skill authors.
+Two files (`skilltree.yml` + `skilltree.lock`), one command (`skilltree install`), git repos as the registry. Resolves transitive dependencies, pins versions via git tags, produces lockfiles for reproducibility, handles dev/prod separation, and supports local (symlinked) dependencies for skill authors.
 
 See [background.md](background.md) for why this tool exists and how it compares to alternatives.
 
@@ -13,7 +13,7 @@ See [background.md](background.md) for why this tool exists and how it compares 
 
 | Where | What it tracks | Who writes it |
 |-------|---------------|---------------|
-| `skilltree.yaml` | What you WANT -- repo URLs, version constraints, local paths | You (via `skilltree add` or hand-edit) |
+| `skilltree.yml` | What you WANT -- repo URLs, version constraints, local paths | You (via `skilltree add` or hand-edit) |
 | `skilltree.lock` | What you GOT -- resolved versions, exact commits, integrity hashes, full graph | skilltree (via `skilltree install`) |
 | SKILL.md frontmatter | What THIS skill NEEDS -- `dependencies: [name, name]` (name-only, no versions/repos) | Skill author |
 
@@ -25,15 +25,17 @@ Developer skills are **gitignored** -- like `node_modules/`, they're ephemeral:
 
 ```
 my-project/
-├── skilltree.yaml              # Checked into git (what you want)
+├── skilltree.yml              # Checked into git (what you want)
 ├── skilltree.lock              # Checked into git (what you got)
-├── .gitignore                 # Includes .claude/skills/, .claude/agents/
+├── .gitignore                 # Includes .claude/skills/, .claude/agents/, .claude/commands/
 ├── .claude/                   # dev_install_path (gitignored)
 │   ├── skills/                # Populated by `skilltree install`
 │   │   ├── code-review/       # Remote dep: copied from git cache
 │   │   └── my-style/          # Local dep: symlinked to source
-│   └── agents/
-│       └── workflow-builder.md
+│   ├── agents/
+│   │   └── workflow-builder.md
+│   └── commands/              # Claude Code slash commands
+│       └── review.md
 ├── src/skills/                # src_install_path (optional -- tracked or gitignored)
 │   ├── code-review/           # deps only (not dev-deps)
 │   └── my-style/
@@ -67,9 +69,9 @@ Error: 2 unresolved dependencies
 
   1. code-review (from github.com/org/repo) declares dependency "linting",
      not found in:
-       - your skilltree.yaml
+       - your skilltree.yml
        - already-resolved dependencies
-       - origin's skilltree.yaml dependencies (github.com/org/repo)
+       - origin's skilltree.yml dependencies (github.com/org/repo)
        - conventional paths in github.com/org/repo
   2. code-review (from github.com/org/repo) declares dependency "testing",
      not found in: (same locations as above)
@@ -91,7 +93,7 @@ These two gaps are independent. A skill can pass `scan --check` (all body refere
 
 ```bash
 # 1. Start a project
-skilltree init                           # Creates skilltree.yaml, updates .gitignore
+skilltree init                           # Creates skilltree.yml, updates .gitignore
 
 # 2. Declare what you need
 skilltree add code-review --repo github.com/org/skills --path skills/code-review --version "^2.0.0"
@@ -137,20 +139,29 @@ skilltree install --prod --frozen        # Zero resolution. Lockfile only.
 1. **Git is the registry.** No server, database, or Docker. Versions are git tags. Private repos just work.
 2. **Dependency resolution is the core value.** What needs installing, in what order, at what version.
 3. **Single binary, zero infrastructure.** TypeScript compiled via Bun. State = two files.
-4. **Standards-aligned.** SKILL.md standard. Installs to `.claude/skills/` and `.claude/agents/`.
+4. **Standards-aligned.** SKILL.md standard. Installs to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`.
 5. **Explicit over magic.** Frontmatter `dependencies` is the source of truth. Scanning is an authoring aid.
 6. **Installed files are never checked in.** Like `node_modules/` -- gitignored, recreated by `skilltree install`.
 
 ## Core Concepts
 
-### Skills and Agents
+### Skills, Agents, and Commands
+
+skilltree manages three first-class resource types. They share the same
+manifest grammar and resolution pipeline; they differ in shape and
+install location.
 
 | Entity | Format | Install Location |
 |--------|--------|------------------|
 | Skill | Directory with `SKILL.md` + optional `references/` | `.claude/skills/{name}/` |
 | Agent | Single `.md` file with YAML frontmatter | `.claude/agents/{name}.md` |
+| Command | Single `.md` file with YAML frontmatter (Claude Code slash commands) | `.claude/commands/{name}.md` |
 
-**Type constraint:** Skills can only depend on skills. Agents can depend on both skills and agents.
+**Type constraint:** Skills can only depend on skills. Agents can depend
+on skills (and other agents). Commands can depend on skills (same
+relaxation as agents). Agents and commands have the same on-disk shape
+(single `.md`); the difference is install location and how Claude Code
+loads them — slash commands are user-invoked via `/<name>`.
 
 ### Dependencies: Remote vs Local
 
@@ -232,12 +243,12 @@ The user controls whether `src_install_path` is tracked in git (committed, like 
 
 ### Origin-Manifest Resolution
 
-A repo that ships its own `skilltree.yaml` becomes **self-describing** to downstream consumers. The origin manifest provides name → location mappings that skilltree uses in two places:
+A repo that ships its own `skilltree.yml` becomes **self-describing** to downstream consumers. The origin manifest provides name → location mappings that skilltree uses in two places:
 
-**Direct deps, path inference (v2 / R9):** Consumers can omit `path:` on their own `skilltree.yaml` entries when origin declares the name. Path is looked up from origin at install time.
+**Direct deps, path inference (v2 / R9):** Consumers can omit `path:` on their own `skilltree.yml` entries when origin declares the name. Path is looked up from origin at install time.
 
 ```yaml
-# Consumer's skilltree.yaml — no path: needed
+# Consumer's skilltree.yml — no path: needed
 dependencies:
   task-builder:
     repo: github.com/org/analysi-backend
@@ -249,10 +260,10 @@ When the consumer's `path:` matches origin's declaration, skilltree warns that i
 **Transitive deps, full resolution:** When a skill's frontmatter declares a dep, skilltree resolves it using this priority:
 
 1. **Resolution context** -- B was already resolved by another chain
-2. **Consumer manifest** -- B is in `skilltree.yaml` (either group)
+2. **Consumer manifest** -- B is in `skilltree.yml` (either group)
 3. **Local-source probe** -- A came from a local source directory; look for B inside it. See [global.md](global.md) for local source details.
-4. **Origin-manifest lookup** -- A came from a remote repo; read the origin's `skilltree.yaml` at the pinned ref and look up B in `dependencies` (NOT `dev-dependencies`). If found as a `local:` entry, treat B as a same-repo dep pinned to A's tag. Lets authors organize repos without following the `skills/<name>/` convention.
-5. **Same-repo conventional probe** -- A came from a remote repo; probe `skills/<name>/SKILL.md`, `agents/<name>.md`, or `<name>/SKILL.md` at A's repo root.
+4. **Origin-manifest lookup** -- A came from a remote repo; read the origin's `skilltree.yml` at the pinned ref and look up B in `dependencies` (NOT `dev-dependencies`). If found as a `local:` entry, treat B as a same-repo dep pinned to A's tag. Lets authors organize repos without following the `skills/<name>/` convention.
+5. **Same-repo conventional probe** -- A came from a remote repo; probe `skills/<name>/SKILL.md`, `agents/<name>.md`, `commands/<name>.md`, or `<name>/SKILL.md` at A's repo root.
 6. **Error** -- actionable message listing every location checked, with a fix command.
 
 The resolution context grows during graph construction, making resolution order-independent. Manifest entries processed in declaration order (`dependencies` before `dev-dependencies`). See [reference.md](reference.md) for the full origin-manifest lookup semantics (cross-repo entries fall through; malformed origin manifests fall through silently).
@@ -279,7 +290,7 @@ workflow-builder-agent:         # YAML key = alias
   name: workflow-builder        # Actual name for installation
 ```
 
-No filesystem collision (skills and agents install to different directories).
+No filesystem collision (skills, agents, and commands install to different directories).
 
 **Frontmatter disambiguation:** When `dependencies: [workflow-builder]` appears in frontmatter and both a skill and agent match, **skill always takes precedence** (skills depending on skills is the only option; agents depending on skills is the common pattern). There is no frontmatter syntax to target a same-name agent -- this is a known limitation. If an agent needs to depend on another agent that shares a name with a skill, the agent must be renamed to have a unique name. See [decisions.md](decisions.md) #7 for full rules and test scenarios.
 
@@ -288,8 +299,8 @@ No filesystem collision (skills and agents install to different directories).
 ### `skilltree init`
 ```bash
 $ skilltree init
-Created skilltree.yaml
-Updated .gitignore (added .claude/skills/, .claude/agents/)
+Created skilltree.yml
+Updated .gitignore (added .claude/skills/, .claude/agents/, .claude/commands/)
 ```
 
 ### `skilltree add <name>`
@@ -305,9 +316,12 @@ $ skilltree add my-style --local ./skills/my-style
 
 # With source shorthand
 $ skilltree add linting --source shared --path skills/linting --version "^2.0.0"
+
+# Slash command (single .md under commands/, installs to .claude/commands/)
+$ skilltree add review --repo github.com/org/cmds --path commands/review.md --type command
 ```
 
-Default version when `--version` omitted: `"*"`. If the name already exists in the manifest, `add` overwrites it (with a warning). To move a dep between groups (dev to prod or vice versa), edit `skilltree.yaml` directly and run `skilltree install`.
+Default version when `--version` omitted: `"*"`. If the name already exists in the manifest, `add` overwrites it (with a warning). To move a dep between groups (dev to prod or vice versa), edit `skilltree.yml` directly and run `skilltree install`.
 
 ### `skilltree install`
 ```bash
@@ -343,7 +357,7 @@ Updated skilltree.lock
 - `--frozen` -- Lockfile-only, error if out of sync
 - `--force` -- Overwrite local modifications
 - `--dry-run` -- Show plan without installing
-- `--install-path <path>` -- Override target (e.g., `./build/.claude` for Docker). Creates `skills/` + `agents/` subdirs. Local deps copied, not symlinked. Takes precedence over `src_install_path`.
+- `--install-path <path>` -- Override target (e.g., `./build/.claude` for Docker). Creates `skills/`, `agents/`, and `commands/` subdirs. Local deps copied, not symlinked. Takes precedence over `src_install_path`.
 
 ### `skilltree update [name]`
 ```bash
@@ -435,7 +449,7 @@ ci-check:
 
 ```
 skilltree (TypeScript, compiled to single binary via Bun)
-  ├── Manifest Parser (skilltree.yaml)
+  ├── Manifest Parser (skilltree.yml)
   ├── Lockfile Manager (skilltree.lock)
   ├── Git Client (clone, fetch, checkout tags)
   ├── Dependency Scanner (regex + optional LLM)
@@ -451,7 +465,7 @@ skilltree (TypeScript, compiled to single binary via Bun)
 
 ## Scope
 
-skilltree manages **raw skills and agents** (SKILL.md files and agent .md files). It does NOT manage Claude Code plugins, MCP servers, or act as a marketplace.
+skilltree manages **raw skills, agents, and slash commands** (SKILL.md files plus single-file `.md` agents and commands). It does NOT manage Claude Code plugins, MCP servers, or act as a marketplace.
 
 Plugins coexist without conflict (different namespaces, different storage). For production Docker images, raw skills are the correct primitive.
 
@@ -459,7 +473,7 @@ Plugins coexist without conflict (different namespaces, different storage). For 
 
 ### Phase 1: Foundation
 - Project setup (TypeScript, Bun, CI)
-- `skilltree.yaml` parser/validator (deps, dev-deps, local, sources, name aliasing)
+- `skilltree.yml` parser/validator (deps, dev-deps, local, sources, name aliasing)
 - `skilltree init`, `skilltree add`
 - SKILL.md frontmatter parser
 

--- a/docs/specs/vendor.md
+++ b/docs/specs/vendor.md
@@ -19,7 +19,7 @@ The maintainer needs to ship the resolved skills inside the repo so `git clone` 
 
 **Vendor mode is a distribution mechanism, not a replacement for skilltree.**
 
-`skilltree.yaml` + `skilltree.lock` remain the source of truth. The vendored files are a derived snapshot — like a build output that happens to be committed. The maintainer can update deps, re-vendor, and push. The consumer never needs to know skilltree exists.
+`skilltree.yml` + `skilltree.lock` remain the source of truth. The vendored files are a derived snapshot — like a build output that happens to be committed. The maintainer can update deps, re-vendor, and push. The consumer never needs to know skilltree exists.
 
 ## How It Works
 
@@ -37,7 +37,7 @@ Copying 5 entities to .claude/
   linting@2.1.3          copied (transitive)
   code-review@2.1.3      copied (transitive)
 
-Updated skilltree.yaml (vendor: true)
+Updated skilltree.yml (vendor: true)
 Updated .gitignore (removed .claude/skills/, .claude/agents/)
 
 Vendor complete. Run `git add .claude/` to commit vendored files.
@@ -46,7 +46,7 @@ Vendor complete. Run `git add .claude/` to commit vendored files.
 What happens:
 1. Resolves deps (runs full resolution if no lockfile, lockfile-first otherwise — same as `install`)
 2. Copies **all** deps to `dev_install_path` (`.claude/` by default) as real files — no symlinks
-3. Sets `vendor: true` in `skilltree.yaml`
+3. Sets `vendor: true` in `skilltree.yml`
 4. Removes `.claude/skills/` and `.claude/agents/` from `.gitignore` so they can be committed
 5. Sets copied files read-only (`chmod 444`/`555`) — same as remote deps in normal mode
 
@@ -56,7 +56,7 @@ What happens:
 $ skilltree unvendor
 
 Deleted vendored files from .claude/skills/ and .claude/agents/
-Updated skilltree.yaml (vendor: false)
+Updated skilltree.yml (vendor: false)
 Updated .gitignore (added .claude/skills/, .claude/agents/)
 
 Run `skilltree install` to restore normal mode.
@@ -64,7 +64,7 @@ Run `skilltree install` to restore normal mode.
 
 What happens:
 1. Deletes all skilltree-managed files from `.claude/skills/` and `.claude/agents/` (tracked in lockfile)
-2. Sets `vendor: false` (or removes the field) in `skilltree.yaml`
+2. Sets `vendor: false` (or removes the field) in `skilltree.yml`
 3. Re-adds `.claude/skills/` and `.claude/agents/` to `.gitignore`
 4. Does NOT run `skilltree install` automatically — the user decides when
 
@@ -92,7 +92,7 @@ skilltree install                      # symlinks in .claude/, gitignored
 
 # Maintainer switches to vendor mode
 skilltree vendor                       # copies to .claude/, now committable
-git add .claude/ skilltree.yaml
+git add .claude/ skilltree.yml
 git commit -m "vendor skills"
 git push
 
@@ -117,7 +117,7 @@ git commit -m "bump python-coding to 2.2.0"
 ## Manifest Field
 
 ```yaml
-# skilltree.yaml
+# skilltree.yml
 name: my-bootstrap-project
 vendor: true                          # set by skilltree vendor/unvendor
 

--- a/skills/skilltree/SKILL.md
+++ b/skills/skilltree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skilltree
-description: Use the skilltree CLI to manage AI agent skill and agent dependencies. IMPORTANT — before adding, editing, or removing any skill or agent file, check if the project has a skilltree.yaml (skilltree-managed). If it does, use skilltree commands and only modify local skills in their origin repo, never installed artifacts.
+description: Use the skilltree CLI to manage AI agent skill and agent dependencies. IMPORTANT — before adding, editing, or removing any skill or agent file, check if the project has a skilltree.yml (skilltree-managed). If it does, use skilltree commands and only modify local skills in their origin repo, never installed artifacts.
 ---
 
 # skilltree — Dependency Manager for AI Agent Skills
@@ -25,7 +25,7 @@ Use this skill when:
 
 ## Key Concepts
 
-**Manifest (`skilltree.yaml`)** — Declares what you want: repo URLs, version constraints, local paths, and install targets. Two groups: `dependencies` (production) and `dev-dependencies` (local only).
+**Manifest (`skilltree.yml`)** — Declares what you want: repo URLs, version constraints, local paths, and install targets. Two groups: `dependencies` (production) and `dev-dependencies` (local only).
 
 **Lockfile (`skilltree.lock`)** — Records what you got: resolved versions, exact commit SHAs, integrity hashes. Checked into git for reproducibility.
 
@@ -41,36 +41,36 @@ Use this skill when:
 
 ## Origin-Manifest Resolution — Concepts Every Author and Consumer Should Know
 
-When a repo ships a `skilltree.yaml`, it becomes **self-describing**: downstream consumers (and skilltree itself) use that manifest as the authoritative map of what skills/agents the repo owns and where they live. This has concrete consequences:
+When a repo ships a `skilltree.yml`, it becomes **self-describing**: downstream consumers (and skilltree itself) use that manifest as the authoritative map of what skills/agents the repo owns and where they live. This has concrete consequences:
 
-**If you consume from a repo that has a `skilltree.yaml`:**
+**If you consume from a repo that has a `skilltree.yml`:**
 - You can omit `path:` on direct deps. Origin's manifest supplies it.
   ```yaml
   dependencies:
     task-builder:
       repo: github.com/org/analysi-backend
-      # no path: — skilltree reads origin's skilltree.yaml and fills it in
+      # no path: — skilltree reads origin's skilltree.yml and fills it in
   ```
 - If you *do* declare `path:` and it matches origin's declared path, skilltree warns "you can omit this." If it differs, you'll see an override warning suggesting `force_path: true` to silence it for intentional forks.
 - Transitive deps resolve automatically, even when the origin repo organizes skills at unconventional paths (e.g., `skills/source/<name>/`).
 - Cross-repo transitive deps work too: if origin's manifest references a third-party repo, skilltree clones and resolves it on demand (respecting origin's version constraint).
 
 **If you publish a repo that others will use as a skill source:**
-- Your `skilltree.yaml` is part of your **public contract**. Changes to `dependencies:` affect downstream consumers.
+- Your `skilltree.yml` is part of your **public contract**. Changes to `dependencies:` affect downstream consumers.
 - Skills declared under `dev-dependencies:` stay private — they will never be exposed to downstream consumers. A consumer transitively needing a dev-dep gets a clear error pointing you, the upstream author, as the fix site.
 - If you reorganize paths (e.g., move `skills/foo/` → `skills/src/foo/`) at a new tag, consumers pinning the old tag are unaffected; consumers pinning `*` or branches pick up the change via the lockfile.
 - Name conflicts between skills you own and skills you transitively expose: the consumer's manifest always wins over origin's manifest (tier 2 beats tier 4).
 
 **When origin's manifest doesn't apply:**
-- Origin has no `skilltree.yaml` → skilltree falls back to conventional paths (`skills/<name>/SKILL.md`, `agents/<name>.md`, `<name>/SKILL.md` at repo root). Old-school repos keep working with zero manifest authoring.
-- Origin's `skilltree.yaml` is malformed or doesn't declare the requested name → same fall-through.
+- Origin has no `skilltree.yml` → skilltree falls back to conventional paths (`skills/<name>/SKILL.md`, `agents/<name>.md`, `<name>/SKILL.md` at repo root). Old-school repos keep working with zero manifest authoring.
+- Origin's `skilltree.yml` is malformed or doesn't declare the requested name → same fall-through.
 - Origin's entry uses a `local:` path that's actually an absolute path on the author's machine (via a `source:` alias expanding to a filesystem path) → skipped silently; consumer gets the conventional probe.
 
-**Quick mental model:** a repo with `skilltree.yaml` is richer than one without. The manifest acts as an internal directory: "here's every skill I own, here's where each one lives, here's any third-party dep any of them needs." Consumers inherit that directory.
+**Quick mental model:** a repo with `skilltree.yml` is richer than one without. The manifest acts as an internal directory: "here's every skill I own, here's where each one lives, here's any third-party dep any of them needs." Consumers inherit that directory.
 
 ## Install Targets (Multi-Agent)
 
-skilltree supports multiple coding agents. The `install_targets` field in `skilltree.yaml` controls where skills are installed:
+skilltree supports multiple coding agents. The `install_targets` field in `skilltree.yml` controls where skills are installed:
 
 ```yaml
 install_targets:
@@ -88,11 +88,11 @@ Three scopes, fully independent:
 
 | Need | Mechanism | Install target | Committed to git |
 |------|-----------|---------------|-----------------|
-| Project needs a skill | `skilltree.yaml` | Per `install_targets` | No (gitignored) |
+| Project needs a skill | `skilltree.yml` | Per `install_targets` | No (gitignored) |
 | You want a skill everywhere | `~/.skilltree/global.yaml` | Per detected agents | No (personal) |
 | Ship skills without upstream access | `skilltree vendor` | Single target | Yes (committed) |
 
-**Global deps are a personal convenience, not a project dependency.** If the project *requires* a skill, put it in `skilltree.yaml`. Global is for "I always want this available" — teammates don't need your global deps.
+**Global deps are a personal convenience, not a project dependency.** If the project *requires* a skill, put it in `skilltree.yml`. Global is for "I always want this available" — teammates don't need your global deps.
 
 **Vendor mode is for distribution.** Copies all resolved deps as real files (no symlinks), removes them from `.gitignore`, and sets `vendor: true`. Consumers `git clone` and it works — no `skilltree install`, no upstream access needed. Vendor operates on a single target; use `--target` when multiple are configured. Fully reversible with `skilltree unvendor`.
 
@@ -109,11 +109,11 @@ To modify a skill: edit the source (in the skill's repo or local `skills/` direc
 
 ## CRITICAL: Modifying skills and agents
 
-Before modifying any skill or agent, check if the project uses skilltree (`skilltree.yaml` exists in the repo). If it does:
-- **Only modify local skills/agents** defined in the current repo (listed with `local:` in `skilltree.yaml`)
+Before modifying any skill or agent, check if the project uses skilltree (`skilltree.yml` exists in the repo). If it does:
+- **Only modify local skills/agents** defined in the current repo (listed with `local:` in `skilltree.yml`)
 - **Never modify installed (remote) skills** — they are managed artifacts from other repos
 - **To change a remote skill**, go to that skill's origin repo and modify it there
-- If you are unsure whether a skill is local or remote, check `skilltree.yaml` or run `skilltree list`
+- If you are unsure whether a skill is local or remote, check `skilltree.yml` or run `skilltree list`
 
 ## Environment
 

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -2,7 +2,7 @@
 
 ## `skilltree init`
 
-Create a new `skilltree.yaml` and update `.gitignore`.
+Create a new `skilltree.yml` and update `.gitignore`.
 
 ```bash
 skilltree init              # Project manifest
@@ -12,7 +12,7 @@ skilltree init --global     # Global manifest (~/.skilltree/global.yaml)
 **Flags:**
 - `-g, --global` — Initialize global dependencies instead of project
 
-Creates `skilltree.yaml` with project name from directory, adds `.claude/skills/` and `.claude/agents/` to `.gitignore`.
+Creates `skilltree.yml` with project name from directory, adds `.claude/skills/` and `.claude/agents/` to `.gitignore`.
 
 ## `skilltree add <name>`
 
@@ -44,7 +44,7 @@ skilltree add testing --dev --repo github.com/org/shared-skills --path skills/te
 - `-v, --version <constraint>` — Semver constraint (default: `"*"`)
 - `-l, --local <path>` — Local filesystem path (mutually exclusive with `--repo`/`--source`)
 - `-D, --dev` — Add to `dev-dependencies` instead of `dependencies`
-- `-t, --type <skill|agent>` — Override type inference
+- `-t, --type <skill|agent|command>` — Override type inference (commands install to `.claude/commands/`)
 - `--registry <name>` — When no `--repo`, resolve from this registry only (disambiguates multiple matches)
 - `-g, --global` — Add to global dependencies (~/.skilltree/global.yaml)
 
@@ -234,7 +234,7 @@ skilltree search python --json
 
 **Flags:**
 - `--registry <name>` — Search only one registry
-- `--type <skill|agent>` — Filter by entity type
+- `--type <skill|agent|command>` — Filter by entity type
 - `--json` — Machine-readable JSON output
 
 ## `skilltree info <name>`
@@ -277,7 +277,7 @@ skilltree vendor --dry-run    # Show plan without making changes
 - `--frozen` — Use lockfile only, error if out of sync
 - `-n, --dry-run` — Show plan without writing files
 
-Sets `vendor: true` in `skilltree.yaml` and removes `.claude/skills/` and `.claude/agents/` from `.gitignore`.
+Sets `vendor: true` in `skilltree.yml` and removes `.claude/skills/` and `.claude/agents/` from `.gitignore`.
 
 ## `skilltree unvendor`
 
@@ -310,7 +310,7 @@ skilltree targets list --global
 
 ## `skilltree targets add <target>`
 
-Add an agent or custom path to `install_targets` in `skilltree.yaml`.
+Add an agent or custom path to `install_targets` in `skilltree.yml`.
 
 | Flag | Description |
 |------|-------------|

--- a/skills/skilltree/references/workflows.md
+++ b/skills/skilltree/references/workflows.md
@@ -86,7 +86,7 @@ skilltree scan --llm ./skills/
 
 ## Use source shorthands
 
-In `skilltree.yaml`:
+In `skilltree.yml`:
 ```yaml
 sources:
   shared: github.com/org/shared-skills
@@ -163,7 +163,7 @@ skilltree targets add codex  # Now you can add more agents
 
 ## Set up global dependencies
 
-Global deps install to all detected agent homes — available in every project without adding to each `skilltree.yaml`.
+Global deps install to all detected agent homes — available in every project without adding to each `skilltree.yml`.
 
 ```bash
 # Initialize global manifest
@@ -182,14 +182,14 @@ skilltree verify --global
 skilltree deps tree --global
 ```
 
-**Important:** Global deps are personal convenience. If the project *requires* a skill, add it to the project's `skilltree.yaml`.
+**Important:** Global deps are personal convenience. If the project *requires* a skill, add it to the project's `skilltree.yml`.
 
 ## Use local sources (avoid repeating paths)
 
 When many skills come from the same local directory:
 
 ```yaml
-# skilltree.yaml or ~/.skilltree/global.yaml
+# skilltree.yml or ~/.skilltree/global.yaml
 sources:
   mine: ~/Projects/my-skills    # local source (starts with ~/)
 
@@ -213,7 +213,7 @@ When skills come from a private repo and consumers don't have access:
 skilltree vendor
 
 # .claude/ is now committed to git — consumers get it via git clone
-git add .claude/ skilltree.yaml skilltree.lock
+git add .claude/ skilltree.yml skilltree.lock
 git commit -m "vendor skills"
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ program
 	.option("-v, --version <constraint>", "Semver version constraint")
 	.option("-l, --local <path>", "Local filesystem path")
 	.option("-D, --dev", "Add as dev dependency")
-	.option("-t, --type <type>", "Entity type (skill or agent)")
+	.option("-t, --type <type>", "Entity type (skill, agent, or command)")
 	.option("--registry <name>", "Resolve from this registry (when no --repo)")
 	.option("-g, --global", "Add to global dependencies")
 	.action(async (name: string, opts) => {
@@ -245,7 +245,7 @@ program
 	.command("search <query>")
 	.description("Search registries for skills and agents")
 	.option("--registry <name>", "Search only one registry")
-	.option("-t, --type <type>", "Filter by entity type (skill or agent)")
+	.option("-t, --type <type>", "Filter by entity type (skill, agent, or command)")
 	.option("--json", "Output results as JSON")
 	.action(async (query: string, opts) => {
 		await searchCommand(query, {

--- a/src/commands/index-cmd.ts
+++ b/src/commands/index-cmd.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 import YAML from "yaml";
+import { mdFileType } from "../core/entity-type.js";
 import { parseFrontmatter } from "../core/frontmatter.js";
 import { SKIP_MD_FILES } from "../core/registry-scanner.js";
 import type { IndexEntry } from "../types.js";
@@ -33,7 +34,10 @@ export async function indexCommand(opts: { check?: boolean }, dir?: string): Pro
 	await writeFile(join(baseDir, "skillkit-index.yaml"), yamlContent, "utf-8");
 	const skills = entries.filter((e) => e.type === "skill").length;
 	const agents = entries.filter((e) => e.type === "agent").length;
-	console.log(`Scanned ${entries.length} entities (${skills} skills, ${agents} agents)`);
+	const commands = entries.filter((e) => e.type === "command").length;
+	console.log(
+		`Scanned ${entries.length} entities (${skills} skills, ${agents} agents, ${commands} commands)`,
+	);
 	console.log("Wrote skillkit-index.yaml");
 }
 
@@ -103,7 +107,7 @@ async function tryAddAgent(
 		if (!fm || (!fm.name && !fm.skills)) return;
 		const relPath = relative(baseDir, fullPath);
 		const name = fm.name ?? basename(item, ".md");
-		const entry: IndexEntry = { name, type: "agent", path: relPath };
+		const entry: IndexEntry = { name, type: mdFileType(relPath), path: relPath };
 		if (fm.description) entry.description = fm.description;
 		entries.push(entry);
 	} catch {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -156,15 +156,22 @@ async function readlineAsk(question: string): Promise<string> {
 function printDiscovered(entries: LocalEntry[]): void {
 	const skills = entries.filter((e) => e.type === "skill");
 	const agents = entries.filter((e) => e.type === "agent");
+	const commands = entries.filter((e) => e.type === "command");
 
-	console.log(
-		`\nFound ${skills.length} skill${skills.length === 1 ? "" : "s"} and ${agents.length} agent${agents.length === 1 ? "" : "s"}:\n`,
-	);
+	const skillStr = `${skills.length} ${pluralize("skill", skills.length)}`;
+	const agentStr = `${agents.length} ${pluralize("agent", agents.length)}`;
+	const commandStr = `${commands.length} ${pluralize("command", commands.length)}`;
+	const summary =
+		commands.length > 0
+			? `${skillStr}, ${agentStr} and ${commandStr}`
+			: `${skillStr} and ${agentStr}`;
+	console.log(`\nFound ${summary}:\n`);
 
 	let idx = 1;
 	for (const section of [
 		{ label: "Skills", items: skills },
 		{ label: "Agents", items: agents },
+		{ label: "Commands", items: commands },
 	]) {
 		if (section.items.length === 0) continue;
 		console.log(`${section.label}:`);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { isSingleFileEntity } from "../core/entity-type.js";
 import { getDeclaredDeps, parseFrontmatter } from "../core/frontmatter.js";
 import { ensureCached, getCommitSha } from "../core/git.js";
 import type { ResolvedEntity } from "../core/graph.js";
@@ -342,10 +343,10 @@ function validateFrozenLocalDeps(
 		try {
 			const expandedLocal = expandTilde(manifestDep.local);
 			const localPath = expandedLocal.startsWith("/") ? expandedLocal : `${dir}/${expandedLocal}`;
-			const skillMdPath = entry.type === "skill" ? `${localPath}/SKILL.md` : localPath;
+			const fmPath = isSingleFileEntity(entry.type) ? localPath : `${localPath}/SKILL.md`;
 			// readFile is sync-compatible here since we imported it at the top
 			const fs = require("node:fs") as typeof import("node:fs");
-			const content = fs.readFileSync(skillMdPath, "utf-8");
+			const content = fs.readFileSync(fmPath, "utf-8");
 			const fm = parseFrontmatter(content);
 			const fmDeps = (fm ? getDeclaredDeps(fm) : []).filter((d) => d !== (entry.name ?? key));
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -154,6 +154,7 @@ export async function registryUpdateCommand(
 
 		const skills = entities.filter((e) => e.type === "skill").length;
 		const agents = entities.filter((e) => e.type === "agent").length;
+		const commands = entities.filter((e) => e.type === "command").length;
 
 		const index: RegistryIndex = {
 			registry: reg.name,
@@ -163,9 +164,9 @@ export async function registryUpdateCommand(
 		};
 		await writeRegistryIndex(index, cacheDir);
 
-		console.log(
-			pc.green(`${entities.length} entities`) + dim(` (${skills} skills, ${agents} agents)`),
-		);
+		const breakdown = [`${skills} skills`, `${agents} agents`];
+		if (commands > 0) breakdown.push(`${commands} commands`);
+		console.log(pc.green(`${entities.length} entities`) + dim(` (${breakdown.join(", ")})`));
 	}
 }
 

--- a/src/core/entity-type.ts
+++ b/src/core/entity-type.ts
@@ -1,0 +1,45 @@
+/**
+ * Helpers that classify entities by their EntityType.
+ *
+ * Centralized so that adding a fourth resource type (or changing the
+ * directory naming convention) is a one-file edit instead of a sweep
+ * across the install path, the resolvers, the scanners, and the
+ * gitignore generator.
+ *
+ * Lives in its own module rather than `paths.ts` because it bridges
+ * `EntityType` (a domain concept from `types.ts`) and the path/layout
+ * conventions — neither side owns the logic outright.
+ */
+
+import type { EntityType } from "../types.js";
+
+/**
+ * Disambiguate a single `.md` artifact between an agent and a command
+ * by looking at its path. Files under any `commands/` segment are
+ * Claude Code slash-commands; everything else defaults to agent —
+ * matching prior behavior for non-command `.md` files.
+ */
+export function mdFileType(path: string): "agent" | "command" {
+	return path.split("/").includes("commands") ? "command" : "agent";
+}
+
+/**
+ * True when the entity's source artifact is a single `.md` file rather
+ * than a directory. Skills are directories containing `SKILL.md`; agents
+ * and commands are single `.md` files. Use at every site that branches
+ * "directory vs single file" — silently breaks if a future entity type
+ * is added without updating this predicate.
+ */
+export function isSingleFileEntity(type: EntityType): boolean {
+	return type === "agent" || type === "command";
+}
+
+/**
+ * Conventional-probe paths for resolving a bare entity name to a path
+ * within a repo (or repo-like tree). Order matters — first match wins,
+ * and the order encodes the "skills > agents > commands > root" priority
+ * the resolver has used since the original layout.
+ */
+export function conventionalCandidates(name: string): string[] {
+	return [`skills/${name}`, `agents/${name}.md`, `commands/${name}.md`, name];
+}

--- a/src/core/gitignore.ts
+++ b/src/core/gitignore.ts
@@ -56,8 +56,13 @@ export async function removeGitignoreEntries(dir: string, entries: string[]): Pr
 
 /**
  * Get the gitignore entries for a given install path.
+ *
+ * Returns one entry per managed resource directory (`skills/`, `agents/`,
+ * `commands/`) so installed artifacts stay out of git. The function name
+ * is kept for backwards compatibility — it covers all three resource
+ * types, not just skills+agents.
  */
 export function getSkillAgentIgnoreEntries(installPath: string): string[] {
 	const base = installPath.replace(/\/$/, "");
-	return [`${base}/skills/`, `${base}/agents/`];
+	return [`${base}/skills/`, `${base}/agents/`, `${base}/commands/`];
 }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -9,6 +9,7 @@ import type {
 	Manifest,
 } from "../types.js";
 import { isLocalDependency, isRemoteDependency } from "../types.js";
+import { conventionalCandidates, isSingleFileEntity, mdFileType } from "./entity-type.js";
 import { MANIFEST_NEW, MANIFEST_NEW_ALT } from "./filenames.js";
 import { getDeclaredDeps, parseFrontmatter } from "./frontmatter.js";
 import {
@@ -250,8 +251,8 @@ async function readLocalFrontmatter(
 	entityName: string,
 ): Promise<string[]> {
 	try {
-		const skillMdPath = type === "skill" ? `${localPath}/SKILL.md` : localPath;
-		const content = await readFile(skillMdPath, "utf-8");
+		const fmPath = isSingleFileEntity(type) ? localPath : `${localPath}/SKILL.md`;
+		const content = await readFile(fmPath, "utf-8");
 		const fm = parseFrontmatter(content);
 		return (fm ? getDeclaredDeps(fm) : []).filter((d) => d !== entityName);
 	} catch {
@@ -267,8 +268,8 @@ async function readRemoteFrontmatter(
 	entityName: string,
 ): Promise<string[]> {
 	try {
-		const skillMdFile = type === "skill" ? `${entityPath}/SKILL.md` : entityPath;
-		const content = await readFileAtRef(cachePath, ref, stripDotSlash(skillMdFile));
+		const fmFile = isSingleFileEntity(type) ? entityPath : `${entityPath}/SKILL.md`;
+		const content = await readFileAtRef(cachePath, ref, stripDotSlash(fmFile));
 		const fm = parseFrontmatter(content);
 		return (fm ? getDeclaredDeps(fm) : []).filter((d) => d !== entityName);
 	} catch {
@@ -446,9 +447,10 @@ function checkExistingResolution(
 		if (existing && parentGroup === "prod" && existing.group === "dev") {
 			existing.group = "prod";
 		}
-		if (parentType === "skill" && existing?.type === "agent") {
+		if (parentType === "skill" && existing && existing.type !== "skill") {
+			const parentName = state.entities.get(parentCompositeKey)?.name;
 			state.errors.push(
-				`Error: Invalid dependency type\n\n  skill:${state.entities.get(parentCompositeKey)?.name} cannot depend on agent:${depName}.\n  Skills can only depend on other skills.\n\nFix: Remove ${depName} from ${state.entities.get(parentCompositeKey)?.name}'s dependencies.`,
+				`Error: Invalid dependency type\n\n  skill:${parentName} cannot depend on ${existing.type}:${depName}.\n  Skills can only depend on other skills.\n\nFix: Remove ${depName} from ${parentName}'s dependencies.`,
 			);
 		}
 	}
@@ -736,8 +738,7 @@ async function inferDirectDepPath(
 	}
 
 	// Tier 2: conventional probe.
-	const candidates = [`skills/${entityName}`, `agents/${entityName}.md`, entityName];
-	for (const candidate of candidates) {
+	for (const candidate of conventionalCandidates(entityName)) {
 		try {
 			const probeFile = candidate.endsWith(".md") ? candidate : `${candidate}/SKILL.md`;
 			await readFileAtRef(resolution.cachePath, ref, probeFile);
@@ -786,9 +787,8 @@ async function tryResolveFromSameRepo(
 	if (!resolution) return false;
 
 	const ref = resolution.tag ?? resolution.commit;
-	const candidates = [`skills/${depName}`, `agents/${depName}.md`, depName];
 
-	for (const candidatePath of candidates) {
+	for (const candidatePath of conventionalCandidates(depName)) {
 		try {
 			const normalizedPath = stripDotSlash(candidatePath);
 			await readFileAtRef(
@@ -860,6 +860,7 @@ async function resolveFromLocalSource(
 	const candidates: Array<{ path: string; type: EntityType }> = [
 		{ path: `${sourceDir}/skills/${depName}`, type: "skill" },
 		{ path: `${sourceDir}/agents/${depName}.md`, type: "agent" },
+		{ path: `${sourceDir}/commands/${depName}.md`, type: "command" },
 		{ path: `${sourceDir}/${depName}`, type: "skill" },
 	];
 
@@ -876,10 +877,10 @@ async function resolveFromLocalSource(
 				await resolveEntity(depName, depName, syntheticDep, group, state);
 				return true;
 			}
-			if (candidate.type === "agent" && stats.isFile()) {
+			if ((candidate.type === "agent" || candidate.type === "command") && stats.isFile()) {
 				const syntheticDep: LocalDependency = {
 					local: candidate.path,
-					type: "agent",
+					type: candidate.type,
 					_sourceDir: sourceDir,
 				};
 				await resolveEntity(depName, depName, syntheticDep, group, state);
@@ -899,8 +900,8 @@ function validateTypeConstraints(state: ResolutionState): void {
 			const depKey = state.resolutionContext.get(depName);
 			if (!depKey) continue;
 			const dep = state.entities.get(depKey);
-			if (dep?.type === "agent") {
-				const errMsg = `Error: Invalid dependency type\n\n  skill:${entity.name} cannot depend on agent:${depName}.\n  Skills can only depend on other skills.\n\nFix: Remove ${depName} from ${entity.name}'s dependencies.`;
+			if (dep && dep.type !== "skill") {
+				const errMsg = `Error: Invalid dependency type\n\n  skill:${entity.name} cannot depend on ${dep.type}:${depName}.\n  Skills can only depend on other skills.\n\nFix: Remove ${depName} from ${entity.name}'s dependencies.`;
 				if (!state.errors.includes(errMsg)) {
 					state.errors.push(errMsg);
 				}
@@ -991,7 +992,7 @@ function detectCycles(
 async function inferType(localPath: string): Promise<EntityType> {
 	try {
 		const stats = await stat(localPath);
-		if (stats.isFile() && localPath.endsWith(".md")) return "agent";
+		if (stats.isFile() && localPath.endsWith(".md")) return mdFileType(localPath);
 		if (stats.isDirectory()) {
 			try {
 				await stat(`${localPath}/SKILL.md`);
@@ -1027,7 +1028,7 @@ export async function inferTypeFromGit(
 		}
 
 		if (entry.objectType === "blob" && entry.name.endsWith(".md")) {
-			return { type: "agent", resolvedPath: normalizedPath };
+			return { type: mdFileType(normalizedPath), resolvedPath: normalizedPath };
 		}
 
 		return { type: "skill", resolvedPath: normalizedPath };
@@ -1043,7 +1044,8 @@ export async function inferTypeFromGit(
 }
 
 function fallbackType(path: string): { type: EntityType; resolvedPath: string } {
-	return { type: path.endsWith(".md") ? "agent" : "skill", resolvedPath: path };
+	const type: EntityType = path.endsWith(".md") ? mdFileType(path) : "skill";
+	return { type, resolvedPath: path };
 }
 
 async function findGitEntry(

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -13,7 +13,8 @@ import {
 } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import simpleGit from "simple-git";
-import type { Lockfile } from "../types.js";
+import type { EntityType, Lockfile } from "../types.js";
+import { isSingleFileEntity } from "./entity-type.js";
 import { readFileAtRef } from "./git.js";
 import type { ResolvedEntity } from "./graph.js";
 import { stripDotSlash } from "./paths.js";
@@ -92,10 +93,19 @@ function basename(path: string): string {
 
 /**
  * Get the install target path for an entity or lockfile entry.
+ *
+ * Commands install as single `.md` files under `commands/` (sibling to
+ * `agents/` and `skills/`) — matching Claude Code's slash-command layout.
  */
-export function getTargetPath(entity: { name: string; type: string }, installBase: string): string {
+export function getTargetPath(
+	entity: { name: string; type: EntityType },
+	installBase: string,
+): string {
 	if (entity.type === "agent") {
 		return join(installBase, "agents", `${entity.name}.md`);
+	}
+	if (entity.type === "command") {
+		return join(installBase, "commands", `${entity.name}.md`);
 	}
 	return join(installBase, "skills", entity.name);
 }
@@ -176,6 +186,7 @@ export async function executeInstall(
 	const installBase = options.installPath ?? join(projectDir, ".claude");
 	await mkdir(join(installBase, "skills"), { recursive: true });
 	await mkdir(join(installBase, "agents"), { recursive: true });
+	await mkdir(join(installBase, "commands"), { recursive: true });
 
 	for (const item of plan.toInstall) {
 		const { entity, action, targetPath } = item;
@@ -235,10 +246,10 @@ async function prepareTarget(
 async function copyEntityFiles(
 	sourcePath: string,
 	targetPath: string,
-	entityType: string,
+	entityType: EntityType,
 ): Promise<void> {
-	if (entityType === "agent") {
-		// Single file copy
+	if (isSingleFileEntity(entityType)) {
+		// Single file copy (agents and commands)
 		await mkdir(dirname(targetPath), { recursive: true });
 		await cp(sourcePath, targetPath);
 	} else {
@@ -261,7 +272,7 @@ async function copyFromGitCache(entity: ResolvedEntity, targetPath: string): Pro
 	const path = stripDotSlash(entity.path);
 
 	try {
-		if (entity.type === "agent") {
+		if (isSingleFileEntity(entity.type)) {
 			await mkdir(dirname(targetPath), { recursive: true });
 			const content = await readFileAtRef(entity.cachePath, ref, path);
 			await writeFile(targetPath, content, "utf-8");

--- a/src/core/registry-scanner.ts
+++ b/src/core/registry-scanner.ts
@@ -2,6 +2,7 @@ import { basename, dirname } from "node:path";
 import simpleGit from "simple-git";
 import YAML from "yaml";
 import type { EntityType, IndexEntry } from "../types.js";
+import { mdFileType } from "./entity-type.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { readFileAtRef } from "./git.js";
 
@@ -114,7 +115,7 @@ export async function dynamicScanRepo(repoDir: string): Promise<IndexEntry[]> {
 				const fm = parseFrontmatter(content);
 				if (!fm || (!fm.name && !fm.skills)) return null;
 				const name = fm.name ?? basename(mdPath, ".md");
-				const entry: IndexEntry = { name, type: "agent", path: mdPath };
+				const entry: IndexEntry = { name, type: mdFileType(mdPath), path: mdPath };
 				if (fm.description) entry.description = fm.description;
 				return entry;
 			} catch {

--- a/src/core/repo-scanner.ts
+++ b/src/core/repo-scanner.ts
@@ -63,6 +63,18 @@ async function walk(rootDir: string, currentDir: string, out: LocalEntry[]): Pro
 		return;
 	}
 
+	// If this directory IS a skill (has a SKILL.md), register it once and
+	// stop descending. Internal `.md` files belong to the skill, not as
+	// independent agents/commands — without this stop, a helper file at
+	// `skills/foo/commands/helper.md` would be mis-classified as a
+	// top-level command (mdFileType matches the segment anywhere in the
+	// path). Mirrors the behavior of `tryAddSkill` in `commands/index-cmd.ts`.
+	if (dirents.some((d) => d.isFile() && d.name === "SKILL.md")) {
+		const entry = await classifyMdFile(rootDir, join(currentDir, "SKILL.md"), "SKILL.md");
+		if (entry) out.push(entry);
+		return;
+	}
+
 	for (const dirent of dirents) {
 		const fullPath = join(currentDir, dirent.name);
 

--- a/src/core/repo-scanner.ts
+++ b/src/core/repo-scanner.ts
@@ -2,6 +2,7 @@ import type { Dirent } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { basename, dirname, join, relative, sep } from "node:path";
 import type { EntityType } from "../types.js";
+import { mdFileType } from "./entity-type.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { SKIP_MD_FILES } from "./registry-scanner.js";
 
@@ -118,13 +119,13 @@ async function classifyMdFile(
 		return entry;
 	}
 
-	// Agent candidate — require a name in frontmatter. Without one we have
-	// no stable identifier and the file is probably not an agent anyway.
+	// Agent or command candidate — require a name in frontmatter. Without one
+	// we have no stable identifier and the file is probably neither.
 	if (!fm?.name) return null;
 
 	const entry: LocalEntry = {
 		name: fm.name,
-		type: "agent",
+		type: mdFileType(relPath),
 		path: relPath,
 	};
 	if (fm.description) entry.description = fm.description;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type EntityType = "skill" | "agent";
+export type EntityType = "skill" | "agent" | "command";
 export type DependencyGroup = "prod" | "dev";
 
 export interface RemoteDependency {

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -94,6 +94,46 @@ describe("addCommand", () => {
 		expect((manifest.dependencies?.["my-skill"] as { version: string }).version).toBe("*");
 	});
 
+	test("adds remote dependency with --type command (Issue #11)", async () => {
+		// Slash commands are a third resource type alongside skills and agents.
+		// `add --type command` must round-trip the explicit type so the resolver
+		// installs to commands/ rather than guessing from the file extension.
+		const dir = await setup();
+		await addCommand(
+			"review",
+			{
+				repo: "github.com/user/cmds",
+				path: "commands/review.md",
+				type: "command",
+			},
+			dir,
+		);
+
+		const manifest = await readManifest(dir);
+		const dep = manifest.dependencies?.review;
+		expect(dep).toBeDefined();
+		expect((dep as { type: string }).type).toBe("command");
+		expect((dep as { path: string }).path).toBe("commands/review.md");
+	});
+
+	test("adds local command dependency", async () => {
+		const dir = await setup();
+		const cmdsDir = join(dir, "commands");
+		await mkdir(cmdsDir, { recursive: true });
+		await writeFile(
+			join(cmdsDir, "review.md"),
+			"---\nname: review\ndescription: Review the diff\n---\nbody\n",
+		);
+
+		await addCommand("review", { local: "./commands/review.md", type: "command" }, dir);
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.review).toEqual({
+			local: "./commands/review.md",
+			type: "command",
+		});
+	});
+
 	test("errors when --repo and --source used together", async () => {
 		const dir = await setup();
 		await expect(

--- a/tests/core/command-type-bugs.test.ts
+++ b/tests/core/command-type-bugs.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Hypothesis-driven probes for the command-type rollout (Issue #11).
+ *
+ * Each test states a suspected bug and either confirms or refutes it.
+ * Confirmed bugs become regression tests after the fix lands; refuted
+ * hypotheses stay as guard-rails so the property can't silently break.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mdFileType } from "../../src/core/entity-type.js";
+import { resolveAll } from "../../src/core/graph.js";
+import { scanLocalRepo } from "../../src/core/repo-scanner.js";
+
+let tempDir: string;
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), prefix));
+	return tempDir;
+}
+
+/**
+ * H1 — A `commands/` segment ANYWHERE in a path is treated as the
+ * top-level commands bucket. A skill that organizes internal helper
+ * `.md` files under `<skill>/commands/` would have those helpers
+ * mis-classified as slash commands.
+ */
+describe("H1: mid-path commands/ segment false positive", () => {
+	test("mdFileType returns 'command' for a deeply nested commands/ segment", () => {
+		// Pure unit-level confirmation that the helper itself doesn't
+		// distinguish "top-level commands/" from "commands/ inside a skill".
+		expect(mdFileType("skills/my-skill/commands/helper.md")).toBe("command");
+		expect(mdFileType("a/b/c/commands/d/e.md")).toBe("command");
+	});
+
+	test("scanLocalRepo does NOT recurse into skill directories — internal helpers stay scoped", async () => {
+		// Regression for H1: previously, a skill that used an internal
+		// `commands/` subdir for helper docs (plausible authoring pattern —
+		// the `references/` convention exists but isn't enforced) would have
+		// each helper mis-classified as a top-level slash command. The fix
+		// is for `walk()` to stop descending when it sees a SKILL.md, the
+		// same way `index-cmd.ts` already did.
+		const dir = await makeTempDir("skilltree-h1-");
+		await mkdir(join(dir, "skills", "my-skill", "commands"), { recursive: true });
+		await writeFile(
+			join(dir, "skills", "my-skill", "SKILL.md"),
+			"---\nname: my-skill\ndescription: A skill with internal helpers\n---\nBody\n",
+		);
+		await writeFile(
+			join(dir, "skills", "my-skill", "commands", "helper.md"),
+			"---\nname: helper\ndescription: An internal helper doc\n---\nBody\n",
+		);
+
+		const entries = await scanLocalRepo(dir);
+		// Only the skill should surface — the helper is internal to it.
+		expect(entries.map((e) => e.name)).toEqual(["my-skill"]);
+		expect(entries.find((e) => e.name === "helper")).toBeUndefined();
+	});
+
+	test("an explicit dep at a path inside a skill is still classified by mdFileType (not the scanner)", async () => {
+		// mdFileType keeps its loose definition because explicit consumer
+		// declarations are intentional — if you `add foo --path
+		// skills/x/commands/y.md`, you really do mean "extract this single
+		// file and install it as a command". The auto-discovery path is the
+		// one that needs the stop-at-skill guard, not type inference.
+		expect(mdFileType("skills/x/commands/y.md")).toBe("command");
+	});
+});
+
+/**
+ * H2 — Same-name skill and command. Different install dirs, no FS
+ * collision, but the resolution context can only point to one entity.
+ * Per the existing aliasing rule (registerEntity in graph.ts), skill
+ * always wins. Verify this still works for skill-vs-command, and that
+ * both entities still install.
+ */
+describe("H2: same-name skill + command collision", () => {
+	test("both install when declared as separate manifest entries with the same name", async () => {
+		const dir = await makeTempDir("skilltree-h2-");
+		await mkdir(join(dir, "skills", "review"), { recursive: true });
+		await writeFile(
+			join(dir, "skills", "review", "SKILL.md"),
+			"---\nname: review\ndescription: Review skill\n---\nBody\n",
+		);
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(
+			join(dir, "commands", "review.md"),
+			"---\nname: review\ndescription: Review command\n---\nBody\n",
+		);
+
+		// YAML keys must be unique, so alias the command via a different key
+		// + name override (the documented aliasing pattern from spec.md).
+		const result = await resolveAll(
+			{
+				dependencies: {
+					review: { local: "./skills/review", type: "skill" },
+					"review-cmd": { local: "./commands/review.md", type: "command", name: "review" },
+				},
+			},
+			dir,
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.entities.has("skill:review")).toBe(true);
+		expect(result.entities.has("command:review")).toBe(true);
+	});
+
+	test("a transitive `dependencies: [review]` from an agent resolves to the skill, not the command", async () => {
+		// The aliasing precedence rule from registerEntity says skill wins
+		// in the resolution context. An agent saying `dependencies: [review]`
+		// when both a skill and command named "review" exist must point at
+		// the skill (and obviously, the skill→skill rule means the inverse
+		// would be a constraint error anyway).
+		const dir = await makeTempDir("skilltree-h2b-");
+		await mkdir(join(dir, "skills", "review"), { recursive: true });
+		await writeFile(join(dir, "skills", "review", "SKILL.md"), "---\nname: review\n---\nBody\n");
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(join(dir, "commands", "review.md"), "---\nname: review\n---\nBody\n");
+		await mkdir(join(dir, "agents"), { recursive: true });
+		await writeFile(
+			join(dir, "agents", "inspector.md"),
+			"---\nname: inspector\ndependencies:\n  - review\n---\nBody\n",
+		);
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					inspector: { local: "./agents/inspector.md", type: "agent" },
+					review: { local: "./skills/review", type: "skill" },
+					"review-cmd": { local: "./commands/review.md", type: "command", name: "review" },
+				},
+			},
+			dir,
+		);
+
+		expect(result.errors).toEqual([]);
+
+		// inspector's transitive resolved to the skill (skill wins), confirmed
+		// by the topo edge: skill must come before agent. The command can sit
+		// anywhere relative to the agent — it has no edge to either.
+		const order = result.installOrder;
+		expect(order.indexOf("skill:review")).toBeLessThan(order.indexOf("agent:inspector"));
+	});
+});
+
+/**
+ * H3 — The skill→non-skill type-constraint error is pushed from two
+ * places: `checkExistingResolution` (transitive path) and
+ * `validateTypeConstraints` (post-pass). validateTypeConstraints has a
+ * `state.errors.includes(errMsg)` dedup guard. checkExistingResolution
+ * doesn't. Confirm whether the same edge produces one error or two.
+ */
+describe("H3: type-constraint error duplication", () => {
+	test("a skill→command edge produces exactly one error message", async () => {
+		const dir = await makeTempDir("skilltree-h3-");
+		await mkdir(join(dir, "my-skill"), { recursive: true });
+		await writeFile(
+			join(dir, "my-skill", "SKILL.md"),
+			"---\nname: my-skill\ndependencies:\n  - review\n---\nBody\n",
+		);
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(join(dir, "commands", "review.md"), "---\nname: review\n---\nBody\n");
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					"my-skill": { local: "./my-skill" },
+					review: { local: "./commands/review.md", type: "command" },
+				},
+			},
+			dir,
+		);
+
+		// Count how many error strings mention the same edge.
+		const edgeErrors = result.errors.filter(
+			(e) => e.includes("skill:my-skill") && e.includes("command:review"),
+		);
+		expect(edgeErrors.length).toBe(1);
+	});
+});
+
+/**
+ * H6 — `--scan` (scanLocalRepo) must not pick up installed artifacts
+ * under `.claude/commands/` as if they were sources. The walker skips
+ * hidden directories; verify that property still holds for the new
+ * commands/ bucket.
+ */
+describe("H6: scanLocalRepo skips installed commands under .claude/", () => {
+	test("an installed .claude/commands/review.md is NOT discovered as a source", async () => {
+		const dir = await makeTempDir("skilltree-h6-");
+		await mkdir(join(dir, ".claude", "commands"), { recursive: true });
+		await writeFile(
+			join(dir, ".claude", "commands", "review.md"),
+			"---\nname: review\n---\nBody\n",
+		);
+		// Also add a real source command at the top level for contrast.
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(join(dir, "commands", "lint.md"), "---\nname: lint\n---\nBody\n");
+
+		const entries = await scanLocalRepo(dir);
+		const names = entries.map((e) => e.name);
+
+		expect(names).toContain("lint");
+		expect(names).not.toContain("review");
+	});
+});

--- a/tests/core/command-type.test.ts
+++ b/tests/core/command-type.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Coverage for the `command` EntityType (Issue #11).
+ *
+ * Slash commands are a third first-class resource alongside skills and
+ * agents. Like agents they're single `.md` files; unlike agents they
+ * install under `commands/` (sibling to `skills/` and `agents/`),
+ * matching Claude Code's slash-command layout.
+ *
+ * These tests pin down the cross-cutting behavior so the type doesn't
+ * regress to "agent-with-a-rename":
+ *  - install path is `commands/<name>.md`
+ *  - install copies a single file (not a directory tree)
+ *  - type inference picks `command` for `.md` files under any
+ *    `commands/` segment, both on local disk and inside a git tree
+ *  - repo and registry scanners label discovered files correctly
+ *  - the gitignore helper covers `commands/` alongside skills+agents
+ *  - lockfile round-trip preserves `type: command`
+ *  - skills cannot depend on commands (extends the existing
+ *    skill→agent invariant)
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit from "simple-git";
+import { getSkillAgentIgnoreEntries } from "../../src/core/gitignore.js";
+import type { ResolvedEntity } from "../../src/core/graph.js";
+import { inferTypeFromGit, resolveAll } from "../../src/core/graph.js";
+import { executeInstall, getTargetPath, planInstall } from "../../src/core/installer.js";
+import { buildLockfile, parseLockfile, serializeLockfile } from "../../src/core/lockfile.js";
+import { dynamicScanRepo } from "../../src/core/registry-scanner.js";
+import { scanLocalRepo } from "../../src/core/repo-scanner.js";
+import { createTestRepo } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), prefix));
+	return tempDir;
+}
+
+/**
+ * Shared mixed-types fixture: a real git repo at tag v1.0.0 with a
+ * command and an agent. Two different consumers (inferTypeFromGit,
+ * dynamicScanRepo) want the same shape, and rebuilding a git tree per
+ * test is expensive — fork+exec dominates the test runtime. Hoisted to
+ * a beforeAll so the single bare clone amortizes across both tests.
+ */
+let mixedFixtureDir: string;
+let mixedFixtureBare: string;
+beforeAll(async () => {
+	mixedFixtureDir = await mkdtemp(join(tmpdir(), "skilltree-cmd-fixture-"));
+	const repoDir = await createTestRepo(
+		mixedFixtureDir,
+		"types-repo",
+		[
+			{ path: "commands/review.md", name: "review", isAgent: true },
+			{ path: "agents/inspector.md", name: "inspector", isAgent: true },
+		],
+		"v1.0.0",
+	);
+	mixedFixtureBare = join(mixedFixtureDir, "bare.git");
+	await simpleGit().clone(repoDir, mixedFixtureBare, ["--bare"]);
+});
+
+afterAll(async () => {
+	if (mixedFixtureDir) {
+		await rm(mixedFixtureDir, { recursive: true, force: true });
+	}
+});
+
+describe("getTargetPath for commands", () => {
+	test("returns commands/<name>.md for command entities", () => {
+		const entity: ResolvedEntity = {
+			key: "my-cmd",
+			name: "my-cmd",
+			type: "command",
+			group: "prod",
+			path: "./commands/my-cmd.md",
+			commit: "HEAD",
+			local: true,
+			dependencies: [],
+		};
+		expect(getTargetPath(entity, "/project/.claude")).toBe("/project/.claude/commands/my-cmd.md");
+	});
+
+	test("commands and agents do not collide in the install layout", () => {
+		// Same name, different type — must not produce the same path.
+		const cmd: ResolvedEntity = {
+			key: "review",
+			name: "review",
+			type: "command",
+			group: "prod",
+			path: "./commands/review.md",
+			commit: "HEAD",
+			local: true,
+			dependencies: [],
+		};
+		const agent: ResolvedEntity = {
+			key: "review",
+			name: "review",
+			type: "agent",
+			group: "prod",
+			path: "./agents/review.md",
+			commit: "HEAD",
+			local: true,
+			dependencies: [],
+		};
+		expect(getTargetPath(cmd, "/p/.claude")).not.toBe(getTargetPath(agent, "/p/.claude"));
+	});
+});
+
+describe("executeInstall for commands", () => {
+	test("copies a command as a single .md file under commands/", async () => {
+		const dir = await makeTempDir("skilltree-cmd-install-");
+		const cmdsDir = join(dir, "commands");
+		await mkdir(cmdsDir, { recursive: true });
+		await writeFile(
+			join(cmdsDir, "review.md"),
+			"---\nname: review\ndescription: Review the diff\n---\n\nReview body\n",
+		);
+
+		const installBase = join(dir, "build", ".claude");
+		const entities = new Map<string, ResolvedEntity>([
+			[
+				"command:review",
+				{
+					key: "review",
+					name: "review",
+					type: "command",
+					group: "prod",
+					path: "./commands/review.md",
+					commit: "HEAD",
+					local: true,
+					dependencies: [],
+				},
+			],
+		]);
+
+		const plan = await planInstall(entities, ["command:review"], installBase, {
+			installPath: installBase,
+		});
+		const integrityMap = await executeInstall(plan, dir, { installPath: installBase });
+
+		const targetPath = join(installBase, "commands", "review.md");
+		const stats = await lstat(targetPath);
+		expect(stats.isFile()).toBe(true);
+		expect(integrityMap.size).toBe(1);
+
+		const content = await readFile(targetPath, "utf-8");
+		expect(content).toContain("name: review");
+	});
+
+	test("creates the commands/ directory even when no commands install", async () => {
+		// The install loop unconditionally creates skills/, agents/, and now
+		// commands/ — so consumers always have a stable layout to drop files
+		// into manually if they want.
+		const dir = await makeTempDir("skilltree-cmd-mkdir-");
+		const installBase = join(dir, ".claude");
+		const plan = await planInstall(new Map(), [], installBase, {});
+		await executeInstall(plan, dir, {});
+		const stats = await lstat(join(installBase, "commands"));
+		expect(stats.isDirectory()).toBe(true);
+	});
+});
+
+describe("inferTypeFromGit for commands", () => {
+	test("classifies .md under commands/ as command, .md under agents/ as agent", async () => {
+		const cmdResult = await inferTypeFromGit(mixedFixtureBare, "v1.0.0", "commands/review.md");
+		expect(cmdResult.type).toBe("command");
+
+		const agentResult = await inferTypeFromGit(mixedFixtureBare, "v1.0.0", "agents/inspector.md");
+		expect(agentResult.type).toBe("agent");
+	});
+});
+
+describe("repo scanner labels commands", () => {
+	test("scanLocalRepo classifies files under commands/ as type=command", async () => {
+		const dir = await makeTempDir("skilltree-cmd-scan-");
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await mkdir(join(dir, "agents"), { recursive: true });
+		await writeFile(
+			join(dir, "commands", "review.md"),
+			"---\nname: review\ndescription: Slash command\n---\nbody\n",
+		);
+		await writeFile(
+			join(dir, "agents", "inspector.md"),
+			"---\nname: inspector\ndescription: Agent\n---\nbody\n",
+		);
+
+		const entries = await scanLocalRepo(dir);
+		const review = entries.find((e) => e.name === "review");
+		const inspector = entries.find((e) => e.name === "inspector");
+
+		expect(review?.type).toBe("command");
+		expect(inspector?.type).toBe("agent");
+	});
+
+	test("dynamicScanRepo on a git tree picks up commands too", async () => {
+		const entries = await dynamicScanRepo(mixedFixtureBare);
+		const types = new Map(entries.map((e) => [e.name, e.type]));
+		expect(types.get("review")).toBe("command");
+		expect(types.get("inspector")).toBe("agent");
+	});
+});
+
+describe("gitignore covers commands/", () => {
+	test("getSkillAgentIgnoreEntries returns skills/, agents/, and commands/", () => {
+		const entries = getSkillAgentIgnoreEntries(".claude");
+		expect(entries).toEqual([".claude/skills/", ".claude/agents/", ".claude/commands/"]);
+	});
+});
+
+describe("lockfile round-trip for commands", () => {
+	test("type: command serializes and parses back", () => {
+		const entities = new Map<string, ResolvedEntity>([
+			[
+				"command:review",
+				{
+					key: "review",
+					name: "review",
+					type: "command",
+					group: "prod",
+					path: "./commands/review.md",
+					commit: "HEAD",
+					local: true,
+					dependencies: [],
+				},
+			],
+		]);
+		const lockfile = buildLockfile(entities);
+		const serialized = serializeLockfile(lockfile);
+		const parsed = parseLockfile(serialized);
+		expect(parsed.packages.review?.type).toBe("command");
+	});
+});
+
+describe("graph type-constraint extends to commands", () => {
+	test("a skill that depends on a command produces a clear type-constraint error", async () => {
+		const dir = await makeTempDir("skilltree-cmd-deps-");
+
+		// Build a local skill that declares a command as a dependency.
+		// The resolver should refuse: skills can only depend on skills.
+		await mkdir(join(dir, "my-skill"), { recursive: true });
+		await writeFile(
+			join(dir, "my-skill", "SKILL.md"),
+			"---\nname: my-skill\ndependencies:\n  - review\n---\nBody\n",
+		);
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(join(dir, "commands", "review.md"), "---\nname: review\n---\nBody\n");
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					"my-skill": { local: "./my-skill" },
+					review: { local: "./commands/review.md", type: "command" },
+				},
+			},
+			dir,
+		);
+
+		const errorText = result.errors.join("\n");
+		expect(errorText).toContain("skill:my-skill");
+		expect(errorText).toContain("command:review");
+		expect(errorText).toContain("Skills can only depend on other skills");
+	});
+});

--- a/tests/core/command-type.test.ts
+++ b/tests/core/command-type.test.ts
@@ -272,3 +272,142 @@ describe("graph type-constraint extends to commands", () => {
 		expect(errorText).toContain("Skills can only depend on other skills");
 	});
 });
+
+/**
+ * Pin down the *positive* side of the type-constraint world: a slash
+ * command is allowed to declare its own `dependencies:` in frontmatter,
+ * and the resolver follows them like it does for skills and agents.
+ *
+ * `dependencies:` in a command `.md` is a skilltree extension — Claude
+ * Code's native slash-command frontmatter spec doesn't define it. The
+ * field is consumed at install time by the resolver and ignored at
+ * runtime by Claude Code, the same way `dependencies:` works for
+ * `SKILL.md`. These tests guard against a future refactor that
+ * accidentally branches on type when reading frontmatter and silently
+ * drops command deps.
+ */
+describe("command frontmatter dependencies are honored", () => {
+	test("local command declaring `dependencies:` pulls in the transitive skill", async () => {
+		const dir = await makeTempDir("skilltree-cmd-frontdeps-");
+
+		await mkdir(join(dir, "skills", "code-review"), { recursive: true });
+		await writeFile(
+			join(dir, "skills", "code-review", "SKILL.md"),
+			"---\nname: code-review\ndescription: Reviews code\n---\nBody\n",
+		);
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(
+			join(dir, "commands", "review.md"),
+			"---\nname: review\ndescription: Slash command\ndependencies:\n  - code-review\n---\nBody\n",
+		);
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					review: { local: "./commands/review.md", type: "command" },
+					"code-review": { local: "./skills/code-review", type: "skill" },
+				},
+			},
+			dir,
+		);
+
+		expect(result.errors).toEqual([]);
+
+		// The command's frontmatter dep was registered on the entity.
+		const cmd = result.entities.get("command:review");
+		expect(cmd?.dependencies).toContain("code-review");
+
+		// And the topo sort puts the skill before the command — proof the
+		// edge made it into the graph, not just the entity record.
+		const order = result.installOrder;
+		expect(order.indexOf("skill:code-review")).toBeLessThan(order.indexOf("command:review"));
+	});
+
+	test("remote command's frontmatter `dependencies:` resolves transitively from the same repo", async () => {
+		// End-to-end via a real git repo so we exercise readRemoteFrontmatter +
+		// the same-repo conventional probe in one shot. This was the path my
+		// manual UAT covered; pinning it as a test means a future regression
+		// in remote frontmatter parsing won't slip through.
+		const dir = await makeTempDir("skilltree-cmd-remote-frontdeps-");
+		const repoDir = await createTestRepo(
+			dir,
+			"upstream",
+			[
+				{
+					path: "commands/review.md",
+					name: "review",
+					isAgent: true,
+					dependencies: ["code-review"],
+				},
+				{ path: "skills/code-review", name: "code-review" },
+			],
+			"v1.0.0",
+		);
+		const bareDir = join(dir, "bare.git");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					review: {
+						repo: `file://${bareDir}`,
+						path: "commands/review.md",
+						type: "command",
+						version: "*",
+					},
+				},
+			},
+			dir,
+		);
+
+		expect(result.errors).toEqual([]);
+
+		// `code-review` was never mentioned in the manifest; it must have come
+		// from the command's frontmatter via the same-repo probe.
+		const cmd = result.entities.get("command:review");
+		expect(cmd?.type).toBe("command");
+		expect(cmd?.dependencies).toContain("code-review");
+
+		const transitive = result.entities.get("skill:code-review");
+		expect(transitive?.type).toBe("skill");
+		expect(transitive?.repo).toContain("bare.git");
+
+		const order = result.installOrder;
+		expect(order.indexOf("skill:code-review")).toBeLessThan(order.indexOf("command:review"));
+	});
+
+	test("command depending on another command is allowed (active resources can compose)", async () => {
+		// Cross-resource dep on the active side: command -> command. The graph
+		// permits this (only skill -> non-skill is rejected). Mostly a
+		// guardrail so the type-constraint rule doesn't accidentally tighten
+		// to "active resources may only depend on skills" without an explicit
+		// design decision.
+		const dir = await makeTempDir("skilltree-cmd-to-cmd-");
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(
+			join(dir, "commands", "lint.md"),
+			"---\nname: lint\ndescription: Lint command\n---\nBody\n",
+		);
+		await writeFile(
+			join(dir, "commands", "full-review.md"),
+			"---\nname: full-review\ndescription: Orchestrator\ndependencies:\n  - lint\n---\nBody\n",
+		);
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					"full-review": { local: "./commands/full-review.md", type: "command" },
+					lint: { local: "./commands/lint.md", type: "command" },
+				},
+			},
+			dir,
+		);
+
+		expect(result.errors).toEqual([]);
+		const parent = result.entities.get("command:full-review");
+		expect(parent?.dependencies).toContain("lint");
+
+		const order = result.installOrder;
+		expect(order.indexOf("command:lint")).toBeLessThan(order.indexOf("command:full-review"));
+	});
+});


### PR DESCRIPTION
Closes #11.

## Summary

Slash commands (`.claude/commands/<name>.md`) join skills and agents as a first-class entity type in skilltree. Same manifest grammar, same resolver, same lockfile — different install location and shape rules.

| Entity | Format | Install Location |
|--------|--------|------------------|
| Skill | Directory with `SKILL.md` | `.claude/skills/{name}/` |
| Agent | Single `.md` with frontmatter | `.claude/agents/{name}.md` |
| Command | Single `.md` with frontmatter (Claude Code slash command) | `.claude/commands/{name}.md` |

## What changed

**Type system & install** — `EntityType = "skill" \| "agent" \| "command"`; `getTargetPath` returns `commands/<name>.md`; the install loop creates a `commands/` bucket; agents and commands share the single-file copy/git-cache code paths via a new `isSingleFileEntity` predicate.

**Type inference** — any `.md` file under any `commands/` segment is a command; everything else stays an agent. Conventional-probe candidates extended to `commands/<name>.md`, so `skilltree add review --repo X` (no `--path`, no `--type`) Just Works for upstream repos that follow the convention.

**Type constraint generalized** — skills can still only depend on skills (now blocks command deps too with a clear `skill:foo cannot depend on command:bar` error).

**Scanners + UX** — `init --scan`, `repo-scanner`, `registry-scanner`, and `registry index` discover and count commands separately. `add --type command` and `search --type command` round-trip. Vendor / unvendor and the gitignore generator cover `commands/` alongside `skills/` and `agents/`.

**New shared module: `src/core/entity-type.ts`** — collects `mdFileType`, `isSingleFileEntity`, and `conventionalCandidates` so adding a fourth resource type later is a one-file edit instead of an eight-file sweep. Replaces what had been four inline copies of the same `commands/` segment check.

**Docs** — `spec.md`, `reference.md`, `decisions.md`, `README.md`, `CLAUDE.md`, and the bundled `skills/skilltree/` skill all describe commands as the third resource type. Same sweep also renames `skilltree.yaml` → `skilltree.yml` in user-facing references (PR #12 made `.yml` the default extension; docs hadn't caught up).

## Dependency rules

| from \ to | skill | agent | command |
|-----------|:-----:|:-----:|:-------:|
| **skill**     | ✅ | ❌ | ❌ |
| **agent**     | ✅ | ✅ | ✅ |
| **command**   | ✅ | ✅ | ✅ |

Skill → only skill stays strict (skills are model-loaded knowledge; can't load an agent or invoke a command). Agent and command are unrestricted active resources — same posture agents had before commands existed. Cross-resource constraints can tighten in a follow-up if real usage justifies it (Issue #11 phase 4).

## Test plan

- [x] 812 tests pass (12 new) — `bun test`
- [x] Typecheck clean — `bun run typecheck`
- [x] Lint clean (only 8 pre-existing warnings) — `bun run lint`
- [x] Standalone binary builds — `bun build --compile src/cli.ts`
- [x] Manual UAT covered: remote command + transitive skill, conventional probe with no `--path`, `skill → command` type-constraint error, `vendor` + `unvendor` round-trip, `registry update` / `search` / `info` show command type, `init --scan` listing groups commands, multi-target install (`.claude/`, `.codex/`, `.cursor/`, `.gemini/`)

## Notes for reviewers

- One pre-existing wart not fixed here: `executeInstall` only mkdir's empty bucket dirs for the project's `.claude/` (because `options.installPath` isn't propagated through the multi-target loop). My `mkdir(commands)` followed the same pattern. Files install correctly to every target on demand. Worth a separate ticket if it ever matters.
- The dependency-direction rules above are a design call — happy to tighten (e.g., block command → command) if reviewers prefer; current posture mirrors agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)