### PR TITLE
fix(install): print 'Install order' once + friendly per-target labels (#20)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,7 +12,7 @@ import { addGitignoreEntries, getSkillAgentIgnoreEntries } from "../core/gitigno
 import { serializeManifest, writeGlobalManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { type LocalEntry, scanLocalRepo } from "../core/repo-scanner.js";
-import { dim, success, warn } from "../core/ui.js";
+import { dim, pluralize, success, warn } from "../core/ui.js";
 import type { Dependency, LocalDependency, Manifest } from "../types.js";
 
 export interface InitOptions {
@@ -220,8 +220,4 @@ export function parseSelectionAnswer(answer: string, entries: LocalEntry[]): Loc
 function toLocalPathValue(scanPath: string): string {
 	if (scanPath === "." || scanPath === "") return ".";
 	return scanPath.startsWith("./") ? scanPath : `./${scanPath}`;
-}
-
-function pluralize(word: string, n: number): string {
-	return n === 1 ? word : `${word}s`;
 }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,10 @@
 import { join } from "node:path";
+import {
+	AGENT_REGISTRY,
+	getAgentLabel,
+	resolveGlobalTarget,
+	resolveTarget,
+} from "../core/agents.js";
 import { isSingleFileEntity } from "../core/entity-type.js";
 import { getDeclaredDeps, parseFrontmatter } from "../core/frontmatter.js";
 import { ensureCached, getCommitSha } from "../core/git.js";
@@ -21,10 +27,20 @@ import {
 	getInstallTargets,
 	loadManifestOrThrow,
 	validateManifestOrThrow,
+	warnLegacyInstallPath,
 } from "../core/manifest.js";
-import { expandTilde, getGlobalDir, getGlobalInstallBase } from "../core/paths.js";
-import { dim, error, header, pc, success, throwOnResolutionErrors, warn } from "../core/ui.js";
-import type { Lockfile, Manifest } from "../types.js";
+import { collapseTilde, expandTilde, getGlobalDir, getGlobalInstallBase } from "../core/paths.js";
+import {
+	dim,
+	error,
+	header,
+	pc,
+	pluralize,
+	success,
+	throwOnResolutionErrors,
+	warn,
+} from "../core/ui.js";
+import type { EntityType, Lockfile, Manifest } from "../types.js";
 import { isLocalDependency } from "../types.js";
 
 export interface InstallCommandOptions extends InstallOptions {
@@ -32,17 +48,141 @@ export interface InstallCommandOptions extends InstallOptions {
 	globalDir?: string; // test override
 }
 
-function printInstallOrder(plan: InstallPlan): void {
+/**
+ * Single line for one entity in the "Install order" listing.
+ * Pure formatting helper — shared by the resolution-based and plan-based callers.
+ */
+function formatInstallOrderLine(index: number, entity: ResolvedEntity): string {
+	const version = entity.version ? pc.green(`@${entity.version}`) : "";
+	const source = entity.local ? dim("local") : dim(entity.repo ?? "");
+	return `  ${pc.bold(`${index + 1}.`)} ${entity.type}:${pc.cyan(entity.name)}${version} ${dim(`(${source})`)}`;
+}
+
+/**
+ * Print the install order from a plan. Used by the (single-target) frozen path.
+ */
+function printInstallOrderFromPlan(plan: InstallPlan): void {
 	header("\nInstall order:");
 	for (let i = 0; i < plan.toInstall.length; i++) {
 		const item = plan.toInstall[i];
 		if (!item) continue;
-		const version = item.entity.version ? pc.green(`@${item.entity.version}`) : "";
-		const source = item.entity.local ? dim("local") : dim(item.entity.repo ?? "");
-		console.log(
-			`  ${pc.bold(`${i + 1}.`)} ${item.entity.type}:${pc.cyan(item.entity.name)}${version} ${dim(`(${source})`)}`,
-		);
+		console.log(formatInstallOrderLine(i, item.entity));
 	}
+}
+
+/**
+ * Print the install order from a resolution result. The order is target-agnostic
+ * (it's determined by the dependency graph, not the install location), so this
+ * is printed exactly once regardless of how many install targets there are.
+ *
+ * Skips entities filtered out by `--prod` so the listing matches what will
+ * actually be installed.
+ */
+function printInstallOrderFromResolution(
+	result: { entities: Map<string, ResolvedEntity>; installOrder: string[] },
+	options: InstallOptions,
+): void {
+	header("\nInstall order:");
+	let i = 0;
+	for (const compositeKey of result.installOrder) {
+		const entity = result.entities.get(compositeKey);
+		if (!entity) continue;
+		if (options.prod && entity.group === "dev") continue;
+		console.log(formatInstallOrderLine(i, entity));
+		i++;
+	}
+}
+
+interface TargetInfo {
+	/** Absolute path where files are written. */
+	installBase: string;
+	/** Relative directory shown to the user (e.g., ".claude" or "./vendor/foo"). */
+	displayDir: string;
+	/** Friendly agent label for known agents, or null for literal paths / overrides. */
+	label: string | null;
+}
+
+/**
+ * Build TargetInfo for project install. Mirrors `getInstallTargets()` but
+ * preserves the raw target name so we can recover the friendly agent label.
+ *
+ * - `install_targets` entries go through the agent registry (so "claude" → ".claude").
+ * - Legacy `dev_install_path` / `install_path` are literal paths and are passed
+ *   through unchanged (they are not agent registry keys).
+ */
+function buildProjectTargets(manifest: Manifest, dir: string): TargetInfo[] {
+	if (manifest.install_targets) {
+		return manifest.install_targets.map((raw) => {
+			const displayDir = resolveTarget(raw);
+			return {
+				installBase: join(dir, displayDir),
+				displayDir,
+				label: getAgentLabel(raw),
+			};
+		});
+	}
+	const legacy = manifest.dev_install_path ?? manifest.install_path ?? ".claude";
+	return [
+		{
+			installBase: join(dir, legacy),
+			displayDir: legacy,
+			label: null,
+		},
+	];
+}
+
+/**
+ * Build TargetInfo for global install. Same shape as the project variant but
+ * `displayDir` keeps the `~/...` form for readable output.
+ */
+function buildGlobalTargets(manifest: Manifest): TargetInfo[] {
+	const rawTargets = manifest.install_targets ?? [];
+	if (rawTargets.length === 0) {
+		const fallback = getGlobalInstallBase();
+		return [{ installBase: fallback, displayDir: fallback, label: null }];
+	}
+	return rawTargets.map((raw) => {
+		// For known agents, show the unexpanded `~/...` form so output is portable.
+		const registryEntry = AGENT_REGISTRY[raw];
+		return {
+			installBase: resolveGlobalTarget(raw),
+			displayDir: registryEntry?.globalHome ?? raw,
+			label: getAgentLabel(raw),
+		};
+	});
+}
+
+/**
+ * Pluralized count by entity type, e.g. "5 skills + 2 agents + 1 command".
+ * Returns "0 skills" when the plan is empty so the line still reads naturally.
+ */
+function formatEntityCounts(plan: InstallPlan): string {
+	const counts: Record<EntityType, number> = { skill: 0, agent: 0, command: 0 };
+	for (const item of plan.toInstall) {
+		counts[item.entity.type]++;
+	}
+
+	const parts: string[] = [];
+	const order: EntityType[] = ["skill", "agent", "command"];
+	for (const type of order) {
+		const n = counts[type];
+		if (n === 0) continue;
+		parts.push(`${n} ${pluralize(type, n)}`);
+	}
+	if (parts.length === 0) return "0 skills";
+	return parts.join(" + ");
+}
+
+/**
+ * Build the per-target "Installing agent knowledge for X… (.claude/) — N skills" line.
+ */
+function formatPerTargetLine(target: TargetInfo, plan: InstallPlan): string {
+	const counts = formatEntityCounts(plan);
+	const dir = dim(`(${target.displayDir})`);
+	if (target.label) {
+		return `Installing agent knowledge for ${pc.bold(target.label)}… ${dir} — ${counts}`;
+	}
+	return `Installing into ${pc.bold(target.displayDir)}… — ${counts}`;
 }
 
 export async function installCommand(dir: string, options: InstallCommandOptions): Promise<void> {
@@ -62,6 +202,7 @@ export async function installCommand(dir: string, options: InstallCommandOptions
 	}
 
 	validateManifestOrThrow(manifest);
+	warnLegacyInstallPath(manifest);
 
 	const existingLockfile = await readLockfile(dir);
 
@@ -76,26 +217,28 @@ export async function installCommand(dir: string, options: InstallCommandOptions
 	const result = await resolveWithLockfile(manifest, existingLockfile, dir);
 	throwOnResolutionErrors(result);
 
-	// Determine install targets
-	const resolvedTargets = options.installPath
-		? [options.installPath]
-		: getInstallTargets(manifest).map((t) => join(dir, t));
+	// Determine install targets — preserves agent labels for friendly per-target output.
+	const targets: TargetInfo[] = options.installPath
+		? [{ installBase: options.installPath, displayDir: options.installPath, label: null }]
+		: buildProjectTargets(manifest, dir);
+
+	// Print install order once — it's the same across targets.
+	printInstallOrderFromResolution(result, options);
 
 	const srcInstallBase = manifest.src_install_path ? join(dir, manifest.src_install_path) : null;
-	const integrityMap = await installToTargets(
-		result,
-		resolvedTargets,
-		srcInstallBase,
-		dir,
-		options,
-	);
+	const integrityMap = await installToTargets(result, targets, srcInstallBase, dir, options);
 
 	if (options.dryRun) return;
 
 	warnStaleTargets(existingLockfile, getInstallTargets(manifest));
 
 	const lockfile = buildLockfile(result.entities);
-	lockfile.install_targets = getInstallTargets(manifest);
+	// Only record install_targets in the lockfile when the user actually set
+	// them — mirrors the global path. Otherwise a legacy `dev_install_path`
+	// manifest gets a synthetic `install_targets: [".claude"]` written to disk.
+	if (manifest.install_targets) {
+		lockfile.install_targets = getInstallTargets(manifest);
+	}
 	applyIntegrityHashes(lockfile, integrityMap, existingLockfile);
 	await writeLockfile(dir, lockfile);
 	console.log(dim("Updated skilltree.lock"));
@@ -104,29 +247,30 @@ export async function installCommand(dir: string, options: InstallCommandOptions
 
 async function installToTargets(
 	result: { entities: Map<string, ResolvedEntity>; installOrder: string[] },
-	targets: string[],
+	targets: TargetInfo[],
 	srcInstallBase: string | null,
 	dir: string,
 	options: InstallOptions,
 ): Promise<Map<string, string>> {
 	let integrityMap: Map<string, string> = new Map();
+	let skippedReported = false;
 
-	for (const installBase of targets) {
-		const primaryBase = options.prod && srcInstallBase ? srcInstallBase : installBase;
+	for (const target of targets) {
+		const primaryBase = options.prod && srcInstallBase ? srcInstallBase : target.installBase;
 		const plan = await planInstall(result.entities, result.installOrder, primaryBase, options);
 
-		printInstallOrder(plan);
-
-		if (plan.skipped.length > 0) {
+		// `--prod` skips are target-agnostic — report once, not once per target.
+		if (plan.skipped.length > 0 && !skippedReported) {
 			console.log(dim(`\nSkipped ${plan.skipped.length} dev dependencies (--prod)`));
+			skippedReported = true;
 		}
 
 		if (options.dryRun) {
-			console.log(pc.yellow("\nDry run — no files written."));
+			console.log(`\n${formatPerTargetLine(target, plan)} ${dim("(dry run)")}`);
 			continue;
 		}
 
-		console.log(`\nInstalling ${pc.bold(String(plan.toInstall.length))} entities...`);
+		console.log(`\n${formatPerTargetLine(target, plan)}`);
 		integrityMap = await executeInstall(plan, dir, options);
 
 		if (srcInstallBase && !options.prod) {
@@ -176,9 +320,7 @@ async function installGlobal(options: InstallCommandOptions): Promise<void> {
 	const manifest = await loadManifestOrThrow("", { global: true, globalDir });
 	validateManifestOrThrow(manifest, true);
 
-	const resolvedTargets = getInstallTargets(manifest, { global: true });
-	// Fallback: if no install_targets set, use legacy hardcoded path
-	const installBases = resolvedTargets.length > 0 ? resolvedTargets : [getGlobalInstallBase()];
+	const targets = buildGlobalTargets(manifest);
 
 	const existingLockfile = await readGlobalLockfile(globalDir);
 
@@ -188,7 +330,7 @@ async function installGlobal(options: InstallCommandOptions): Promise<void> {
 		}
 		await frozenInstall(manifest, existingLockfile, globalDir, {
 			...options,
-			installPath: installBases[0],
+			installPath: targets[0]?.installBase,
 		});
 		return;
 	}
@@ -196,7 +338,10 @@ async function installGlobal(options: InstallCommandOptions): Promise<void> {
 	const result = await resolveWithLockfile(manifest, existingLockfile, globalDir, "Global ");
 	throwOnResolutionErrors(result);
 
-	const integrityMap = await installToTargets(result, installBases, null, globalDir, options);
+	// Print install order once — shared across all targets.
+	printInstallOrderFromResolution(result, options);
+
+	const integrityMap = await installToTargets(result, targets, null, globalDir, options);
 
 	if (options.dryRun) return;
 
@@ -289,16 +434,43 @@ async function frozenInstall(
 	const primaryBase = options.prod && srcBase ? srcBase : devBase;
 	const plan = await planInstall(entities, installOrder, primaryBase, options);
 
-	printInstallOrder(plan);
+	printInstallOrderFromPlan(plan);
+
+	// Reconstruct a TargetInfo so frozen output matches the regular install line.
+	const target = frozenTarget(primaryBase, dir, manifest);
 
 	if (options.dryRun) {
-		console.log(pc.yellow("\nDry run — no files written."));
+		console.log(`\n${formatPerTargetLine(target, plan)} ${dim("(dry run)")}`);
 		return;
 	}
 
-	console.log(`\nInstalling ${pc.bold(String(plan.toInstall.length))} entities...`);
+	console.log(`\n${formatPerTargetLine(target, plan)}`);
 	await executeInstall(plan, dir, options);
 	success("Done.");
+}
+
+/**
+ * Best-effort TargetInfo for the single-target frozen path. Used to format
+ * the per-target line consistently with the regular install path.
+ *
+ * `displayDir` precedence:
+ *   1. Strip a leading `${dir}/` prefix when the install base is under the
+ *      project root → readable relative path like `.claude`.
+ *   2. Fall back to `~/...` form via collapseTilde for absolute paths under
+ *      the user's home (covers global frozen, where `dir` is `~/.skilltree`
+ *      but installBase is `~/.claude`).
+ *   3. Otherwise show the absolute path verbatim — the user passed it.
+ */
+function frozenTarget(installBase: string, dir: string, manifest: Manifest): TargetInfo {
+	const raw = manifest.install_targets?.[0];
+	const label = raw ? getAgentLabel(raw) : null;
+	let displayDir: string;
+	if (installBase.startsWith(`${dir}/`)) {
+		displayDir = installBase.slice(dir.length + 1);
+	} else {
+		displayDir = collapseTilde(installBase);
+	}
+	return { installBase, displayDir, label };
 }
 
 function verifyFrozenSync(manifest: Manifest, lockfile: Lockfile): void {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -12,6 +12,8 @@ import {
 import {
 	getDevInstallPath,
 	loadManifestOrThrow,
+	validateManifestOrThrow,
+	warnLegacyInstallPath,
 	writeGlobalManifest,
 	writeManifest,
 } from "../core/manifest.js";
@@ -35,6 +37,11 @@ export async function removeCommand(
 	const isGlobal = !!options.global;
 
 	const manifest = await loadManifestOrThrow(dir, { global: isGlobal, globalDir });
+	// Validate first — match the install command's invariants so a malformed
+	// global manifest (e.g., with `dev_install_path`) errors loudly instead of
+	// silently using `~/.claude` and ignoring the user's stated intent.
+	validateManifestOrThrow(manifest, isGlobal);
+	if (!isGlobal) warnLegacyInstallPath(manifest);
 	const lockfile = isGlobal ? await readGlobalLockfile(globalDir) : await readLockfile(dir);
 
 	validateRemoveTarget(name, manifest, lockfile, isGlobal);

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -19,6 +19,7 @@ import {
 	getInstallTargets,
 	loadManifestOrThrow,
 	validateManifestOrThrow,
+	warnLegacyInstallPath,
 	writeManifest,
 } from "../core/manifest.js";
 import { dim, header, pc, success, throwOnResolutionErrors, warn } from "../core/ui.js";
@@ -33,6 +34,7 @@ export interface VendorOptions {
 export async function vendorCommand(dir: string, options: VendorOptions): Promise<void> {
 	const manifest = await loadManifestOrThrow(dir);
 	validateManifestOrThrow(manifest);
+	warnLegacyInstallPath(manifest);
 
 	// Resolve vendor target — single target only
 	const targets = getInstallTargets(manifest);

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -23,6 +23,21 @@ export const AGENT_REGISTRY: Record<string, AgentEntry> = {
 	windsurf: { dir: ".windsurf", globalHome: "~/.codeium/windsurf" },
 };
 
+/**
+ * Display labels for known agents — used in install output so users see
+ * "Claude Code" instead of the bare registry key "claude".
+ *
+ * Keep keys in sync with AGENT_REGISTRY.
+ */
+export const AGENT_LABELS: Record<string, string> = {
+	claude: "Claude Code",
+	codex: "Codex",
+	copilot: "GitHub Copilot",
+	cursor: "Cursor",
+	gemini: "Gemini CLI",
+	windsurf: "Windsurf",
+};
+
 function lookupAgent(target: string): AgentEntry {
 	const entry = AGENT_REGISTRY[target];
 	if (!entry) {
@@ -51,6 +66,16 @@ export function resolveTarget(target: string): string {
 export function resolveGlobalTarget(target: string): string {
 	if (isLocalSource(target)) return target;
 	return expandTilde(lookupAgent(target).globalHome);
+}
+
+/**
+ * Friendly display label for a target. Returns the label for known agent
+ * registry keys (e.g., "claude" → "Claude Code") and `null` for literal
+ * paths or unknown bare words — callers should fall back to the path.
+ */
+export function getAgentLabel(target: string): string | null {
+	if (isLocalSource(target)) return null;
+	return AGENT_LABELS[target] ?? null;
 }
 
 /**

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -84,20 +84,34 @@ export function getDevInstallPath(manifest: Manifest): string {
 /**
  * Resolve install targets from manifest.
  * - If `install_targets` is set, resolve each entry via the agent registry
- * - If only `dev_install_path` is set, return it as a single-element array (with deprecation warning)
+ * - If only `dev_install_path` is set, return it as a single-element array
  * - If neither is set, default to [".claude"]
+ *
+ * Note: this helper is called from multiple sites in a single command run
+ * (e.g., target build + lockfile build + stale-target check), so the
+ * deprecation warning lives in `warnLegacyInstallPath` instead — call that
+ * once per command from the entry point.
  */
 export function getInstallTargets(manifest: Manifest, opts?: { global?: boolean }): string[] {
 	const resolve = opts?.global ? resolveGlobalTarget : resolveTarget;
 	if (manifest.install_targets) {
 		return manifest.install_targets.map(resolve);
 	}
+	return [getDevInstallPath(manifest)];
+}
+
+/**
+ * Emit a deprecation warning when a manifest still uses legacy
+ * `dev_install_path` / `install_path` instead of `install_targets`.
+ * Idempotent per call — fire once at the start of a command.
+ */
+export function warnLegacyInstallPath(manifest: Manifest): void {
+	if (manifest.install_targets) return;
 	if (manifest.dev_install_path || manifest.install_path) {
 		warn(
 			"dev_install_path is deprecated — use install_targets instead. Run: skilltree targets migrate",
 		);
 	}
-	return [getDevInstallPath(manifest)];
 }
 
 /**
@@ -244,6 +258,14 @@ export function validateGlobalManifest(manifest: Manifest): string[] {
 	}
 	if (manifest.src_install_path) {
 		errors.push("Global manifest does not support src_install_path.");
+	}
+	// Per docs/specs/global.md: legacy install-path fields are project-only.
+	// Without this guard, the field is silently dropped by buildGlobalTargets.
+	if (manifest.dev_install_path) {
+		errors.push("Global manifest does not support dev_install_path. Use install_targets instead.");
+	}
+	if (manifest.install_path) {
+		errors.push("Global manifest does not support install_path. Use install_targets instead.");
 	}
 	if (manifest.vendor) {
 		errors.push("Global manifest does not support vendor mode.");

--- a/src/core/ui.ts
+++ b/src/core/ui.ts
@@ -27,6 +27,9 @@ export const tableHeader = (msg: string) => console.log(pc.bold(pc.underline(msg
 /** Blue for labels/keys in info displays */
 export const label = (msg: string) => pc.blue(msg);
 
+/** Naive English pluralizer: returns `word` for n=1, `${word}s` otherwise. */
+export const pluralize = (word: string, n: number): string => (n === 1 ? word : `${word}s`);
+
 /**
  * Print resolution warnings and throw if errors exist.
  * Used by install, installGlobal, and vendor commands.

--- a/tests/commands/install-deprecation.test.ts
+++ b/tests/commands/install-deprecation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression tests for legacy install-path deprecation warnings.
+ *
+ * Background: `warnLegacyInstallPath` lives outside `getInstallTargets` so the
+ * warning fires even in `--dry-run` and `--frozen` modes (which short-circuit
+ * before the code paths that previously called `getInstallTargets`).
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installCommand } from "../../src/commands/install.js";
+import { removeCommand } from "../../src/commands/remove.js";
+import { createLocalSkill } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-depr-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+/** Capture console.warn output during fn(). */
+async function captureWarn(fn: () => Promise<void>): Promise<string[]> {
+	const warns: string[] = [];
+	const original = console.warn;
+	console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+	try {
+		await fn();
+	} finally {
+		console.warn = original;
+	}
+	return warns;
+}
+
+const LEGACY_MANIFEST =
+	"dev_install_path: .claude\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n";
+
+async function writeManifest(dir: string, content: string): Promise<void> {
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
+}
+
+describe("dev_install_path deprecation warning", () => {
+	test("emits warning in normal install mode", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, LEGACY_MANIFEST);
+
+		const warns = await captureWarn(() => installCommand(dir, {}));
+		expect(warns.some((w) => w.includes("deprecated"))).toBe(true);
+	});
+
+	test("emits warning in --dry-run mode", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, LEGACY_MANIFEST);
+
+		const warns = await captureWarn(() => installCommand(dir, { dryRun: true }));
+		expect(warns.some((w) => w.includes("deprecated"))).toBe(true);
+	});
+
+	test("emits warning in --frozen mode", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, LEGACY_MANIFEST);
+
+		// First do a normal install to produce a lockfile.
+		await installCommand(dir, {});
+
+		const warns = await captureWarn(() => installCommand(dir, { frozen: true }));
+		expect(warns.some((w) => w.includes("deprecated"))).toBe(true);
+	});
+
+	test("emits warning when removing from a project with legacy field", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, LEGACY_MANIFEST);
+
+		// Install first so there's something to remove.
+		await installCommand(dir, {});
+
+		const warns = await captureWarn(() => removeCommand("my-skill", dir, { force: true }));
+		expect(warns.some((w) => w.includes("deprecated"))).toBe(true);
+	});
+});
+
+describe("global manifest rejects legacy install-path fields", () => {
+	test("validateGlobalManifest reports dev_install_path", async () => {
+		const { validateGlobalManifest, parseManifest } = await import("../../src/core/manifest.js");
+		const m = parseManifest("dev_install_path: .claude\ndependencies: {}\n");
+		const errors = validateGlobalManifest(m);
+		expect(errors.some((e) => e.includes("dev_install_path"))).toBe(true);
+	});
+
+	test("validateGlobalManifest reports install_path", async () => {
+		const { validateGlobalManifest, parseManifest } = await import("../../src/core/manifest.js");
+		const m = parseManifest("install_path: .claude\ndependencies: {}\n");
+		const errors = validateGlobalManifest(m);
+		expect(errors.some((e) => e.includes("install_path"))).toBe(true);
+	});
+
+	test("removeCommand --global rejects legacy global manifest", async () => {
+		const dir = await makeTempDir();
+		const globalDir = join(dir, "global-config");
+		const { mkdir } = await import("node:fs/promises");
+		await mkdir(globalDir, { recursive: true });
+		// Legacy global manifest: dev_install_path with no install_targets,
+		// plus one dependency so removeCommand has a candidate to look at.
+		await writeFile(
+			join(globalDir, "global.yaml"),
+			"dev_install_path: .claude\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
+			"utf-8",
+		);
+
+		await expect(
+			removeCommand("my-skill", dir, { global: true, globalDir, force: true }),
+		).rejects.toThrow("Global manifest validation failed");
+	});
+});

--- a/tests/commands/install-output.test.ts
+++ b/tests/commands/install-output.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for `skilltree install` console output formatting.
+ *
+ * Issue #20: with multiple `install_targets`, the "Install order" block was
+ * printed once per target. It should be printed exactly once, and the
+ * per-target line should name the agent in human-friendly form.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { installCommand } from "../../src/commands/install.js";
+import { createLocalSkill } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-install-out-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+/** Capture console.log output and return joined string. */
+async function captureOutput(fn: () => Promise<void>): Promise<string> {
+	const logs: string[] = [];
+	const originalLog = console.log;
+	console.log = (...args: unknown[]) => logs.push(args.join(" "));
+	try {
+		await fn();
+	} finally {
+		console.log = originalLog;
+	}
+	return logs.join("\n");
+}
+
+/** Strip ANSI codes so we can match raw text. */
+function stripAnsi(s: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: need to match ANSI escape sequences
+	return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+async function writeManifest(dir: string, content: string): Promise<void> {
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
+}
+
+describe("install output: single 'Install order' block (issue #20)", () => {
+	test("prints 'Install order:' exactly once with multiple install_targets", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+		await createLocalSkill(join(dir, "skills"), "beta");
+
+		await writeManifest(
+			dir,
+			[
+				"name: test",
+				"install_targets:",
+				"  - claude",
+				"  - codex",
+				"  - cursor",
+				"  - gemini",
+				"dependencies:",
+				"  alpha:",
+				"    local: ./skills/alpha",
+				"  beta:",
+				"    local: ./skills/beta",
+				"",
+			].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, {}));
+		const clean = stripAnsi(output);
+
+		// Should appear exactly once even though there are 4 install targets.
+		const matches = clean.match(/Install order:/g) ?? [];
+		expect(matches.length).toBe(1);
+	});
+
+	test("prints 'Install order:' once with a single install_target", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+
+		await writeManifest(
+			dir,
+			[
+				"name: test",
+				"install_targets:",
+				"  - claude",
+				"dependencies:",
+				"  alpha:",
+				"    local: ./skills/alpha",
+				"",
+			].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, {}));
+		const clean = stripAnsi(output);
+
+		const matches = clean.match(/Install order:/g) ?? [];
+		expect(matches.length).toBe(1);
+	});
+});
+
+describe("install output: friendly per-target label (issue #20)", () => {
+	test("per-target line uses friendly agent labels", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+
+		await writeManifest(
+			dir,
+			[
+				"name: test",
+				"install_targets:",
+				"  - claude",
+				"  - codex",
+				"dependencies:",
+				"  alpha:",
+				"    local: ./skills/alpha",
+				"",
+			].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, {}));
+		const clean = stripAnsi(output);
+
+		// Friendly names appear (one per target).
+		expect(clean).toContain("Claude Code");
+		expect(clean).toContain("Codex");
+
+		// Resolved directories appear next to the labels.
+		expect(clean).toContain(".claude");
+		expect(clean).toContain(".agents");
+
+		// Counts use entity-type words instead of "entities" / "skills".
+		// At least pluralized "skill" should appear.
+		expect(clean).toMatch(/\bskill\b|\bskills\b/);
+	});
+
+	test("literal-path target shows path as-is (no friendly label)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+
+		await writeManifest(
+			dir,
+			[
+				"name: test",
+				"install_targets:",
+				"  - ./vendor/foo",
+				"dependencies:",
+				"  alpha:",
+				"    local: ./skills/alpha",
+				"",
+			].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, {}));
+		const clean = stripAnsi(output);
+
+		// Path should appear in the per-target line.
+		expect(clean).toContain("./vendor/foo");
+	});
+});
+
+describe("frozen install output: friendly tilde path", () => {
+	test("frozen install with home-relative installBase shows ~/... not absolute path", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(
+			dir,
+			["name: test", "dependencies:", "  my-skill:", "    local: ./skills/my-skill", ""].join("\n"),
+		);
+
+		// Regular install first to produce lockfile.
+		await installCommand(dir, {});
+
+		// Frozen install with installBase pointing under home — exercises the
+		// `collapseTilde` fallback in `frozenTarget`.
+		const home = homedir();
+		const homeBase = join(home, ".skilltree-test-home-base");
+		try {
+			const output = await captureOutput(() =>
+				installCommand(dir, { frozen: true, installPath: homeBase }),
+			);
+			const clean = stripAnsi(output);
+			// Friendly tilde form must appear; raw home prefix must not.
+			expect(clean).toContain("~/.skilltree-test-home-base");
+			expect(clean).not.toContain(home);
+		} finally {
+			await rm(homeBase, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("install output: 'entities' wording removed (issue #20)", () => {
+	test("does not use the opaque 'entities' jargon in per-target line", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+
+		await writeManifest(
+			dir,
+			[
+				"name: test",
+				"install_targets:",
+				"  - claude",
+				"dependencies:",
+				"  alpha:",
+				"    local: ./skills/alpha",
+				"",
+			].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, {}));
+		const clean = stripAnsi(output);
+
+		// "Installing N entities..." should be gone — replaced by the friendly line.
+		expect(clean).not.toMatch(/Installing \d+ entities/);
+	});
+});

--- a/tests/core/agents.test.ts
+++ b/tests/core/agents.test.ts
@@ -4,6 +4,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	detectInstalledAgents,
+	getAgentLabel,
 	getKnownAgentNames,
 	pathToAgentName,
 	resolveGlobalTarget,
@@ -145,6 +146,27 @@ describe("detectInstalledAgents", () => {
 
 		const agents = await detectInstalledAgents(tempDir);
 		expect(agents).toContain("copilot");
+	});
+});
+
+describe("getAgentLabel", () => {
+	test("returns friendly label for each known agent", () => {
+		expect(getAgentLabel("claude")).toBe("Claude Code");
+		expect(getAgentLabel("codex")).toBe("Codex");
+		expect(getAgentLabel("copilot")).toBe("GitHub Copilot");
+		expect(getAgentLabel("cursor")).toBe("Cursor");
+		expect(getAgentLabel("gemini")).toBe("Gemini CLI");
+		expect(getAgentLabel("windsurf")).toBe("Windsurf");
+	});
+
+	test("returns null for literal paths", () => {
+		expect(getAgentLabel("./custom")).toBeNull();
+		expect(getAgentLabel("/abs/path")).toBeNull();
+		expect(getAgentLabel("~/somewhere")).toBeNull();
+	});
+
+	test("returns null for unknown bare words", () => {
+		expect(getAgentLabel("foo")).toBeNull();
 	});
 });
 


### PR DESCRIPTION
Closes #20.

## Summary

- Hoist `printInstallOrderFromResolution` out of the per-target loop — the install order is target-agnostic so it now prints exactly once instead of once per `install_target` (4× duplication on a typical multi-agent setup).
- Replace `Installing N entities...` with `Installing agent knowledge for Claude Code… (.claude) — 7 skills` using a new `AGENT_LABELS` map and pluralized entity-type counts. Falls back to `Installing into <path>… — N skills` for literal-path targets.
- Use `collapseTilde` in `frozenTarget` so global frozen output shows `~/.claude` instead of the absolute home path.

## Hardening (uncovered by 5 rounds of `/code-refinement-with-hypothesis`)

- Extract `warnLegacyInstallPath` so the `dev_install_path is deprecated` warning fires in `--dry-run` and `--frozen` modes (previously lost because both paths bypass `getInstallTargets`).
- Add the warning + `validateManifestOrThrow` to `removeCommand` so `remove --global` rejects malformed global manifests symmetrically with `install --global`.
- `validateGlobalManifest` now hard-rejects `dev_install_path` / `install_path` for global manifests per `docs/specs/global.md` (previously silently dropped).
- Lockfile no longer records a synthetic `install_targets: [".claude"]` for legacy-only manifests — mirrors the existing global guard.
- Promote `pluralize` from `init.ts` to shared `core/ui.ts` and reuse it in `formatEntityCounts`.

## Output sample

Before:
```
Install order: ... (4× duplicated)
Installing 7 entities...   (4×)
```

After:
```
Install order:
  1. skill:alpha (local)
  2. skill:beta (local)

Installing agent knowledge for Claude Code… (.claude) — 2 skills
Installing agent knowledge for Codex… (.agents) — 2 skills
Installing agent knowledge for Cursor… (.cursor) — 2 skills
Installing agent knowledge for Gemini CLI… (.gemini) — 2 skills
```

## Test plan

- [x] `bun test` — 883 pass (was 875; 8 new regression tests added in `tests/commands/install-output.test.ts` + `tests/commands/install-deprecation.test.ts` + `tests/core/agents.test.ts`)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Manual smoke test: `skilltree install` in a multi-agent project (claude/codex/cursor/gemini) — output matches the sample above.
- [x] `skilltree install --dry-run` with legacy `dev_install_path` — deprecation warning now fires.
- [x] `skilltree install --frozen` against home-relative install path — output shows `~/...` form.
- [x] `skilltree remove --global` against malformed global manifest — rejects with validation error.

## Follow-ups

Six small follow-ups (3 pre-existing, 3 from review) tracked in #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)