### PR TITLE
fix(ci): set explicit GITHUB_TOKEN permissions on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an explicit `permissions: contents: read` block to `.github/workflows/ci.yml`
- Resolves CodeQL alert [#1](https://github.com/imarios/skilltree/security/code-scanning/1) (`actions/missing-workflow-permissions`, CWE-275)

## Why
The CI workflow had no `permissions` block, so it inherited the repo/org default — which can be broader than needed. The only external write the workflow performs is uploading coverage to Codecov, and that uses `CODECOV_TOKEN` rather than `GITHUB_TOKEN`. Read-only is the principle of least privilege here.

The other two workflows (`publish.yml`, `release.yml`) already declare explicit permissions, so they were not flagged.

## Test plan
- [ ] CI runs green on this PR (checkout, lint, format check, typecheck, tests, Codecov upload all succeed under `contents: read`)
- [ ] CodeQL re-scan after merge marks alert #1 as fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)