### PR TITLE
feat(scan): detect slash-command references + command parity polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ demo/*.gif
 demo/*.mp4
 .claude/skills/
 .claude/agents/
+.claude/commands/
+.claude/worktrees/
 test
 package-lock.json
 .playwright-cli/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,10 @@ program
 	.command("init")
 	.description("Initialize a new skilltree project")
 	.option("-g, --global", "Initialize global dependencies")
-	.option("--scan", "Scan the repo for existing skills/agents and register them as local deps")
+	.option(
+		"--scan",
+		"Scan the repo for existing skills, agents, and commands and register them as local deps",
+	)
 	.option("-y, --yes", "With --scan, include all discovered entries without prompting")
 	.action(async (opts) => {
 		await initCommand(process.cwd(), {
@@ -243,7 +246,7 @@ registry
 
 program
 	.command("search <query>")
-	.description("Search registries for skills and agents")
+	.description("Search registries for skills, agents, and commands")
 	.option("--registry <name>", "Search only one registry")
 	.option("-t, --type <type>", "Filter by entity type (skill, agent, or command)")
 	.option("--json", "Output results as JSON")
@@ -257,7 +260,7 @@ program
 
 program
 	.command("info <name>")
-	.description("Show detailed information about a skill or agent")
+	.description("Show detailed information about a skill, agent, or command")
 	.option("--json", "Output results as JSON")
 	.action(async (name: string, opts) => {
 		await infoCommand(name, { json: opts.json });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,7 +138,7 @@ program
 
 program
 	.command("scan <paths...>")
-	.description("Scan skills for undeclared dependencies")
+	.description("Scan skills, agents, and commands for undeclared dependencies")
 	.option("--check", "Exit 1 if undeclared deps found (pre-commit mode)")
 	.option("--apply", "Auto-update frontmatter with detected deps (regex only)")
 	.option("--llm", "Use LLM for deep dependency detection (requires ANTHROPIC_API_KEY)")

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -44,7 +44,7 @@ const COMMANDS: CmdDef[] = [
 		description: "Initialize a new skilltree project",
 		flags: [
 			{ long: "--global", short: "-g", description: "Initialize global dependencies" },
-			{ long: "--scan", description: "Scan repo for existing skills/agents" },
+			{ long: "--scan", description: "Scan repo for existing skills, agents, and commands" },
 			{
 				long: "--yes",
 				short: "-y",
@@ -62,7 +62,12 @@ const COMMANDS: CmdDef[] = [
 			{ long: "--version", short: "-v", description: "Semver version constraint", takesArg: true },
 			{ long: "--local", short: "-l", description: "Local filesystem path", takesArg: true },
 			{ long: "--dev", short: "-D", description: "Add as dev dependency" },
-			{ long: "--type", short: "-t", description: "Entity type (skill or agent)", takesArg: true },
+			{
+				long: "--type",
+				short: "-t",
+				description: "Entity type (skill, agent, or command)",
+				takesArg: true,
+			},
 			{ long: "--registry", description: "Resolve from this registry", takesArg: true },
 			{ long: "--global", short: "-g", description: "Add to global dependencies" },
 		],
@@ -113,7 +118,7 @@ const COMMANDS: CmdDef[] = [
 	},
 	{
 		name: "scan",
-		description: "Scan skills for undeclared dependencies",
+		description: "Scan skills, agents, and commands for undeclared dependencies",
 		flags: [
 			{ long: "--check", description: "Exit 1 if undeclared deps found" },
 			{ long: "--apply", description: "Auto-update frontmatter" },
@@ -128,7 +133,7 @@ const COMMANDS: CmdDef[] = [
 	},
 	{
 		name: "search",
-		description: "Search registries for skills and agents",
+		description: "Search registries for skills, agents, and commands",
 		flags: [
 			{ long: "--registry", description: "Search only one registry", takesArg: true },
 			{ long: "--type", short: "-t", description: "Filter by entity type", takesArg: true },
@@ -137,7 +142,7 @@ const COMMANDS: CmdDef[] = [
 	},
 	{
 		name: "info",
-		description: "Show detailed information about a skill or agent",
+		description: "Show detailed information about a skill, agent, or command",
 		positionalComplete: "deps",
 		flags: [{ long: "--json", description: "Output results as JSON" }],
 	},

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,5 +1,6 @@
 import { readdir, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { mdFileType } from "../core/entity-type.js";
 import type { ScanResult } from "../core/scanner.js";
 import { applyToFrontmatter, scanFiles, scanFileWithLlm } from "../core/scanner.js";
 import { dim, pc, success } from "../core/ui.js";
@@ -31,12 +32,34 @@ async function collectMdFiles(path: string): Promise<string[]> {
 	return files;
 }
 
+/**
+ * Classify a `.md` path into an entity descriptor with the right `type`.
+ * SKILL.md → skill (name from declaring directory); single-file `.md` under
+ * a `commands/` segment → command; everything else → agent. Names default
+ * to the filename stem when frontmatter doesn't supply one — commands and
+ * many agents are named by filename, not a `name:` field.
+ */
+function classifyEntityFile(
+	filePath: string,
+	frontmatterName?: string,
+): { name: string; type: string } | null {
+	const stem = basename(filePath, ".md");
+	if (stem === "SKILL") {
+		const name = frontmatterName ?? basename(dirname(filePath));
+		return name ? { name, type: "skill" } : null;
+	}
+	const name = frontmatterName ?? stem;
+	if (!name) return null;
+	return { name, type: mdFileType(filePath) };
+}
+
 async function buildKnownEntities(files: string[]): Promise<Array<{ name: string; type: string }>> {
 	const entities: Array<{ name: string; type: string }> = [];
 	const results = await scanFiles(files);
 	for (const result of results) {
-		if (result.name) {
-			entities.push({ name: result.name, type: "skill" });
+		const classified = classifyEntityFile(result.file, result.name);
+		if (classified) {
+			entities.push(classified);
 		}
 	}
 	return entities;
@@ -101,7 +124,7 @@ async function displayResults(results: ScanResult[], options: ScanOptions): Prom
 	}
 
 	if (!hasGaps && !results.some((r) => (r.confirmed?.length ?? 0) > 0)) {
-		success("All skill references are declared in frontmatter.");
+		success("All entity references are declared in frontmatter.");
 	}
 
 	return hasGaps;

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -39,7 +39,7 @@ async function collectMdFiles(path: string): Promise<string[]> {
  * to the filename stem when frontmatter doesn't supply one — commands and
  * many agents are named by filename, not a `name:` field.
  */
-function classifyEntityFile(
+export function classifyEntityFile(
 	filePath: string,
 	frontmatterName?: string,
 ): { name: string; type: string } | null {

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,9 +1,10 @@
 import { readdir, stat } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
-import { mdFileType } from "../core/entity-type.js";
+import { basename, join } from "node:path";
+import { entityNameFromPath, mdFileType } from "../core/entity-type.js";
 import type { ScanResult } from "../core/scanner.js";
 import { applyToFrontmatter, scanFiles, scanFileWithLlm } from "../core/scanner.js";
 import { dim, pc, success } from "../core/ui.js";
+import type { EntityType } from "../types.js";
 
 export interface ScanOptions {
 	check?: boolean;
@@ -33,34 +34,31 @@ async function collectMdFiles(path: string): Promise<string[]> {
 }
 
 /**
- * Classify a `.md` path into an entity descriptor with the right `type`.
- * SKILL.md → skill (name from declaring directory); single-file `.md` under
- * a `commands/` segment → command; everything else → agent. Names default
- * to the filename stem when frontmatter doesn't supply one — commands and
- * many agents are named by filename, not a `name:` field.
+ * Classify a `.md` path into an entity descriptor for the LLM scanner's
+ * known-entity list. SKILL.md → skill; `.md` under any `commands/` segment
+ * → command; everything else → agent. Frontmatter `name:` wins; otherwise
+ * the name is derived from the path (parent dir for SKILL.md, filename
+ * stem otherwise). Returns null only for the degenerate empty-name case
+ * (e.g., a literal `.md` file with no frontmatter name).
  */
 export function classifyEntityFile(
 	filePath: string,
 	frontmatterName?: string,
-): { name: string; type: string } | null {
-	const stem = basename(filePath, ".md");
-	if (stem === "SKILL") {
-		const name = frontmatterName ?? basename(dirname(filePath));
-		return name ? { name, type: "skill" } : null;
-	}
-	const name = frontmatterName ?? stem;
+): { name: string; type: EntityType } | null {
+	const name = frontmatterName ?? entityNameFromPath(filePath);
 	if (!name) return null;
-	return { name, type: mdFileType(filePath) };
+	const type: EntityType = basename(filePath) === "SKILL.md" ? "skill" : mdFileType(filePath);
+	return { name, type };
 }
 
-async function buildKnownEntities(files: string[]): Promise<Array<{ name: string; type: string }>> {
-	const entities: Array<{ name: string; type: string }> = [];
+async function buildKnownEntities(
+	files: string[],
+): Promise<Array<{ name: string; type: EntityType }>> {
 	const results = await scanFiles(files);
+	const entities: Array<{ name: string; type: EntityType }> = [];
 	for (const result of results) {
 		const classified = classifyEntityFile(result.file, result.name);
-		if (classified) {
-			entities.push(classified);
-		}
+		if (classified) entities.push(classified);
 	}
 	return entities;
 }

--- a/src/core/entity-type.ts
+++ b/src/core/entity-type.ts
@@ -11,6 +11,7 @@
  * conventions — neither side owns the logic outright.
  */
 
+import { basename, dirname } from "node:path";
 import type { EntityType } from "../types.js";
 
 /**
@@ -42,4 +43,15 @@ export function isSingleFileEntity(type: EntityType): boolean {
  */
 export function conventionalCandidates(name: string): string[] {
 	return [`skills/${name}`, `agents/${name}.md`, `commands/${name}.md`, name];
+}
+
+/**
+ * Derive an entity name from its `.md` path alone — the parent directory
+ * for `SKILL.md`, the filename stem otherwise. Used as the fallback when
+ * frontmatter doesn't carry a `name:` field (commands and many agents
+ * are named by file, not by frontmatter).
+ */
+export function entityNameFromPath(filePath: string): string {
+	const stem = basename(filePath, ".md");
+	return stem === "SKILL" ? basename(dirname(filePath)) : stem;
 }

--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -1,10 +1,11 @@
 import { readFile, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
 import { getDeclaredDeps, parseFrontmatter } from "./frontmatter.js";
 import { llmScanContent } from "./llm.js";
 
 /**
- * Regex patterns for detecting skill references in body text.
- * Battle-tested patterns for detecting skill references.
+ * Regex patterns for detecting entity references in body text.
+ * Battle-tested patterns for skill prose plus slash-command syntax.
  */
 const PATTERNS = [
 	// **LOAD** `task-builder` skill
@@ -20,6 +21,11 @@ const PATTERNS = [
 	/(?:the|a)\s+[`'"<]?([a-z0-9][a-z0-9-]*)[`'">]?\s+skill\b/gi,
 	// Standalone quoted/bracketed: `X` skill, "X" skill, 'X' skill, <X> skill (no article needed)
 	/[`'"<]([a-z0-9][a-z0-9-]*)[`'">]\s+skill\b/gi,
+	// Claude Code slash-command syntax: /<name>. Lookbehind blocks path segments
+	// (path/to, https://...) by requiring the `/` to follow whitespace, line start,
+	// or a quoting/bracketing character — not a word/identifier character or another
+	// `/`. Lookahead `(?!/)` blocks multi-segment paths like /usr/local/share.
+	/(?<![/\w])\/([a-z][a-z0-9-]+)\b(?!\/)/g,
 ];
 
 /**
@@ -96,7 +102,8 @@ export interface ScanResult {
 }
 
 /**
- * Scan a single SKILL.md or agent .md file for undeclared dependencies.
+ * Scan a single SKILL.md, agent .md, or command .md file for undeclared
+ * dependencies.
  */
 export async function scanFile(filePath: string): Promise<ScanResult | null> {
 	const content = await readFile(filePath, "utf-8");
@@ -108,7 +115,14 @@ export async function scanFile(filePath: string): Promise<ScanResult | null> {
 	}
 
 	const declared = getDeclaredDeps(frontmatter);
-	const name = frontmatter.name;
+	// Self-reference filter wants the *entity name*. Skills usually carry
+	// `name:` in frontmatter; agents and commands typically don't — their
+	// name is the filename stem (or parent dir for `SKILL.md`). Falling back
+	// to the filename keeps self-refs from leaking into `undeclared` for
+	// command files like `verify-documentation.md` that mention themselves.
+	const stem = basename(filePath, ".md");
+	const fileDerivedName = stem === "SKILL" ? basename(dirname(filePath)) : stem;
+	const name = frontmatter.name ?? fileDerivedName;
 
 	// Extract body (everything after frontmatter)
 	const bodyStart = content.indexOf("---", content.indexOf("---") + 3);

--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { basename, dirname } from "node:path";
+import { entityNameFromPath } from "./entity-type.js";
 import { getDeclaredDeps, parseFrontmatter } from "./frontmatter.js";
 import { llmScanContent } from "./llm.js";
 
@@ -118,11 +118,9 @@ export async function scanFile(filePath: string): Promise<ScanResult | null> {
 	// Self-reference filter wants the *entity name*. Skills usually carry
 	// `name:` in frontmatter; agents and commands typically don't — their
 	// name is the filename stem (or parent dir for `SKILL.md`). Falling back
-	// to the filename keeps self-refs from leaking into `undeclared` for
-	// command files like `verify-documentation.md` that mention themselves.
-	const stem = basename(filePath, ".md");
-	const fileDerivedName = stem === "SKILL" ? basename(dirname(filePath)) : stem;
-	const name = frontmatter.name ?? fileDerivedName;
+	// to the path-derived name keeps self-refs from leaking into `undeclared`
+	// for command files like `verify-documentation.md` that mention themselves.
+	const name = frontmatter.name ?? entityNameFromPath(filePath);
 
 	// Extract body (everything after frontmatter)
 	const bodyStart = content.indexOf("---", content.indexOf("---") + 3);

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -180,6 +180,27 @@ describe("completion generator", () => {
 		expect(zsh).toContain("compdef");
 	});
 
+	// Pins the slash-commands feature into user-facing strings so a future
+	// rewrite that drops "command" from a description is caught at PR time
+	// rather than via a confused user wondering why `add --type command` is
+	// "supported but not in the help".
+	describe("user-facing strings include 'command' for the third resource type", () => {
+		const lines: Array<[string, string]> = [
+			["zsh --type completion", "Entity type (skill, agent, or command)"],
+			["zsh init --scan description", "skills, agents, and commands"],
+			["zsh search description", "Search registries for skills, agents, and commands"],
+			["zsh info description", "Show detailed information about a skill, agent, or command"],
+			["zsh scan description", "Scan skills, agents, and commands for undeclared dependencies"],
+		];
+
+		for (const [label, needle] of lines) {
+			test(label, () => {
+				const zsh = generateZshCompletion();
+				expect(zsh).toContain(needle);
+			});
+		}
+	});
+
 	// Regression: escapeZsh used to escape `'`, `[`, `]` but not `\`. A
 	// description containing `\[` would emit `\\[` to the script, which zsh
 	// reads as literal-backslash + description-group-start — breaking the

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -73,7 +73,7 @@ describe("scanCommand", () => {
 		} finally {
 			restore();
 		}
-		expect(logs.some((l) => l.includes("All skill references are declared"))).toBe(true);
+		expect(logs.some((l) => l.includes("All entity references are declared"))).toBe(true);
 	});
 
 	test("--json outputs JSON array", async () => {

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { classifyEntityFile, scanCommand } from "../../src/commands/scan.js";
+import type { EntityType } from "../../src/types.js";
 
 let tempDir: string;
 
@@ -195,7 +196,7 @@ describe("classifyEntityFile", () => {
 	// Parametrized: each row is [path, frontmatter name | undefined, expected].
 	// Edge cases live next to canonical inputs so the matrix stays the single
 	// source of truth — adding a new layout convention is one new row.
-	const cases: Array<[string, string | undefined, { name: string; type: string } | null]> = [
+	const cases: Array<[string, string | undefined, { name: string; type: EntityType } | null]> = [
 		// Skill: directory-based, name from declaring directory or frontmatter
 		["skills/python-coding/SKILL.md", undefined, { name: "python-coding", type: "skill" }],
 		[

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { scanCommand } from "../../src/commands/scan.js";
+import { classifyEntityFile, scanCommand } from "../../src/commands/scan.js";
 
 let tempDir: string;
 
@@ -171,4 +171,60 @@ describe("scanCommand", () => {
 		}
 		expect(logs.some((l) => l.includes("testing"))).toBe(true);
 	});
+
+	test("detects undeclared slash-command reference in a command file", async () => {
+		const dir = await makeTempDir();
+		const cmdDir = join(dir, "commands");
+		await mkdir(cmdDir, { recursive: true });
+		await writeFile(
+			join(cmdDir, "code-refinement.md"),
+			"---\ndescription: Iterate hypotheses\n---\n\nRun /hypothesis each round until clean.\n",
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await scanCommand([cmdDir], {});
+		} finally {
+			restore();
+		}
+		expect(logs.some((l) => l.includes("hypothesis"))).toBe(true);
+	});
+});
+
+describe("classifyEntityFile", () => {
+	// Parametrized: each row is [path, frontmatter name | undefined, expected].
+	// Edge cases live next to canonical inputs so the matrix stays the single
+	// source of truth — adding a new layout convention is one new row.
+	const cases: Array<[string, string | undefined, { name: string; type: string } | null]> = [
+		// Skill: directory-based, name from declaring directory or frontmatter
+		["skills/python-coding/SKILL.md", undefined, { name: "python-coding", type: "skill" }],
+		[
+			"/abs/path/skills/python-coding/SKILL.md",
+			"python-coding",
+			{ name: "python-coding", type: "skill" },
+		],
+		["skills/aliased-dir/SKILL.md", "real-name", { name: "real-name", type: "skill" }],
+
+		// Command: under any commands/ segment, name from filename stem
+		["commands/hypothesis.md", undefined, { name: "hypothesis", type: "command" }],
+		["commands/hypothesis.md", "fm-named", { name: "fm-named", type: "command" }],
+		[
+			".claude/commands/code-refinement.md",
+			undefined,
+			{ name: "code-refinement", type: "command" },
+		],
+		["nested/commands/sub/foo.md", undefined, { name: "foo", type: "command" }],
+
+		// Agent: single-file .md not under commands/, name from filename or frontmatter
+		["agents/reviewer.md", undefined, { name: "reviewer", type: "agent" }],
+		["agents/reviewer.md", "fm-named", { name: "fm-named", type: "agent" }],
+		["loose-agent.md", undefined, { name: "loose-agent", type: "agent" }],
+	];
+
+	for (const [path, fmName, expected] of cases) {
+		const fmDesc = fmName === undefined ? "no fm name" : `fm=${fmName}`;
+		test(`${path} (${fmDesc}) → ${expected ? `${expected.type}:${expected.name}` : "null"}`, () => {
+			expect(classifyEntityFile(path, fmName)).toEqual(expected);
+		});
+	}
 });

--- a/tests/core/scanner.test.ts
+++ b/tests/core/scanner.test.ts
@@ -276,6 +276,98 @@ describe("scanFile", () => {
 	});
 });
 
+describe("scanFile — slash-command references", () => {
+	async function writeCommand(
+		dir: string,
+		name: string,
+		body: string,
+		deps?: string[],
+	): Promise<string> {
+		const cmdDir = join(dir, "commands");
+		await mkdir(cmdDir, { recursive: true });
+		const depsYaml = deps?.length ? `dependencies:\n${deps.map((d) => `  - ${d}`).join("\n")}` : "";
+		const content = `---\nname: ${name}\n${depsYaml}\n---\n\n${body}\n`;
+		const filePath = join(cmdDir, `${name}.md`);
+		await writeFile(filePath, content);
+		return filePath;
+	}
+
+	test("detects /name slash-command reference in body", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(
+			dir,
+			"code-refinement-with-hypothesis",
+			"Use /loop 1m /hypothesis to run iteratively.",
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("hypothesis");
+		expect(result?.detected).toContain("loop");
+		expect(result?.undeclared).toContain("hypothesis");
+	});
+
+	test("does not match path segments like /tmp or /usr/local", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(
+			dir,
+			"my-command",
+			"Write to /tmp/output and read /usr/local/share. URLs like https://example.com are common.",
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).not.toContain("tmp");
+		expect(result?.detected).not.toContain("usr");
+		expect(result?.detected).not.toContain("local");
+		expect(result?.detected).not.toContain("share");
+		expect(result?.detected).not.toContain("example");
+	});
+
+	test("filters self-reference for slash command", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(dir, "hypothesis", "Run /hypothesis recursively.");
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).not.toContain("hypothesis");
+	});
+
+	test("does not report declared slash-command deps as undeclared", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(
+			dir,
+			"code-refinement-with-hypothesis",
+			"Use /hypothesis each round.",
+			["hypothesis"],
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("hypothesis");
+		expect(result?.undeclared).toEqual([]);
+	});
+
+	test("detects backticked /name reference", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(dir, "my-cmd", "Run `/hypothesis` first.");
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("hypothesis");
+	});
+
+	test("filters self-reference by filename when no name: in frontmatter", async () => {
+		const dir = await makeTempDir();
+		const cmdDir = join(dir, "commands");
+		await mkdir(cmdDir, { recursive: true });
+		const filePath = join(cmdDir, "verify-documentation.md");
+		await writeFile(
+			filePath,
+			"---\ndescription: Verify the docs\n---\n\nRun /verify-documentation across the repo.\n",
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).not.toContain("verify-documentation");
+		expect(result?.undeclared).toEqual([]);
+	});
+});
+
 describe("applyToFrontmatter", () => {
 	test("adds undeclared deps to frontmatter", async () => {
 		const dir = await makeTempDir();


### PR DESCRIPTION
Closes #15.

`skilltree scan` now recognizes Claude Code slash-command syntax (`/<name>`) and the LLM scanner sees commands and agents — not just skills — in the known-entity universe it matches against. Plus a sweep of user-facing strings the slash-commands merge (#11) didn't update, an internal helper extraction from /simplify review, and a small `.gitignore` follow-up.

## Summary

- **Detect `/<name>` references in scanner** (`src/core/scanner.ts`) — new regex with lookbehind blocking word/identifier chars and `/` (so `path/to`, `https://...`, `/usr/local` don't match) and lookahead `(?!\/)` blocking multi-segment paths.
- **Self-reference filter falls back to filename stem** when frontmatter has no `name:`. Commands and many agents are named by file, not field — without the fallback, a command file mentioning itself flagged itself as undeclared.
- **LLM known-entity list is type-classified by file location** (`src/commands/scan.ts`) using `mdFileType` from `entity-type.ts`. Commands surface as `type: command` and agents as `type: agent` in the LLM's universe instead of everything being labeled `skill`.
- **CLI/completion strings updated** — `add --type <TAB>` now lists `command` as a valid value (was "(skill or agent)"). `init --scan`, `search`, `info`, and the `scan` command's own description in both `cli.ts` and the completion mirror now mention commands.
- **Output text** changed from "All skill references are declared" → "All entity references are declared".
- **Internal helper `entityNameFromPath`** added to `src/core/entity-type.ts` so `scan.ts` and `scanner.ts` share the SKILL-vs-stem name derivation instead of duplicating it.
- **`.gitignore`** adds `.claude/commands/` (parity with `skills/` and `agents/`) and `.claude/worktrees/` (per-issue worktrees).

## Verified empirically

`vibes/commands/code-refinement-with-hypothesis.md` (a real-world command referencing `/loop` and `/hypothesis` in prose) was the motivating example. Before this PR:

```
$ skilltree scan code-refinement-with-hypothesis.md
✔ All skill references are declared in frontmatter.
```

After:

```
$ skilltree scan code-refinement-with-hypothesis.md
  Declared: (none)
  Undeclared: loop, hypothesis
```

End-to-end command→command dependency resolution (the original question) was also confirmed: a producer with `dependencies: [hypothesis]` in `code-refinement-with-hypothesis.md`'s frontmatter resolves transitively, topo-sorts `hypothesis` before `code-refinement-with-hypothesis`, and installs both with correct symlinks.

## Tests

- 6 new in `tests/core/scanner.test.ts` covering positive `/name` detection, backticked `` `/name` ``, declared-deps suppression, path-segment rejection (`/tmp`, `/usr/local/share`, `https://example.com`), and filename-stem self-reference.
- 11-row parametrized table in `tests/commands/scan.test.ts` for `classifyEntityFile` covering skill (frontmatter name, dir-derived name, alias mismatch), command (under any `commands/` segment, frontmatter overrides filename, nested), and agent variants. Plus an `scanCommand` integration test for end-to-end command-file scanning.
- 5 string-parity assertions in `tests/commands/completion.test.ts` pinning the new descriptions so a future rewrite that drops "command" from help text is caught at PR time.
- Full suite: 812 → 844 tests, all green.

## Out of scope (potential follow-ups)

- **Detecting *unknown* references** — the LLM prompt only matches against known entities. A "you mention /X but it's nowhere" mode is a separate feature.
- **`add --type command --local <dir>` bug** — discovered in testing: when `--local` points at a directory instead of a `.md` file, install symlinks the directory itself and silently drops transitive deps. Worth a separate issue + TDD fix.
- **`scanFileWithLlm` reads each file twice** and `buildKnownEntities` reads them a third time in `--llm` mode. Pre-existing on main.

## Test plan

- [ ] `bun test` — 844 pass
- [ ] `skilltree scan --check` on a project with command files referencing other commands — exits 1 if undeclared
- [ ] `skilltree add --type <TAB>` shows `command` in zsh completion
- [ ] `skilltree info` / `skilltree search` `--help` text mentions commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)