### PR TITLE
fix(install): polish output + harden tests (#27)

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -11,7 +11,12 @@ import { ensureCached, getCommitSha } from "../core/git.js";
 import type { ResolvedEntity } from "../core/graph.js";
 import { resolveAll, topologicalSort } from "../core/graph.js";
 import type { InstallOptions, InstallPlan } from "../core/installer.js";
-import { applyIntegrityHashes, executeInstall, planInstall } from "../core/installer.js";
+import {
+	applyIntegrityHashes,
+	executeInstall,
+	isSkippedForProd,
+	planInstall,
+} from "../core/installer.js";
 import {
 	buildLockfile,
 	diffManifestLockfile,
@@ -76,20 +81,32 @@ function printInstallOrderFromPlan(plan: InstallPlan): void {
  * is printed exactly once regardless of how many install targets there are.
  *
  * Skips entities filtered out by `--prod` so the listing matches what will
- * actually be installed.
+ * actually be installed. If `--prod` filters everything, suppress the header
+ * and print a clear "nothing to install" message instead of a bare label
+ * followed by silence (issue #27 item 5).
  */
 function printInstallOrderFromResolution(
 	result: { entities: Map<string, ResolvedEntity>; installOrder: string[] },
 	options: InstallOptions,
 ): void {
-	header("\nInstall order:");
-	let i = 0;
+	const visible: ResolvedEntity[] = [];
 	for (const compositeKey of result.installOrder) {
 		const entity = result.entities.get(compositeKey);
 		if (!entity) continue;
-		if (options.prod && entity.group === "dev") continue;
+		if (isSkippedForProd(entity, options)) continue;
+		visible.push(entity);
+	}
+
+	if (visible.length === 0) {
+		if (options.prod) {
+			console.log(dim("\nNothing to install for --prod (all dependencies are dev-only)."));
+		}
+		return;
+	}
+
+	header("\nInstall order:");
+	for (const [i, entity] of visible.entries()) {
 		console.log(formatInstallOrderLine(i, entity));
-		i++;
 	}
 }
 
@@ -192,6 +209,11 @@ export async function installCommand(dir: string, options: InstallCommandOptions
 
 	const manifest = await loadManifestOrThrow(dir);
 
+	// Fire deprecation warnings before any early-return guard so vendor-mode
+	// users still see the nudge to migrate off legacy install-path fields.
+	// (Issue #27 item 2.)
+	warnLegacyInstallPath(manifest);
+
 	// Vendor mode guard
 	if (manifest.vendor && !options.force) {
 		warn("Vendor mode is active. Vendored files in .claude/ are committed to git.");
@@ -202,7 +224,6 @@ export async function installCommand(dir: string, options: InstallCommandOptions
 	}
 
 	validateManifestOrThrow(manifest);
-	warnLegacyInstallPath(manifest);
 
 	const existingLockfile = await readLockfile(dir);
 
@@ -252,7 +273,10 @@ async function installToTargets(
 	dir: string,
 	options: InstallOptions,
 ): Promise<Map<string, string>> {
-	let integrityMap: Map<string, string> = new Map();
+	// Accumulate across targets instead of letting the last target win
+	// (issue #27 item 3). Content-derived hashes are identical per target
+	// today, so this is data-flow hygiene rather than a behavior fix.
+	const integrityMap: Map<string, string> = new Map();
 	let skippedReported = false;
 
 	for (const target of targets) {
@@ -265,13 +289,28 @@ async function installToTargets(
 			skippedReported = true;
 		}
 
+		// When --prod filters every entity to "skipped", the per-target line
+		// would say "Installing into X… — 0 skills" once per target, which
+		// contradicts the "Nothing to install for --prod" message printed by
+		// printInstallOrderFromResolution. Suppress the per-target line in
+		// that case — the "Skipped N dev dependencies (--prod)" line above
+		// is the user's signal.
+		const suppressPerTarget = plan.toInstall.length === 0 && Boolean(options.prod);
+
 		if (options.dryRun) {
-			console.log(`\n${formatPerTargetLine(target, plan)} ${dim("(dry run)")}`);
+			if (!suppressPerTarget) {
+				console.log(`\n${formatPerTargetLine(target, plan)} ${dim("(dry run)")}`);
+			}
 			continue;
 		}
 
-		console.log(`\n${formatPerTargetLine(target, plan)}`);
-		integrityMap = await executeInstall(plan, dir, options);
+		if (!suppressPerTarget) {
+			console.log(`\n${formatPerTargetLine(target, plan)}`);
+		}
+		const perTargetMap = await executeInstall(plan, dir, options);
+		for (const [key, hash] of perTargetMap) {
+			integrityMap.set(key, hash);
+		}
 
 		if (srcInstallBase && !options.prod) {
 			const srcOptions: InstallOptions = { ...options, prod: true, installPath: srcInstallBase };

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -27,6 +27,15 @@ export interface InstallOptions {
 	installPath?: string;
 }
 
+/**
+ * Single source of truth for "is this entity filtered out by --prod?".
+ * Used by `planInstall` (decides what to install) and the install-order
+ * printer (decides what to display) so the two views can never disagree.
+ */
+export function isSkippedForProd(entity: ResolvedEntity, options: InstallOptions): boolean {
+	return Boolean(options.prod) && entity.group === "dev";
+}
+
 export interface InstallPlan {
 	toInstall: Array<{
 		entity: ResolvedEntity;
@@ -150,8 +159,7 @@ export async function planInstall(
 		const entity = entities.get(compositeKey);
 		if (!entity) continue;
 
-		// Skip dev deps in prod mode
-		if (options.prod && entity.group === "dev") {
+		if (isSkippedForProd(entity, options)) {
 			skipped.push(compositeKey);
 			continue;
 		}

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -226,6 +226,13 @@ export function validateManifest(manifest: Manifest): string[] {
 	validateDeps(manifest.dependencies, "dependencies");
 	validateDeps(manifest["dev-dependencies"], "dev-dependencies");
 
+	// Reject empty install_targets explicitly. An empty array would otherwise
+	// pass through as a no-op install (loop runs zero times) — silent success
+	// is worse than a clear error. Omit the field entirely to use defaults.
+	if (Array.isArray(manifest.install_targets) && manifest.install_targets.length === 0) {
+		errors.push("install_targets must not be empty — omit the field to use the default (.claude)");
+	}
+
 	// Check for install_targets + dev_install_path conflict
 	if (manifest.install_targets && (manifest.dev_install_path || manifest.install_path)) {
 		errors.push(

--- a/tests/commands/install-deprecation.test.ts
+++ b/tests/commands/install-deprecation.test.ts
@@ -75,6 +75,21 @@ describe("dev_install_path deprecation warning", () => {
 		expect(warns.some((w) => w.includes("deprecated"))).toBe(true);
 	});
 
+	// Issue #27 item 2: warnLegacyInstallPath used to live BELOW the vendor-mode
+	// early return, so vendor-mode users with a legacy dev_install_path never
+	// saw the deprecation nudge.
+	test("emits warning in vendor mode (early return must not bypass it)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(
+			dir,
+			`vendor: true\ndev_install_path: .claude\ndependencies:\n  my-skill:\n    local: ./skills/my-skill\n`,
+		);
+
+		const warns = await captureWarn(() => installCommand(dir, {}));
+		expect(warns.some((w) => w.includes("deprecated"))).toBe(true);
+	});
+
 	test("emits warning when removing from a project with legacy field", async () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "my-skill");

--- a/tests/commands/install-output.test.ts
+++ b/tests/commands/install-output.test.ts
@@ -178,20 +178,79 @@ describe("frozen install output: friendly tilde path", () => {
 		await installCommand(dir, {});
 
 		// Frozen install with installBase pointing under home — exercises the
-		// `collapseTilde` fallback in `frozenTarget`.
+		// `collapseTilde` fallback in `frozenTarget`. Path is randomized so
+		// parallel test runs don't collide and a SIGKILL leaves at most one
+		// uniquely-named stray dir behind. (Issue #27 item 6.)
 		const home = homedir();
-		const homeBase = join(home, ".skilltree-test-home-base");
+		const suffix = Math.random().toString(36).slice(2);
+		const homeBaseName = `.skilltree-test-${suffix}`;
+		const homeBase = join(home, homeBaseName);
 		try {
 			const output = await captureOutput(() =>
 				installCommand(dir, { frozen: true, installPath: homeBase }),
 			);
 			const clean = stripAnsi(output);
 			// Friendly tilde form must appear; raw home prefix must not.
-			expect(clean).toContain("~/.skilltree-test-home-base");
+			expect(clean).toContain(`~/${homeBaseName}`);
 			expect(clean).not.toContain(home);
 		} finally {
 			await rm(homeBase, { recursive: true, force: true });
 		}
+	});
+});
+
+// Issue #27 item 5: with --prod and a project that has only dev-dependencies,
+// the install order list iterates and skips every entity. The user used to see
+// a bare "Install order:" header followed by an empty list — confusing.
+describe("install output: --prod with only dev-deps suppresses empty header", () => {
+	test("does not print bare 'Install order:' when --prod filters everything", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+
+		await writeManifest(
+			dir,
+			["name: test", "dev-dependencies:", "  alpha:", "    local: ./skills/alpha", ""].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, { prod: true }));
+		const clean = stripAnsi(output);
+
+		// Header should NOT appear when nothing is going to print under it.
+		expect(clean).not.toMatch(/Install order:/);
+		// User should get an explicit message instead of silent success.
+		expect(clean).toMatch(/nothing to install for --prod/i);
+	});
+
+	// Hypothesis-review follow-up: with multiple install_targets, the per-target
+	// "Installing into X… — 0 skills" line used to fire once per target,
+	// contradicting the "Nothing to install for --prod" message above. The
+	// suppression must hold across all targets.
+	test("does not print contradictory per-target lines with multi-target + --prod", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "alpha");
+
+		await writeManifest(
+			dir,
+			[
+				"name: test",
+				"install_targets:",
+				"  - claude",
+				"  - codex",
+				"dev-dependencies:",
+				"  alpha:",
+				"    local: ./skills/alpha",
+				"",
+			].join("\n"),
+		);
+
+		const output = await captureOutput(() => installCommand(dir, { prod: true }));
+		const clean = stripAnsi(output);
+
+		expect(clean).toMatch(/nothing to install for --prod/i);
+		// No per-target "Installing …" lines should appear — they would say
+		// "0 skills" and contradict the message above.
+		expect(clean).not.toMatch(/Installing agent knowledge for/);
+		expect(clean).not.toMatch(/Installing into /);
 	});
 });
 

--- a/tests/core/agents.test.ts
+++ b/tests/core/agents.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	AGENT_LABELS,
+	AGENT_REGISTRY,
 	detectInstalledAgents,
 	getAgentLabel,
 	getKnownAgentNames,
@@ -167,6 +169,15 @@ describe("getAgentLabel", () => {
 
 	test("returns null for unknown bare words", () => {
 		expect(getAgentLabel("foo")).toBeNull();
+	});
+});
+
+// Issue #27 item 4: AGENT_LABELS and AGENT_REGISTRY are two parallel maps
+// that must stay in lockstep. A future contributor adding an entry to one
+// but not the other would silently lose the friendly label.
+describe("AGENT_LABELS / AGENT_REGISTRY parity", () => {
+	test("AGENT_LABELS keys match AGENT_REGISTRY keys", () => {
+		expect(Object.keys(AGENT_LABELS).sort()).toEqual(Object.keys(AGENT_REGISTRY).sort());
 	});
 });
 

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -4,6 +4,7 @@ import {
 	getInstallTargets,
 	parseManifest,
 	serializeManifest,
+	validateGlobalManifest,
 	validateManifest,
 } from "../../src/core/manifest.js";
 
@@ -234,6 +235,20 @@ dev-dependencies:
 		const errors = validateManifest(manifest);
 		expect(errors.some((e) => e.includes("both dependencies and dev-dependencies"))).toBe(true);
 	});
+
+	// Issue #27 item 1: empty install_targets used to silently no-op installs.
+	// Both validators must reject this — global inherits from project but the
+	// guard is part of the shared logic, so it has to hold in both contexts.
+	for (const [label, validator] of [
+		["validateManifest", validateManifest] as const,
+		["validateGlobalManifest", validateGlobalManifest] as const,
+	]) {
+		test(`${label} errors on empty install_targets array`, () => {
+			const manifest = parseManifest("install_targets: []\ndependencies: {}\n");
+			const errors = validator(manifest);
+			expect(errors.some((e) => /install_targets must not be empty/i.test(e))).toBe(true);
+		});
+	}
 });
 
 describe("expandSources", () => {


### PR DESCRIPTION
## Summary

Six independent follow-ups from issue #27 (review fallout from #28), plus one fix surfaced by hypothesis review and one helper extraction from the simplify pass.

| # | Change |
|---|--------|
| 1 | `validateManifest` rejects empty `install_targets: []` — used to silently no-op installs |
| 2 | `warnLegacyInstallPath` fires before the vendor-mode early-return |
| 3 | `installToTargets` accumulates integrity hashes across targets instead of last-target-wins |
| 4 | Parity test: `AGENT_LABELS` keys must match `AGENT_REGISTRY` keys |
| 5 | Suppress `Install order:` header AND contradictory per-target "0 skills" lines when `--prod` filters everything; replaced by single "Nothing to install for --prod" message |
| 6 | Randomize `$HOME`-relative test path so concurrent runs / SIGKILL leftovers don't collide |
| + | Extract `isSkippedForProd` helper in `core/installer` so `planInstall` and the install-order printer share one predicate |
| + | Multi-target follow-up to #5: per-target "Installing 0 skills" lines used to fire once per target after "Nothing to install for --prod" — caught by hypothesis review |

## Test plan

- [x] `bun test` — 922 pass / 0 fail (added 4 new tests: empty `install_targets` validation × 2, vendor-mode deprecation, `AGENT_LABELS`/`AGENT_REGISTRY` parity, `--prod` empty-header suppression, `--prod` multi-target contradiction)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Pre-commit hooks — all passed
- [x] P0 security scan — no injection / auth-bypass / secrets concerns

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)