### PR TITLE
feat(add): apply --type filter during registry resolution and glob expansion (#22)

### DIFF
--- a/src/commands/_complete.ts
+++ b/src/commands/_complete.ts
@@ -15,10 +15,18 @@
 
 import { getKnownAgentNames } from "../core/agents.js";
 import { getAllDependencyNames, readGlobalManifest, readManifest } from "../core/manifest.js";
+import { listRegistries } from "../core/registry-config.js";
 import type { Manifest } from "../types.js";
 
-export const COMPLETE_KINDS = ["deps", "targets", "agents"] as const;
+export const COMPLETE_KINDS = ["deps", "targets", "agents", "types", "registries"] as const;
 export type CompleteKind = (typeof COMPLETE_KINDS)[number];
+
+/**
+ * Static set for the `types` kind. Hard-coded (not derived from a TS union)
+ * because completion must succeed without a project manifest. Update both
+ * here and `EntityType` in `types.ts` if the set ever changes.
+ */
+const ENTITY_TYPE_NAMES: readonly string[] = ["agent", "command", "skill"];
 
 export function isCompleteKind(value: string): value is CompleteKind {
 	return COMPLETE_KINDS.includes(value as CompleteKind);
@@ -28,6 +36,7 @@ export interface CompleteOptions {
 	global?: boolean;
 	dir?: string; // override CWD (testing)
 	globalDir?: string; // override ~/.skilltree (testing)
+	configPath?: string; // override ~/.skilltree/config.yaml (testing)
 }
 
 /**
@@ -56,6 +65,12 @@ export async function getSuggestions(
 				return [...((await loadManifest(opts)).install_targets ?? [])].sort();
 			case "agents":
 				return getKnownAgentNames();
+			case "types":
+				return [...ENTITY_TYPE_NAMES].sort();
+			case "registries": {
+				const entries = await listRegistries(opts.configPath);
+				return entries.map((r) => r.name).sort();
+			}
 			default:
 				kind satisfies never;
 				return [];

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -113,11 +113,18 @@ async function addGlobCommand(pattern: string, opts: AddOptions, dir: string): P
 
 	const re = globToRegex(pattern);
 	const all = await loadRegistryEntities(opts);
-	const items = buildGlobPreview(all.filter((m) => re.test(m.entity.name)));
+	// `--type` filters expansion (Issue #22). Without it, `add 'hyp-*' --type
+	// command` would still pull in matching skills/agents — surprising and
+	// inconsistent with single-name resolution.
+	const matched = all.filter(
+		(m) => re.test(m.entity.name) && (!opts.type || m.entity.type === opts.type),
+	);
+	const items = buildGlobPreview(matched);
 
 	if (items.length === 0) {
+		const typeHint = opts.type ? ` of type '${opts.type}'` : "";
 		throw new Error(
-			`Glob "${pattern}": no entries matched in any registry. Run 'skilltree search ${pattern.replace(/[*?]/g, "")}' to see available names.`,
+			`Glob "${pattern}": no entries${typeHint} matched in any registry. Run 'skilltree search ${pattern.replace(/[*?]/g, "")}' to see available names.`,
 		);
 	}
 
@@ -436,16 +443,34 @@ function checkOtherGroup(
  * the "found in: X, Y" hint when the name is missing from the requested
  * registry but present elsewhere. The cross-registry name check is the
  * reason this can't simply pre-filter via `loadRegistryEntities`.
+ *
+ * `--type` is applied as an *additional* filter on top of `--registry` (Issue
+ * #22). Two same-named entries in one registry that differ only in type
+ * (skill vs command) are unresolvable without it.
  */
 async function resolveFromRegistries(name: string, opts: AddOptions): Promise<Dependency> {
 	const allEntities = await loadRegistryEntities({ ...opts, registry: undefined });
-	const matches = allEntities.filter((m) => m.entity.name === name);
-	const filtered = opts.registry ? matches.filter((m) => m.registry === opts.registry) : matches;
+	const nameMatches = allEntities.filter((m) => m.entity.name === name);
+	const byRegistry = opts.registry
+		? nameMatches.filter((m) => m.registry === opts.registry)
+		: nameMatches;
+	const filtered = opts.type ? byRegistry.filter((m) => m.entity.type === opts.type) : byRegistry;
 
 	if (filtered.length === 0) {
-		if (opts.registry && matches.length > 0) {
+		// Distinguish three "no match" cases so the error names the actual
+		// constraint that eliminated everything. Order matters: check
+		// registry-only emptiness first so a user who typoed --registry
+		// gets the existing "found in: X, Y" hint instead of a confusing
+		// "no entries of type" message.
+		if (opts.registry && nameMatches.length > 0 && byRegistry.length === 0) {
 			throw new Error(
-				`"${name}" not found in registry '${opts.registry}'. Found in: ${matches.map((m) => m.registry).join(", ")}`,
+				`"${name}" not found in registry '${opts.registry}'. Found in: ${nameMatches.map((m) => m.registry).join(", ")}`,
+			);
+		}
+		if (opts.type && byRegistry.length > 0) {
+			const haveTypes = [...new Set(byRegistry.map((m) => m.entity.type))].sort().join(", ");
+			throw new Error(
+				`"${name}" exists but no entries of type '${opts.type}' (found types: ${haveTypes}).`,
 			);
 		}
 		throw new Error(
@@ -456,14 +481,20 @@ async function resolveFromRegistries(name: string, opts: AddOptions): Promise<De
 	if (filtered.length === 1) {
 		const m = filtered[0] as RegistryEntity;
 		console.log(`Resolved from registry '${m.registry}': ${dim(`${m.repo}/${m.entity.path}`)}`);
-		return { repo: m.repo, path: m.entity.path, version: opts.version ?? "*" };
+		const dep: Dependency = { repo: m.repo, path: m.entity.path, version: opts.version ?? "*" };
+		if (opts.type) dep.type = opts.type;
+		return dep;
 	}
 
+	// Multi-match: annotate each row with type so users see whether the
+	// collision is across registries, across types, or both. Hint mentions
+	// both flags — `--type` resolves intra-registry collisions that
+	// `--registry` alone cannot.
 	const listing = filtered
-		.map((m, i) => `  [${i + 1}] ${m.registry} — ${m.repo} :: ${m.entity.path}`)
+		.map((m, i) => `  [${i + 1}] ${m.registry} (${m.entity.type}) — ${m.repo} :: ${m.entity.path}`)
 		.join("\n");
 
 	throw new Error(
-		`"${name}" found in ${filtered.length} registries:\n${listing}\n\nUse --registry <name> to specify which one.`,
+		`"${name}" found in ${filtered.length} entries:\n${listing}\n\nUse --registry <name> and/or --type <type> to disambiguate.`,
 	);
 }

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -27,6 +27,12 @@ interface FlagDef {
 	short?: string;
 	description: string;
 	takesArg?: boolean;
+	/**
+	 * If set, the *value* of this flag tab-completes via the named
+	 * `_complete` kind. Implies `takesArg: true`. Drives the zsh
+	 * `:arg:helper` spec and the bash `case "$prev"` dispatch (Issue #22).
+	 */
+	valueComplete?: CompleteKind;
 }
 
 interface CmdDef {
@@ -67,8 +73,14 @@ const COMMANDS: CmdDef[] = [
 				short: "-t",
 				description: "Entity type (skill, agent, or command)",
 				takesArg: true,
+				valueComplete: "types",
 			},
-			{ long: "--registry", description: "Resolve from this registry", takesArg: true },
+			{
+				long: "--registry",
+				description: "Resolve from this registry",
+				takesArg: true,
+				valueComplete: "registries",
+			},
 			{ long: "--global", short: "-g", description: "Add to global dependencies" },
 		],
 	},
@@ -135,8 +147,19 @@ const COMMANDS: CmdDef[] = [
 		name: "search",
 		description: "Search registries for skills, agents, and commands",
 		flags: [
-			{ long: "--registry", description: "Search only one registry", takesArg: true },
-			{ long: "--type", short: "-t", description: "Filter by entity type", takesArg: true },
+			{
+				long: "--registry",
+				description: "Search only one registry",
+				takesArg: true,
+				valueComplete: "registries",
+			},
+			{
+				long: "--type",
+				short: "-t",
+				description: "Filter by entity type",
+				takesArg: true,
+				valueComplete: "types",
+			},
 			{ long: "--json", description: "Output results as JSON" },
 		],
 	},
@@ -311,7 +334,11 @@ function zshFlagSpecs(flags: FlagDef[]): string[] {
 	const specs: string[] = [];
 	for (const f of flags) {
 		const desc = escapeZsh(f.description);
-		const argSuffix = f.takesArg ? ":arg:" : "";
+		// `:arg:` with a trailing helper name (or empty) is the zsh
+		// argument spec for "this flag takes one argument completed via
+		// <helper>". Empty helper falls back to default file completion.
+		const helper = f.valueComplete ? zshHelperName(f.valueComplete) : "";
+		const argSuffix = f.takesArg || f.valueComplete ? `:arg:${helper}` : "";
 		if (f.short) {
 			specs.push(`'(${f.long} ${f.short})'{${f.long},${f.short}}'[${desc}]${argSuffix}'`);
 		} else {
@@ -441,6 +468,18 @@ _skilltree_complete_agents() {
     local -a items
     items=(${"$"}{(f)"$(skilltree _complete agents 2>/dev/null)"})
     _describe 'agent' items
+}
+
+_skilltree_complete_types() {
+    local -a items
+    items=(${"$"}{(f)"$(skilltree _complete types 2>/dev/null)"})
+    _describe 'type' items
+}
+
+_skilltree_complete_registries() {
+    local -a items
+    items=(${"$"}{(f)"$(skilltree _complete registries 2>/dev/null)"})
+    _describe 'registry' items
 }`;
 }
 
@@ -533,29 +572,66 @@ function bashFlagWords(flags: FlagDef[]): string {
 	return words.join(" ");
 }
 
+/**
+ * Build a `case "$prev" in` snippet that completes flag *values* via
+ * `_skilltree_dyn <kind>` when the previous word is one of the flags
+ * declaring `valueComplete`. Each case-arm returns immediately so the
+ * surrounding flag/positional logic doesn't run on the value slot.
+ *
+ * Returns an empty string if the command has no value-completed flags.
+ *
+ * Indentation is controlled by `indent` so subcommand emitters and
+ * top-level emitters can both reuse this helper without misaligning.
+ */
+function bashFlagValueDispatch(flags: FlagDef[] | undefined, indent: string): string {
+	const valueFlags = (flags ?? []).filter((f) => f.valueComplete);
+	if (valueFlags.length === 0) return "";
+	const arms = valueFlags
+		.map((f) => {
+			const tokens = f.short ? `${f.long}|${f.short}` : f.long;
+			return `${indent}    ${tokens}) COMPREPLY=($(compgen -W "$(_skilltree_dyn ${f.valueComplete})" -- "$cur")); return ;;`;
+		})
+		.join("\n");
+	return `${indent}case "$prev" in\n${arms}\n${indent}esac`;
+}
+
 function bashCmdBranch(cmd: CmdDef): string {
 	const flagWords = cmd.flags?.length ? bashFlagWords(cmd.flags) : "";
 	const completeKind = cmd.positionalComplete;
+	const valueDispatch = bashFlagValueDispatch(cmd.flags, "            ");
 
-	if (!flagWords && !completeKind) return "";
+	if (!flagWords && !completeKind && !valueDispatch) return "";
 
+	// Compose body: any flag-value dispatch runs first; then the
+	// flag-vs-positional split (if both apply); else just one of them.
+	const lines: string[] = [];
+	if (valueDispatch) lines.push(valueDispatch);
 	if (completeKind && flagWords) {
 		// Mix of flags and a value-completing positional. If the current
 		// word starts with `-`, suggest flags; otherwise suggest values.
-		return `        ${cmd.name})
-            if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "${flagWords}" -- "$cur"))
-            else
-                COMPREPLY=($(compgen -W "$(_skilltree_dyn ${completeKind})" -- "$cur"))
-            fi
-            ;;`;
+		lines.push(`            if [[ "$cur" == -* ]]; then`);
+		lines.push(`                COMPREPLY=($(compgen -W "${flagWords}" -- "$cur"))`);
+		lines.push(`            else`);
+		lines.push(
+			`                COMPREPLY=($(compgen -W "$(_skilltree_dyn ${completeKind})" -- "$cur"))`,
+		);
+		lines.push(`            fi`);
+	} else if (completeKind) {
+		lines.push(
+			`            COMPREPLY=($(compgen -W "$(_skilltree_dyn ${completeKind})" -- "$cur"))`,
+		);
+	} else if (flagWords) {
+		lines.push(`            COMPREPLY=($(compgen -W "${flagWords}" -- "$cur"))`);
 	}
 
-	if (completeKind) {
-		return `        ${cmd.name}) COMPREPLY=($(compgen -W "$(_skilltree_dyn ${completeKind})" -- "$cur")) ;;`;
+	// Single-line form preserves the original output shape when there's
+	// no value-dispatch — keeps existing freshness tests / regex anchors
+	// stable for the simple case (e.g. `remove)`).
+	if (!valueDispatch && lines.length === 1) {
+		return `        ${cmd.name}) ${lines[0]?.trim() ?? ""} ;;`;
 	}
 
-	return `        ${cmd.name}) COMPREPLY=($(compgen -W "${flagWords}" -- "$cur")) ;;`;
+	return `        ${cmd.name})\n${lines.join("\n")}\n            ;;`;
 }
 
 export function generateBashCompletion(): string {

--- a/tests/commands/_complete.test.ts
+++ b/tests/commands/_complete.test.ts
@@ -100,6 +100,51 @@ describe("_complete: getSuggestions", () => {
 		});
 	});
 
+	// Issue #22: flag-value completion needs `types` (static set) and
+	// `registries` (read from config) so users can tab `--type <TAB>` and
+	// `--registry <TAB>` instead of typing values from memory.
+	describe("types", () => {
+		test("returns the EntityType values, sorted", async () => {
+			const result = await getSuggestions("types");
+			expect(result).toEqual(["agent", "command", "skill"]);
+		});
+
+		test("works regardless of cwd / manifest presence", async () => {
+			const result = await getSuggestions("types");
+			expect(result.length).toBe(3);
+		});
+	});
+
+	describe("registries", () => {
+		test("returns registry names from the config, sorted", async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "skilltree-complete-reg-"));
+			const configPath = join(tempDir, "config.yaml");
+			await writeFile(
+				configPath,
+				`registries:\n  - name: zeta\n    repo: github.com/x/z\n  - name: alpha\n    repo: github.com/x/a\n`,
+				"utf-8",
+			);
+			const result = await getSuggestions("registries", { configPath });
+			expect(result).toEqual(["alpha", "zeta"]);
+		});
+
+		test("returns [] when the config file is missing (silent failure)", async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "skilltree-complete-reg-empty-"));
+			const result = await getSuggestions("registries", {
+				configPath: join(tempDir, "missing.yaml"),
+			});
+			expect(result).toEqual([]);
+		});
+
+		test("returns [] when the config has no registries field", async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "skilltree-complete-reg-novel-"));
+			const configPath = join(tempDir, "config.yaml");
+			await writeFile(configPath, "other_field: 1\n", "utf-8");
+			const result = await getSuggestions("registries", { configPath });
+			expect(result).toEqual([]);
+		});
+	});
+
 	// Regression: the boundary used to cast `kind: string` straight into the
 	// typed kind, then rely on the switch having no default to throw via
 	// "undefined.length". `completeCommand` now validates explicitly so an
@@ -109,6 +154,8 @@ describe("_complete: getSuggestions", () => {
 			expect(isCompleteKind("deps")).toBe(true);
 			expect(isCompleteKind("targets")).toBe(true);
 			expect(isCompleteKind("agents")).toBe(true);
+			expect(isCompleteKind("types")).toBe(true);
+			expect(isCompleteKind("registries")).toBe(true);
 			expect(isCompleteKind("bogus")).toBe(false);
 			expect(isCompleteKind("")).toBe(false);
 		});

--- a/tests/commands/add-registry.test.ts
+++ b/tests/commands/add-registry.test.ts
@@ -481,6 +481,187 @@ describe("glob-pattern add (Issue #14)", () => {
 		);
 	});
 
+	// Issue #22: `--type` must filter during registry resolution AND glob
+	// expansion. Today it only flows through to the written entry as
+	// declarative metadata when paired with `--repo`/`--path`.
+	test("--type filters when one registry has same-name skill+command", async () => {
+		const dir = await setup();
+		const configPath = join(dir, ".skilltree-config.yaml");
+		const cacheDir = join(dir, ".skilltree-cache");
+
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+		// Same-name collision *within* one registry across types — the case
+		// `--registry` alone cannot resolve.
+		await writeRegistryIndex(
+			{
+				registry: "vibes",
+				repo: "github.com/imarios/vibes",
+				updated_at: new Date().toISOString(),
+				entities: [
+					{ name: "hypothesis", type: "skill", path: "skills/hypothesis" },
+					{ name: "hypothesis", type: "command", path: "commands/hypothesis" },
+				],
+			},
+			cacheDir,
+		);
+
+		await addCommand("hypothesis", { configPath, cacheDir, type: "command" }, dir);
+
+		const manifest = await readManifestRaw(dir);
+		const dep = manifest.dependencies?.hypothesis;
+		expect(dep && isRemoteDependency(dep) && dep.path).toBe("commands/hypothesis");
+		// Explicit --type also persists as declarative metadata so a future
+		// `install` doesn't have to re-resolve and pick the wrong type.
+		expect(dep && isRemoteDependency(dep) && dep.type).toBe("command");
+	});
+
+	test("--type errors clearly when no entry of that type exists", async () => {
+		const dir = await setup();
+		const configPath = join(dir, ".skilltree-config.yaml");
+		const cacheDir = join(dir, ".skilltree-cache");
+
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+		await writeRegistryIndex(
+			{
+				registry: "vibes",
+				repo: "github.com/imarios/vibes",
+				updated_at: new Date().toISOString(),
+				// Only a skill exists — `--type command` should not silently
+				// resolve to it.
+				entities: [{ name: "hypothesis", type: "skill", path: "skills/hypothesis" }],
+			},
+			cacheDir,
+		);
+
+		await expect(
+			addCommand("hypothesis", { configPath, cacheDir, type: "command" }, dir),
+		).rejects.toThrow(/type/);
+	});
+
+	test("multi-match error annotates rows with type and mentions --type", async () => {
+		const dir = await setup();
+		const configPath = join(dir, ".skilltree-config.yaml");
+		const cacheDir = join(dir, ".skilltree-cache");
+
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+		await writeRegistryIndex(
+			{
+				registry: "vibes",
+				repo: "github.com/imarios/vibes",
+				updated_at: new Date().toISOString(),
+				entities: [
+					{ name: "hypothesis", type: "skill", path: "skills/hypothesis" },
+					{ name: "hypothesis", type: "command", path: "commands/hypothesis" },
+				],
+			},
+			cacheDir,
+		);
+
+		try {
+			await addCommand("hypothesis", { configPath, cacheDir }, dir);
+			throw new Error("expected addCommand to throw");
+		} catch (err) {
+			const msg = (err as Error).message;
+			// Each row should carry the type so the user sees the collision is
+			// across types, not registries.
+			expect(msg).toContain("skill");
+			expect(msg).toContain("command");
+			// And the disambiguator hint must mention --type, not just
+			// --registry, since this collision is intra-registry.
+			expect(msg).toMatch(/--type/);
+		}
+	});
+
+	test("glob respects --type filter (only matching types added)", async () => {
+		const dir = await setup();
+		const configPath = join(dir, ".skilltree-config.yaml");
+		const cacheDir = join(dir, ".skilltree-cache");
+
+		await writeConfig(
+			{ registries: [{ name: "vibes", repo: "github.com/imarios/vibes" }] },
+			configPath,
+		);
+		await writeRegistryIndex(
+			{
+				registry: "vibes",
+				repo: "github.com/imarios/vibes",
+				updated_at: new Date().toISOString(),
+				entities: [
+					{ name: "hyp-1", type: "skill", path: "skills/hyp-1" },
+					{ name: "hyp-2", type: "command", path: "commands/hyp-2" },
+					{ name: "hyp-3", type: "command", path: "commands/hyp-3" },
+				],
+			},
+			cacheDir,
+		);
+
+		await addCommand("hyp-*", { configPath, cacheDir, type: "command", yes: true }, dir);
+
+		const manifest = await readManifestRaw(dir);
+		expect(manifest.dependencies?.["hyp-1"]).toBeUndefined();
+		expect(manifest.dependencies?.["hyp-2"]).toBeDefined();
+		expect(manifest.dependencies?.["hyp-3"]).toBeDefined();
+	});
+
+	test("glob with --type + --registry intersects both filters", async () => {
+		const dir = await setup();
+		const configPath = join(dir, ".skilltree-config.yaml");
+		const cacheDir = join(dir, ".skilltree-cache");
+
+		await writeConfig(
+			{
+				registries: [
+					{ name: "vibes", repo: "github.com/imarios/vibes" },
+					{ name: "other", repo: "github.com/other/other" },
+				],
+			},
+			configPath,
+		);
+		await writeRegistryIndex(
+			{
+				registry: "vibes",
+				repo: "github.com/imarios/vibes",
+				updated_at: new Date().toISOString(),
+				entities: [
+					{ name: "hyp-skill", type: "skill", path: "skills/hyp-skill" },
+					{ name: "hyp-cmd", type: "command", path: "commands/hyp-cmd" },
+				],
+			},
+			cacheDir,
+		);
+		await writeRegistryIndex(
+			{
+				registry: "other",
+				repo: "github.com/other/other",
+				updated_at: new Date().toISOString(),
+				entities: [{ name: "hyp-cmd-other", type: "command", path: "commands/hyp-cmd-other" }],
+			},
+			cacheDir,
+		);
+
+		await addCommand(
+			"hyp-*",
+			{ configPath, cacheDir, type: "command", registry: "vibes", yes: true },
+			dir,
+		);
+
+		const manifest = await readManifestRaw(dir);
+		// Only the command from vibes; skill from vibes excluded by type;
+		// command from other excluded by registry.
+		expect(manifest.dependencies?.["hyp-cmd"]).toBeDefined();
+		expect(manifest.dependencies?.["hyp-skill"]).toBeUndefined();
+		expect(manifest.dependencies?.["hyp-cmd-other"]).toBeUndefined();
+	});
+
 	test("supports `?` as single-char glob", async () => {
 		const dir = await setup();
 		const configPath = join(dir, ".skilltree-config.yaml");

--- a/tests/commands/completion.test.ts
+++ b/tests/commands/completion.test.ts
@@ -269,6 +269,59 @@ describe("completion generator", () => {
 		expect(branch).toContain("_skilltree_dyn deps");
 	});
 
+	// Issue #22: --type and --registry are the disambiguation interface for
+	// `add` and `search`. Their *values* must tab-complete or users still
+	// have to type "skill"/"agent"/"command" and registry names from memory.
+	describe("flag-value completion (--type, --registry)", () => {
+		test("zsh declares helper functions for types and registries", () => {
+			const zsh = generateZshCompletion();
+			expect(zsh).toContain("_skilltree_complete_types()");
+			expect(zsh).toContain("_skilltree_complete_registries()");
+			expect(zsh).toContain("skilltree _complete types");
+			expect(zsh).toContain("skilltree _complete registries");
+		});
+
+		test("zsh wires --type and --registry value completion on `add`", () => {
+			const zsh = generateZshCompletion();
+			const branch = extractCaseBranch(zsh, "add");
+			expect(branch).toContain("_skilltree_complete_types");
+			expect(branch).toContain("_skilltree_complete_registries");
+		});
+
+		test("zsh wires --type and --registry value completion on `search`", () => {
+			const zsh = generateZshCompletion();
+			const branch = extractCaseBranch(zsh, "search");
+			expect(branch).toContain("_skilltree_complete_types");
+			expect(branch).toContain("_skilltree_complete_registries");
+		});
+
+		// Bash `extractCaseBranch` stops at the first `;;`, which inner
+		// `case "$prev"` arms would terminate prematurely. Match the
+		// full-script slice between the outer `add)` / `search)` start and
+		// the next outer command branch instead.
+		function extractOuterBranch(script: string, name: string): string {
+			const re = new RegExp(`(^|\\n)\\s*${name}\\)([\\s\\S]*?)(?=\\n\\s+(?:[a-z][\\w-]*\\)|esac))`);
+			const m = script.match(re);
+			return m ? (m[2] ?? "") : "";
+		}
+
+		test("bash dispatches --type and --registry value completion on `add`", () => {
+			const bash = generateBashCompletion();
+			const branch = extractOuterBranch(bash, "add");
+			expect(branch).not.toBe("");
+			expect(branch).toMatch(/--type.*_skilltree_dyn types/s);
+			expect(branch).toMatch(/--registry.*_skilltree_dyn registries/s);
+		});
+
+		test("bash dispatches --type and --registry value completion on `search`", () => {
+			const bash = generateBashCompletion();
+			const branch = extractOuterBranch(bash, "search");
+			expect(branch).not.toBe("");
+			expect(branch).toMatch(/--type.*_skilltree_dyn types/s);
+			expect(branch).toMatch(/--registry.*_skilltree_dyn registries/s);
+		});
+	});
+
 	// Issue 1 regression: `*::value:func` (any-number) re-fired completion
 	// after the user already typed an arg. We use `:value:func` (exactly one)
 	// because every command with positionalComplete takes one positional.


### PR DESCRIPTION
## Summary

Fixes #22. `--type` was declared as add-time metadata but ignored during registry resolution and glob expansion, so a name colliding across types in one registry (e.g., a `hypothesis` *skill* and a `hypothesis` *command* in `vibes`) had no clean resolution path — users had to fall back to `--repo`+`--path`.

- **`resolveFromRegistries`**: apply `opts.type` as a filter on top of `opts.registry`. Distinguish three "no match" causes (registry typo, type filter eliminates everything, name truly absent) so the error names the actual constraint that fired.
- **`addGlobCommand`**: same `opts.type` filter during glob expansion, with a clearer "no entries of type 'X'" message when the filter empties the match set.
- **Multi-match error**: each row is now annotated with `(<type>)` so users see whether the collision is across registries, across types, or both. Hint mentions both `--registry` and `--type`.
- **Tab completion**: new `_complete` kinds `types` (static) and `registries` (reads config); new `valueComplete?: CompleteKind` field on `FlagDef` drives the zsh `:arg:helper` spec and a bash `case "$prev" in` flag-value dispatch. Wired on `add` and `search` for `--type` and `--registry`.

```sh
# Before — unresolvable collision
$ skilltree add hypothesis
✘ "hypothesis" found in 2 registries: ...   # but they're in the same registry, --registry doesn't help

# After — disambiguates cleanly
$ skilltree add hypothesis --type command
Resolved from registry 'vibes': github.com/imarios/vibes/commands/hypothesis
```

## Test plan

- [x] New tests cover: same-name skill+command collision in one registry resolved by `--type`; glob + `--type`; glob + `--type` + `--registry` intersection; multi-match error rows annotated with type and hint mentioning `--type`; all-eliminated-by-type error wording; new completion kinds (`types`, `registries`) including the silent-failure paths; flag-value dispatch wired in zsh + bash branches for `add` and `search`.
- [x] Full suite: 900 / 900 passing.
- [x] Generated scripts pass `bash -n` and `zsh -n`.
- [x] Pre-commit hooks (biome, tsc, commitizen) all green.

## Deliberately out of scope

- README updates — will batch with the #23 flag-audit cleanup.
- Glob support in `search` (issue mentioned it; non-essential).
- `registry remove`/`registry update` positional → `registries` completion (small follow-up).
- `teach --agent` value completion.
- `--type` accepting comma-separated values (open question in issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)