### PR TITLE
fix(cache): fingerprint registry index cache by scanner version (#25)

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -5,7 +5,7 @@ import { canonicalSource } from "../core/deps.js";
 import { MANIFEST_NEW } from "../core/filenames.js";
 import { loadManifestOrThrow, writeGlobalManifest, writeManifest } from "../core/manifest.js";
 import { collapseTilde, expandTilde, getGlobalDir } from "../core/paths.js";
-import { readRegistryIndex } from "../core/registry-cache.js";
+import { loadFreshRegistryIndex } from "../core/registry-cache.js";
 import { listRegistries } from "../core/registry-config.js";
 import { dim, pc, success, warn } from "../core/ui.js";
 import type {
@@ -262,7 +262,12 @@ async function loadRegistryEntities(opts: AddOptions): Promise<RegistryEntity[]>
 
 	const targets = opts.registry ? registries.filter((r) => r.name === opts.registry) : registries;
 	const loaded = await Promise.all(
-		targets.map(async (reg) => ({ reg, index: await readRegistryIndex(reg.name, opts.cacheDir) })),
+		// loadFreshRegistryIndex skips fingerprint-incompatible caches (issue #25),
+		// so a stale index can't surface entities that no longer match reality.
+		targets.map(async (reg) => ({
+			reg,
+			index: await loadFreshRegistryIndex(reg.name, opts.cacheDir),
+		})),
 	);
 
 	const entities: RegistryEntity[] = [];

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,6 +1,6 @@
 import semver from "semver";
 import { listTags } from "../core/git.js";
-import { getRegistryRepoDir, readRegistryIndex } from "../core/registry-cache.js";
+import { getRegistryRepoDir, loadFreshRegistryIndex } from "../core/registry-cache.js";
 import { listRegistries } from "../core/registry-config.js";
 import { dim, label, pc } from "../core/ui.js";
 import type { IndexEntry } from "../types.js";
@@ -9,6 +9,17 @@ interface InfoMatch {
 	entity: IndexEntry;
 	registry: string;
 	repo: string;
+}
+
+interface FindMatchesResult {
+	matches: InfoMatch[];
+	/**
+	 * True iff at least one registry's cache loaded successfully. Distinguishes
+	 * "no usable indexes" (issue #25 — caches missing or fingerprint-stale)
+	 * from "indexes loaded but the entity isn't there" so the error message can
+	 * point the user at the right remediation.
+	 */
+	anyIndexLoaded: boolean;
 }
 
 export async function infoCommand(
@@ -23,7 +34,15 @@ export async function infoCommand(
 		throw new Error("No registries configured. Run 'skilltree registry add <url>' to add one.");
 	}
 
-	const matches = await findMatches(name, registries, cacheDir);
+	const { matches, anyIndexLoaded } = await findMatches(name, registries, cacheDir);
+
+	// Distinguish "no caches usable" (issue #25) from "entity truly absent" so
+	// the user — or a scripted JSON consumer — gets the right next step
+	// instead of bouncing through search or treating the empty result as
+	// definitive. Setup failures throw regardless of --json (matches search.ts).
+	if (!anyIndexLoaded) {
+		throw new Error("No registry indexes available. Run 'skilltree registry update' first.");
+	}
 
 	if (matches.length === 0) {
 		if (opts?.json) {
@@ -51,18 +70,21 @@ async function findMatches(
 	name: string,
 	registries: Array<{ name: string; repo: string }>,
 	cacheDir?: string,
-): Promise<InfoMatch[]> {
+): Promise<FindMatchesResult> {
 	const matches: InfoMatch[] = [];
+	let anyIndexLoaded = false;
 	for (const reg of registries) {
-		const index = await readRegistryIndex(reg.name, cacheDir);
+		// loadFreshRegistryIndex skips fingerprint-incompatible caches (issue #25).
+		const index = await loadFreshRegistryIndex(reg.name, cacheDir);
 		if (!index) continue;
+		anyIndexLoaded = true;
 		for (const entity of index.entities) {
 			if (entity.name === name) {
 				matches.push({ entity, registry: reg.name, repo: reg.repo });
 			}
 		}
 	}
-	return matches;
+	return { matches, anyIndexLoaded };
 }
 
 async function fetchVersions(registry: string, cacheDir?: string): Promise<string[]> {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -2,6 +2,7 @@ import { cleanGitUrl, normalizeGitUrl } from "../core/git.js";
 import {
 	cleanRegistryCache,
 	ensureRegistryRepo,
+	isCacheCompatible,
 	readRegistryIndex,
 	writeRegistryIndex,
 } from "../core/registry-cache.js";
@@ -9,6 +10,13 @@ import { addRegistry, listRegistries, removeRegistry } from "../core/registry-co
 import { scanRegistry } from "../core/registry-scanner.js";
 import { dim, pc, success, warn } from "../core/ui.js";
 import type { RegistryEntry, RegistryIndex } from "../types.js";
+
+/**
+ * Suffix on `registry list`'s "Last Updated" column when a cache's
+ * `scanner_version` doesn't match the running build (issue #25). Tested
+ * against the same constant so the literal lives in one place.
+ */
+export const OUTDATED_SUFFIX = " (outdated)";
 
 /**
  * Curated default registries for `skilltree registry init`.
@@ -86,6 +94,9 @@ export async function registryListCommand(
 					repo: reg.repo,
 					entities: index.entities.length,
 					updated_at: index.updated_at,
+					// Issue #25: surface caches whose scanner_version doesn't match
+					// the running build so users know they need to refresh.
+					outdated: !isCacheCompatible(index),
 				};
 			}
 			return {
@@ -93,6 +104,7 @@ export async function registryListCommand(
 				repo: reg.repo,
 				entities: null as number | null,
 				updated_at: null as string | null,
+				outdated: false,
 			};
 		}),
 	);
@@ -103,12 +115,17 @@ export async function registryListCommand(
 	}
 
 	// Build display rows with formatted strings
-	const rows = rowData.map((r) => ({
-		name: r.name,
-		repo: r.repo,
-		entities: r.entities !== null ? r.entities.toString() : "--",
-		updated: r.updated_at ? formatTimeAgo(new Date(r.updated_at)) : "never",
-	}));
+	const rows = rowData.map((r) => {
+		const baseUpdated = r.updated_at ? formatTimeAgo(new Date(r.updated_at)) : "never";
+		// Surface incompatibility at a glance so users don't have to diff versions.
+		const updated = r.outdated ? `${baseUpdated}${OUTDATED_SUFFIX}` : baseUpdated;
+		return {
+			name: r.name,
+			repo: r.repo,
+			entities: r.entities !== null ? r.entities.toString() : "--",
+			updated,
+		};
+	});
 
 	// Calculate column widths
 	const nameW = Math.max(4, ...rows.map((r) => r.name.length));

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TTL_MS, readRegistryIndex } from "../core/registry-cache.js";
+import { DEFAULT_TTL_MS, loadFreshRegistryIndex } from "../core/registry-cache.js";
 import { listRegistries } from "../core/registry-config.js";
 import { searchRegistries } from "../core/registry-search.js";
 import { dim, pc, warn } from "../core/ui.js";
@@ -31,10 +31,13 @@ export async function searchCommand(
 		// Skip registries not targeted by --registry
 		if (opts.registry && reg.name !== opts.registry) continue;
 
-		const index = await readRegistryIndex(reg.name, cacheDir);
+		// Fingerprint-aware load: a cache produced by a logically-incompatible
+		// scanner (issue #25) returns null here, same as missing — both fix
+		// with `skilltree registry update`.
+		const index = await loadFreshRegistryIndex(reg.name, cacheDir);
 		if (!index) {
 			warn(
-				`Skipping registry '${reg.name}' (never updated). Run ${pc.cyan(`'skilltree registry update ${reg.name}'`)} first.`,
+				`Skipping registry '${reg.name}' (never updated or outdated cache). Run ${pc.cyan(`'skilltree registry update ${reg.name}'`)} first.`,
 			);
 			continue;
 		}

--- a/src/core/registry-cache.ts
+++ b/src/core/registry-cache.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import pkg from "../../package.json" with { type: "json" };
 import type { RegistryIndex } from "../types.js";
 import { cloneOrFetchBare } from "./git.js";
 
@@ -8,6 +9,24 @@ const REGISTRY_CACHE_DIR = join(homedir(), ".skilltree", "registry-cache");
 
 /** Default TTL: 24 hours in milliseconds */
 export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Fingerprint stamped into every cached `index.json` so we can detect when
+ * a cache was produced by a logically-incompatible scanner.
+ *
+ * BUMP THIS whenever `scanRegistry` (or anything it calls) changes its output
+ * in a way that would make existing on-disk caches wrong — e.g. a new entity
+ * type is recognized, classification rules change, or new fields become
+ * material to consumers (`search`, `info`, `add`).
+ *
+ * Pre-#25 caches lack this field entirely, so they fail the equality check and
+ * are treated as incompatible automatically.
+ *
+ * History:
+ *   1 — initial fingerprinted version (issue #25). Implicitly covers the
+ *       slash-command scanner fix from #21/#24.
+ */
+export const SCANNER_VERSION = 1;
 
 export function getRegistryCacheDir(): string {
 	return REGISTRY_CACHE_DIR;
@@ -22,40 +41,121 @@ export function getRegistryIndexPath(name: string, cacheDir?: string): string {
 }
 
 /**
- * Read the cached index for a registry. Returns null if not found.
+ * Read the cached index for a registry.
+ *
+ * Returns null on:
+ *   - file missing (ENOENT)
+ *   - malformed JSON (torn write, hand-edit, encoding issue)
+ *   - structural shape violation (e.g. `entities` not an array)
+ *
+ * All three buckets need the same remediation — `skilltree registry update` —
+ * so we collapse them into a single null-return rather than throwing opaque
+ * `SyntaxError` / `TypeError` at consumers (issue #25 follow-up).
  */
 export async function readRegistryIndex(
 	name: string,
 	cacheDir?: string,
 ): Promise<RegistryIndex | null> {
 	const indexPath = getRegistryIndexPath(name, cacheDir);
+	let content: string;
 	try {
-		const content = await readFile(indexPath, "utf-8");
-		return JSON.parse(content) as RegistryIndex;
+		content = await readFile(indexPath, "utf-8");
 	} catch (err: unknown) {
 		if (err instanceof Error && "code" in err && err.code === "ENOENT") {
 			return null;
 		}
 		throw err;
 	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(content);
+	} catch {
+		return null;
+	}
+	if (!isWellFormedRegistryIndex(parsed)) {
+		return null;
+	}
+	return parsed;
 }
 
 /**
- * Write a registry index to disk.
+ * Shallow shape check for a parsed `index.json`. Cheap, defensive: the goal
+ * is to reject obviously-corrupt caches, not to fully validate every entity.
+ * If a future field becomes load-bearing, add it here.
+ */
+function isWellFormedRegistryIndex(value: unknown): value is RegistryIndex {
+	if (typeof value !== "object" || value === null) return false;
+	const v = value as Record<string, unknown>;
+	return (
+		typeof v.registry === "string" &&
+		typeof v.repo === "string" &&
+		typeof v.updated_at === "string" &&
+		Array.isArray(v.entities)
+	);
+}
+
+/**
+ * Write a registry index to disk. Always stamps the cache with the running
+ * `SCANNER_VERSION` and `package_version` — callers don't pass these, and any
+ * value already on the input is overwritten so a round-trip read→write can't
+ * resurrect a stale fingerprint.
  */
 export async function writeRegistryIndex(index: RegistryIndex, cacheDir?: string): Promise<void> {
 	const indexPath = getRegistryIndexPath(index.registry, cacheDir);
 	await mkdir(dirname(indexPath), { recursive: true });
-	await writeFile(indexPath, JSON.stringify(index, null, 2), "utf-8");
+	const stamped: RegistryIndex = {
+		...index,
+		scanner_version: SCANNER_VERSION,
+		package_version: pkg.version,
+	};
+	await writeFile(indexPath, JSON.stringify(stamped, null, 2), "utf-8");
 }
 
 /**
- * Check if a registry's cached index is stale (older than TTL).
- * Returns true if stale or missing.
+ * Returns true iff the cache's `scanner_version` matches the running build.
+ *
+ * Strict equality (not `>=`) so that downgrades — e.g. a teammate ran a newer
+ * skilltree and their cache claims a higher version than this build can speak
+ * — are also flagged as incompatible. Both directions of skew get the same
+ * "rebuild me" UX.
+ */
+export function isCacheCompatible(index: RegistryIndex): boolean {
+	return index.scanner_version === SCANNER_VERSION;
+}
+
+/**
+ * Read a registry index AND verify it was produced by a compatible scanner.
+ * Returns null when the cache is missing OR fingerprint-incompatible — both
+ * cases need the same remediation (`skilltree registry update`).
+ *
+ * Use this from any code path that consumes the index for correctness
+ * (`search`, `info`, `add`). Reserve raw `readRegistryIndex` for diagnostics.
+ */
+export async function loadFreshRegistryIndex(
+	name: string,
+	cacheDir?: string,
+): Promise<RegistryIndex | null> {
+	const index = await readRegistryIndex(name, cacheDir);
+	if (!index) return null;
+	if (!isCacheCompatible(index)) return null;
+	return index;
+}
+
+/**
+ * Check if a registry's cached index is stale.
+ *
+ * "Stale" includes both axes:
+ *   - missing on disk
+ *   - `scanner_version` mismatch (defense in depth — same condition that
+ *     `loadFreshRegistryIndex` uses to gate consumers)
+ *   - `updated_at` older than `ttlMs`
  */
 export async function isStale(name: string, ttlMs?: number, cacheDir?: string): Promise<boolean> {
 	const index = await readRegistryIndex(name, cacheDir);
 	if (!index) {
+		return true;
+	}
+	if (!isCacheCompatible(index)) {
 		return true;
 	}
 	const updatedAt = new Date(index.updated_at).getTime();

--- a/src/core/registry-scanner.ts
+++ b/src/core/registry-scanner.ts
@@ -26,6 +26,11 @@ export const SKIP_MD_FILES = new Set([
 /**
  * Scan a bare git repo for skills and agents.
  * Tries skillkit-index.yaml first, falls back to dynamic scanning.
+ *
+ * IMPORTANT: if you change the output shape, classification rules, or which
+ * files are recognized here (or in any helper this calls), bump
+ * `SCANNER_VERSION` in `core/registry-cache.ts`. That fingerprint is what
+ * tells consumers their on-disk caches are no longer trustworthy (issue #25).
  */
 export async function scanRegistry(repoDir: string): Promise<IndexEntry[]> {
 	// Try skillkit-index.yaml first (fast path)

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,14 @@ export interface RegistryIndex {
 	registry: string;
 	repo: string;
 	updated_at: string; // ISO 8601
+	/**
+	 * Bumped whenever `scanRegistry` semantics change in a way that makes
+	 * older cached indexes wrong (not just out-of-date). See
+	 * `SCANNER_VERSION` in `core/registry-cache.ts`.
+	 */
+	scanner_version?: number;
+	/** Running skilltree version that produced this cache (diagnostic). */
+	package_version?: string;
 	entities: IndexEntry[];
 }
 

--- a/tests/commands/add-registry.test.ts
+++ b/tests/commands/add-registry.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import YAML from "yaml";
 import { addCommand } from "../../src/commands/add.js";
 import { initCommand } from "../../src/commands/init.js";
-import { writeRegistryIndex } from "../../src/core/registry-cache.js";
+import { getRegistryIndexPath, writeRegistryIndex } from "../../src/core/registry-cache.js";
 import { writeConfig } from "../../src/core/registry-config.js";
 import {
 	isLocalDependency,
@@ -448,6 +448,37 @@ describe("glob-pattern add (Issue #14)", () => {
 		const dep = manifest.dependencies?.kubernetes;
 		expect(dep && isRemoteDependency(dep) && dep.repo).toBe("github.com/imarios/vibes");
 		expect(warnings.some((w) => w.includes("kubernetes") && w.includes("open-vibes"))).toBe(true);
+	});
+
+	test("glob add throws 'registry update' when caches are fingerprint-stale (issue #25)", async () => {
+		// Pre-#25 caches have no scanner_version; loadFreshRegistryIndex rejects
+		// them. Glob expansion must fail with the same registry-update guidance
+		// the single-name path emits, not silently expand against stale data.
+		const dir = await setup();
+		const configPath = join(dir, ".skilltree-config.yaml");
+		const cacheDir = join(dir, ".skilltree-cache");
+
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+
+		const indexPath = getRegistryIndexPath("vibes", cacheDir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		await writeFile(
+			indexPath,
+			JSON.stringify({
+				registry: "vibes",
+				repo: "github.com/imarios/vibes",
+				updated_at: new Date().toISOString(),
+				entities: [{ name: "kibana-search", type: "skill", path: "skills/kibana-search" }],
+			}),
+			"utf-8",
+		);
+
+		await expect(addCommand("kibana-*", { configPath, cacheDir, yes: true }, dir)).rejects.toThrow(
+			"registry update",
+		);
 	});
 
 	test("supports `?` as single-char glob", async () => {

--- a/tests/commands/registry.test.ts
+++ b/tests/commands/registry.test.ts
@@ -2,16 +2,17 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	DEFAULT_REGISTRIES,
 	inferRegistryName,
+	OUTDATED_SUFFIX,
 	registryAddCommand,
 	registryInitCommand,
 	registryListCommand,
 	registryRemoveCommand,
 } from "../../src/commands/registry.js";
-import { writeRegistryIndex } from "../../src/core/registry-cache.js";
+import { getRegistryIndexPath, writeRegistryIndex } from "../../src/core/registry-cache.js";
 import { readConfig, writeConfig } from "../../src/core/registry-config.js";
 import type { RegistryIndex } from "../../src/types.js";
 
@@ -195,6 +196,41 @@ describe("registryListCommand", () => {
 		expect(output).toContain("vibes");
 		expect(output).toContain("community");
 		expect(output).toContain("github.com/imarios/vibes");
+	});
+
+	test("annotates outdated caches (scanner_version mismatch) so users see they need to update", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+
+		// Hand-write a cache without scanner_version (pre-#25 shape).
+		const indexPath = getRegistryIndexPath("vibes", cacheDir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		const stale = {
+			registry: "vibes",
+			repo: "github.com/imarios/vibes",
+			updated_at: new Date().toISOString(),
+			entities: [{ name: "python-coding", type: "skill", path: "skills/python-coding" }],
+		};
+		await writeFile(indexPath, JSON.stringify(stale), "utf-8");
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await registryListCommand(configPath, cacheDir);
+		} finally {
+			console.log = originalLog;
+		}
+
+		const output = logs.join("\n");
+		expect(output).toContain("vibes");
+		expect(output).toContain(OUTDATED_SUFFIX);
 	});
 
 	test("shows message when no registries configured", async () => {

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { searchCommand } from "../../src/commands/search.js";
-import { writeRegistryIndex } from "../../src/core/registry-cache.js";
+import { getRegistryIndexPath, writeRegistryIndex } from "../../src/core/registry-cache.js";
 import { writeConfig } from "../../src/core/registry-config.js";
 import type { RegistryIndex } from "../../src/types.js";
 
@@ -140,5 +140,42 @@ describe("searchCommand", () => {
 		await expect(searchCommand("python", {}, configPath, join(dir, "cache"))).rejects.toThrow(
 			"No registry indexes",
 		);
+	});
+
+	test("ignores cached indexes that predate the scanner_version field (issue #25)", async () => {
+		// Repro: a build from before #25 wrote `index.json` without a
+		// `scanner_version` fingerprint. After upgrading skilltree, that cache
+		// is logically stale (e.g. it lacks slash-commands from the #21/#24 fix)
+		// but its `updated_at` is recent. `searchCommand` must NOT serve it.
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+
+		const indexPath = getRegistryIndexPath("vibes", cacheDir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		const preFixIndex = {
+			registry: "vibes",
+			repo: "github.com/imarios/vibes",
+			updated_at: new Date().toISOString(),
+			entities: [{ name: "python-coding", type: "skill", path: "skills/python-coding" }],
+		};
+		await writeFile(indexPath, JSON.stringify(preFixIndex), "utf-8");
+
+		// Suppress the warn() output during the test.
+		const originalWarn = console.warn;
+		console.warn = () => {
+			// noop — we don't want the warning printed during the assertion
+		};
+		try {
+			await expect(searchCommand("python", {}, configPath, cacheDir)).rejects.toThrow(
+				"No registry indexes",
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
 	});
 });

--- a/tests/commands/ux-fixes.test.ts
+++ b/tests/commands/ux-fixes.test.ts
@@ -5,13 +5,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { addCommand } from "../../src/commands/add.js";
 import { infoCommand } from "../../src/commands/info.js";
 import { initCommand } from "../../src/commands/init.js";
 import { registryAddCommand } from "../../src/commands/registry.js";
 import { searchCommand } from "../../src/commands/search.js";
-import { writeRegistryIndex } from "../../src/core/registry-cache.js";
+import { getRegistryIndexPath, writeRegistryIndex } from "../../src/core/registry-cache.js";
 import { addRegistry, writeConfig } from "../../src/core/registry-config.js";
 import { dynamicScanRepo } from "../../src/core/registry-scanner.js";
 import { scoreEntity, searchRegistries } from "../../src/core/registry-search.js";
@@ -117,6 +117,63 @@ describe("Fix #6: search/info exit codes", () => {
 		await writeRegistryIndex(index, cacheDir);
 
 		await expect(infoCommand("nonexistent", {}, configPath, cacheDir)).rejects.toThrow("not found");
+	});
+
+	test("infoCommand directs user to 'registry update' when every cache is outdated (issue #25)", async () => {
+		// When ALL caches are fingerprint-incompatible, loadFreshRegistryIndex
+		// returns null for every registry. The error message must NOT claim the
+		// entity is absent — it should tell the user to refresh the cache,
+		// otherwise they get stuck in an info → "try search" → search →
+		// "run registry update" loop.
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [{ name: "r", repo: "x" }] }, configPath);
+
+		// Hand-write a pre-#25 cache (no scanner_version → incompatible).
+		const indexPath = getRegistryIndexPath("r", cacheDir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		await writeFile(
+			indexPath,
+			JSON.stringify({
+				registry: "r",
+				repo: "x",
+				updated_at: new Date().toISOString(),
+				entities: [{ name: "python-coding", type: "skill", path: "skills/python-coding" }],
+			}),
+			"utf-8",
+		);
+
+		await expect(infoCommand("python-coding", {}, configPath, cacheDir)).rejects.toThrow(
+			"registry update",
+		);
+	});
+
+	test("infoCommand --json still throws on outdated caches (don't mask setup failure as empty result)", async () => {
+		// A scripted JSON consumer would otherwise see `[]` and treat it as
+		// "entity definitively absent". Setup failures must propagate as
+		// non-zero exits regardless of --json (matches search.ts behavior).
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [{ name: "r", repo: "x" }] }, configPath);
+
+		const indexPath = getRegistryIndexPath("r", cacheDir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		await writeFile(
+			indexPath,
+			JSON.stringify({
+				registry: "r",
+				repo: "x",
+				updated_at: new Date().toISOString(),
+				entities: [{ name: "python-coding", type: "skill", path: "skills/python-coding" }],
+			}),
+			"utf-8",
+		);
+
+		await expect(
+			infoCommand("python-coding", { json: true }, configPath, cacheDir),
+		).rejects.toThrow("registry update");
 	});
 });
 

--- a/tests/core/registry-cache.test.ts
+++ b/tests/core/registry-cache.test.ts
@@ -2,15 +2,19 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import simpleGit from "simple-git";
+import pkg from "../../package.json";
 import {
 	cleanRegistryCache,
 	ensureRegistryRepo,
 	getRegistryIndexPath,
 	getRegistryRepoDir,
+	isCacheCompatible,
 	isStale,
+	loadFreshRegistryIndex,
 	readRegistryIndex,
+	SCANNER_VERSION,
 	writeRegistryIndex,
 } from "../../src/core/registry-cache.js";
 import type { RegistryIndex } from "../../src/types.js";
@@ -113,6 +117,199 @@ describe("isStale", () => {
 		await writeRegistryIndex(index, dir);
 		const stale = await isStale("vibes", 24 * 60 * 60 * 1000, dir);
 		expect(stale).toBe(true);
+	});
+
+	test("returns true when scanner_version is missing (pre-#25 cache)", async () => {
+		// Defense in depth: even if the time-based check would say "fresh",
+		// a cache produced by a pre-fingerprint build is not safe to consume.
+		const dir = await setup();
+		const indexPath = getRegistryIndexPath("vibes", dir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		const raw = {
+			registry: "vibes",
+			repo: "github.com/imarios/vibes",
+			updated_at: new Date().toISOString(),
+			entities: [],
+		};
+		await writeFile(indexPath, JSON.stringify(raw), "utf-8");
+		const stale = await isStale("vibes", 24 * 60 * 60 * 1000, dir);
+		expect(stale).toBe(true);
+	});
+});
+
+describe("scanner_version stamping", () => {
+	test("writeRegistryIndex stamps the running SCANNER_VERSION and package_version", async () => {
+		const dir = await setup();
+		// Caller does NOT pass either field — they should be filled in.
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "github.com/imarios/vibes",
+			updated_at: new Date().toISOString(),
+			entities: [],
+		};
+		await writeRegistryIndex(index, dir);
+		const readBack = await readRegistryIndex("vibes", dir);
+		expect(readBack?.scanner_version).toBe(SCANNER_VERSION);
+		expect(readBack?.package_version).toBe(pkg.version);
+	});
+
+	test("writeRegistryIndex preserves an explicit scanner_version (no clobber on round-trip)", async () => {
+		// We never want callers to pin an arbitrary version, but the round-trip
+		// of read → write must not lose the field. The current design always
+		// stamps the running version, so this test pins that behavior:
+		// whatever caller passes is replaced by the running constant.
+		const dir = await setup();
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "github.com/imarios/vibes",
+			updated_at: new Date().toISOString(),
+			entities: [],
+			scanner_version: 99,
+		};
+		await writeRegistryIndex(index, dir);
+		const readBack = await readRegistryIndex("vibes", dir);
+		expect(readBack?.scanner_version).toBe(SCANNER_VERSION);
+	});
+});
+
+describe("isCacheCompatible", () => {
+	test("returns true when scanner_version matches", () => {
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			entities: [],
+			scanner_version: SCANNER_VERSION,
+		};
+		expect(isCacheCompatible(index)).toBe(true);
+	});
+
+	test("returns false when scanner_version is missing", () => {
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			entities: [],
+		};
+		expect(isCacheCompatible(index)).toBe(false);
+	});
+
+	test("returns false when scanner_version is older", () => {
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			entities: [],
+			scanner_version: SCANNER_VERSION - 1,
+		};
+		expect(isCacheCompatible(index)).toBe(false);
+	});
+
+	test("returns false when scanner_version is newer (downgrade scenario)", () => {
+		// If a user ran a newer skilltree once, then downgraded, the cache
+		// fingerprint now claims a higher version than this build can speak.
+		// Treat that as incompatible too — same UX as "needs rebuild".
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			entities: [],
+			scanner_version: SCANNER_VERSION + 1,
+		};
+		expect(isCacheCompatible(index)).toBe(false);
+	});
+});
+
+describe("loadFreshRegistryIndex", () => {
+	test("returns the index when scanner_version matches", async () => {
+		const dir = await setup();
+		const index: RegistryIndex = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			entities: [{ name: "foo", type: "skill", path: "skills/foo" }],
+		};
+		await writeRegistryIndex(index, dir);
+		const loaded = await loadFreshRegistryIndex("vibes", dir);
+		expect(loaded).not.toBeNull();
+		expect(loaded?.entities[0]?.name).toBe("foo");
+	});
+
+	test("returns null when index file is missing", async () => {
+		const dir = await setup();
+		const loaded = await loadFreshRegistryIndex("nonexistent", dir);
+		expect(loaded).toBeNull();
+	});
+
+	test("returns null for a corrupt JSON cache (truncated mid-write)", async () => {
+		// A torn write or hand-edit of index.json shouldn't crash consumers.
+		// The right remediation is identical to "missing" / "outdated":
+		// re-run `skilltree registry update`. So treat parse failures as null.
+		const dir = await setup();
+		const indexPath = getRegistryIndexPath("vibes", dir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		await writeFile(indexPath, '{"registry":"vibes","entities":[', "utf-8");
+
+		const loaded = await loadFreshRegistryIndex("vibes", dir);
+		expect(loaded).toBeNull();
+	});
+
+	test("returns null when entities is the wrong shape (defensive against corrupt cache)", async () => {
+		// Even with a valid scanner_version, if `entities` isn't an array,
+		// every consumer (search/info/add) would crash on `.length` or
+		// iteration. Treat shape-violations the same as missing.
+		const dir = await setup();
+		const indexPath = getRegistryIndexPath("vibes", dir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		await writeFile(
+			indexPath,
+			JSON.stringify({
+				registry: "vibes",
+				repo: "x",
+				updated_at: new Date().toISOString(),
+				scanner_version: SCANNER_VERSION,
+				entities: "not-an-array",
+			}),
+			"utf-8",
+		);
+
+		const loaded = await loadFreshRegistryIndex("vibes", dir);
+		expect(loaded).toBeNull();
+	});
+
+	test("returns null for a pre-#25 cache (no scanner_version)", async () => {
+		// Reproduces the issue #25 bug: a recently-generated but logically-stale
+		// index.json (produced by an older scanner) must NOT be served as fresh.
+		const dir = await setup();
+		const indexPath = getRegistryIndexPath("vibes", dir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		const raw = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(), // recent — would pass the time-based check
+			entities: [{ name: "foo", type: "skill", path: "skills/foo" }],
+		};
+		await writeFile(indexPath, JSON.stringify(raw), "utf-8");
+
+		const loaded = await loadFreshRegistryIndex("vibes", dir);
+		expect(loaded).toBeNull();
+	});
+
+	test("returns null when scanner_version is older than current build", async () => {
+		const dir = await setup();
+		const indexPath = getRegistryIndexPath("vibes", dir);
+		await mkdir(dirname(indexPath), { recursive: true });
+		const raw = {
+			registry: "vibes",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			scanner_version: SCANNER_VERSION - 1,
+			entities: [],
+		};
+		await writeFile(indexPath, JSON.stringify(raw), "utf-8");
+
+		const loaded = await loadFreshRegistryIndex("vibes", dir);
+		expect(loaded).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes #25. After the slash-command scanner fix in #21/#24, users on existing installs continued to see stale `skilltree search` results until they manually ran `skilltree registry update`, because cached `index.json` files had no fingerprint tying them to the scanner that produced them.

- Stamp every cached `index.json` with `scanner_version` (bumped when scan semantics change) + `package_version` (diagnostic). `SCANNER_VERSION = 1`; pre-#25 caches lack the field and bust automatically.
- New `loadFreshRegistryIndex` returns `null` for missing OR fingerprint-stale OR malformed-JSON OR shape-violating caches; `search`, `info`, `add` (single + glob) consume it so all consumer paths surface "run registry update" guidance.
- `info.ts`: distinguishes "no usable indexes" (→ run update) from "entity truly absent" (→ try search) so users don't ping-pong between commands. The registry-update guidance also flows through `--json` (non-zero exit on setup failure, matching `search`).
- `registry list` annotates outdated caches inline with `(outdated)` next to the timestamp.
- Defensive: `readRegistryIndex` now treats malformed JSON and shape-violating caches as missing instead of throwing opaque `SyntaxError` / `TypeError` at consumers.
- Inverse documentation link in `registry-scanner.ts` reminds future editors to bump `SCANNER_VERSION` when scan output changes.

## Test plan

- [x] New regression: pre-#25 cache (no `scanner_version`) makes `search` raise the registry-update guidance instead of silently serving stale results
- [x] New regression: `info` directs user to `registry update` when every cache is outdated (not "not found")
- [x] New regression: `info --json` still throws on outdated caches (no silent `[]` for scripted consumers)
- [x] New regression: glob `add 'kibana-*'` rejects fingerprint-stale caches with the same error guidance
- [x] New: `registry list` annotates outdated caches with `(outdated)`
- [x] New: `writeRegistryIndex` auto-stamps the running `SCANNER_VERSION` + `package_version` (round-trip read→write can't resurrect a stale fingerprint)
- [x] New: `isCacheCompatible` strict equality — both older and newer scanner_version are rejected
- [x] New: corrupt JSON / wrong-shape `entities` → treated as missing
- [x] Full suite: 885 pass / 0 fail (was 867 before this branch; +18 net tests)
- [x] Lint + typecheck + pre-commit hooks clean
- [ ] Manual smoke: with a vibes cache from a pre-fix build, run `skilltree search hypothesis` — expect the warning + skip; after `skilltree registry update vibes`, expect commands to appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)