### PR TITLE
CLI flag consistency: --json + --dry-run parity, help snapshots, registry add --repo (#23)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,6 +14,59 @@
 
 - [x] **Migration guide** — Documented in commands.md under `targets migrate`. → Fixed.
 
+## Deferred from issue #23 (CLI flag consistency)
+
+The non-breaking subset of issue #23 shipped in PRs PM1–PM4. The items
+below need either design discussion or a major-version bump and were
+deliberately left for a future cycle.
+
+### Breaking changes (queue for next major)
+
+- [ ] **`-f, --force` short-flag overload** — today `-f` means three
+  different things (overwrite local files in `install`, skip confirmation
+  in `remove`, discard modified files in `unvendor`). Remap so `-f,
+  --force` only ever means "clobber files on disk", and migrate `remove`'s
+  "skip confirmation" to `-y, --yes` (which is the conventional Unix
+  meaning and already used by `init` and `add`). Requires a deprecation
+  cycle: accept both for one major, warn on the deprecated form.
+
+- [ ] **Rename `registry add --name` to `--as`** — disambiguates from
+  "the thing's name." Same deprecation cycle: accept both, warn on `--name`.
+
+- [ ] **Pick canonical positional name for the agent enum** — `targets
+  add <target>` and `teach --agent <name>` accept the same set of values
+  (`getKnownAgentNames()`). One should rename to match the other; issue
+  #23 suggests `<agent>` since `AGENT_REGISTRY` is the source of truth.
+  Update PROJECTS.md commands documentation when this lands.
+
+- [ ] **`add -D, --dev` symmetric `remove --dev`** — today `remove foo`
+  silently searches both groups. Add `--dev` for explicit disambiguation
+  if a future state has a same-named entry in both groups. Low priority
+  — flagging for awareness.
+
+### Design questions (premise needs discussion before code)
+
+- [ ] **`info --global`** — issue #23's premise was that `info` inspects
+  project state, but it actually queries registry indexes. Real ask seems
+  to be "show install status across project + global manifests." That's a
+  feature, not a flag — needs a design pass on what `info <name>` should
+  return when the entity is installed locally vs globally vs only in a
+  registry vs nowhere.
+
+- [ ] **`update --frozen`** — semantically overlaps with the existing
+  `--dry-run` on `update`. Issue #23 itself describes it as "effectively
+  a no-op verification." If we want a distinct verb, decide whether
+  `--frozen` means "exit 1 if any version would actually update" (a
+  CI-shaped check) and document the difference vs `--dry-run`.
+
+### Pre-existing bugs surfaced during PM1
+
+- [ ] **`cache clean` swallows real errors** — both human-mode ("Cache
+  is already clean") and `--json` mode (`{cleaned: false, bytesFreed: 0}`)
+  silently lie when `rm` fails partway (e.g. one sub-file with bad perms).
+  Distinguish ENOENT from EPERM/EACCES and either re-raise the real error
+  or report best-effort `bytesFreed` regardless of `cleaned`.
+
 ## Stale
 
 (none)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,320 +34,336 @@ import { unvendorCommand, vendorCommand } from "./commands/vendor.js";
 import { verifyCommand } from "./commands/verify.js";
 import { pc } from "./core/ui.js";
 
-const program = new Command();
+/**
+ * Build the full Commander program tree without invoking it. Exported so
+ * tests can introspect commands, options, and help output (snapshot +
+ * parity tests in `tests/cli/`) without spawning the binary.
+ */
+export function buildProgram(): Command {
+	const program = new Command();
 
-program
-	.name("skilltree")
-	.description("Dependency manager for AI agent skills")
-	.version(pkg.version)
-	.enablePositionalOptions()
-	.passThroughOptions();
+	program
+		.name("skilltree")
+		.description("Dependency manager for AI agent skills")
+		.version(pkg.version)
+		.enablePositionalOptions()
+		.passThroughOptions();
 
-program
-	.command("init")
-	.description("Initialize a new skilltree project")
-	.option("-g, --global", "Initialize global dependencies")
-	.option(
-		"--scan",
-		"Scan the repo for existing skills, agents, and commands and register them as local deps",
-	)
-	.option("-y, --yes", "With --scan, include all discovered entries without prompting")
-	.action(async (opts) => {
-		await initCommand(process.cwd(), {
-			global: opts.global,
-			scan: opts.scan,
-			yes: opts.yes,
+	program
+		.command("init")
+		.description("Initialize a new skilltree project")
+		.option("-g, --global", "Initialize global dependencies")
+		.option(
+			"--scan",
+			"Scan the repo for existing skills, agents, and commands and register them as local deps",
+		)
+		.option("-y, --yes", "With --scan, include all discovered entries without prompting")
+		.action(async (opts) => {
+			await initCommand(process.cwd(), {
+				global: opts.global,
+				scan: opts.scan,
+				yes: opts.yes,
+			});
 		});
-	});
 
-program
-	.command("add <name>")
-	.description("Add a dependency")
-	.option("-r, --repo <url>", "Git repository URL")
-	.option("--source <alias>", "Source alias (from sources: map)")
-	.option("-p, --path <path>", "Path within the repository")
-	.option("-v, --version <constraint>", "Semver version constraint")
-	.option("-l, --local <path>", "Local filesystem path")
-	.option("-D, --dev", "Add as dev dependency")
-	.option("-t, --type <type>", "Entity type (skill, agent, or command)")
-	.option("--registry <name>", "Resolve from this registry (when no --repo)")
-	.option("-g, --global", "Add to global dependencies")
-	.option("-y, --yes", "Skip the glob-mode confirmation prompt")
-	.action(async (name: string, opts) => {
-		await addCommand(name, opts, process.cwd());
-	});
-
-program
-	.command("install")
-	.description("Resolve and install dependencies")
-	.option("--prod", "Install production dependencies only")
-	.option("--frozen", "Use lockfile only, error if out of sync")
-	.option("-f, --force", "Overwrite locally modified files")
-	.option("-n, --dry-run", "Show plan without installing")
-	.option("--install-path <path>", "Override install directory")
-	.option("-g, --global", "Install global dependencies")
-	.action(async (opts) => {
-		await installCommand(process.cwd(), {
-			prod: opts.prod,
-			frozen: opts.frozen,
-			force: opts.force,
-			dryRun: opts.dryRun,
-			installPath: opts.installPath,
-			global: opts.global,
+	program
+		.command("add <name>")
+		.description("Add a dependency")
+		.option("-r, --repo <url>", "Git repository URL")
+		.option("--source <alias>", "Source alias (from sources: map)")
+		.option("-p, --path <path>", "Path within the repository")
+		.option("-v, --version <constraint>", "Semver version constraint")
+		.option("-l, --local <path>", "Local filesystem path")
+		.option("-D, --dev", "Add as dev dependency")
+		.option("-t, --type <type>", "Entity type (skill, agent, or command)")
+		.option("--registry <name>", "Resolve from this registry (when no --repo)")
+		.option("-g, --global", "Add to global dependencies")
+		.option("-y, --yes", "Skip the glob-mode confirmation prompt")
+		.action(async (name: string, opts) => {
+			await addCommand(name, opts, process.cwd());
 		});
-	});
 
-program
-	.command("update [name]")
-	.description("Update dependencies to latest versions")
-	.option("-n, --dry-run", "Preview version bumps without applying")
-	.option("-g, --global", "Update global dependencies")
-	.action(async (name: string | undefined, opts) => {
-		await updateCommand(process.cwd(), name, {
-			dryRun: opts.dryRun,
-			global: opts.global,
+	program
+		.command("install")
+		.description("Resolve and install dependencies")
+		.option("--prod", "Install production dependencies only")
+		.option("--frozen", "Use lockfile only, error if out of sync")
+		.option("-f, --force", "Overwrite locally modified files")
+		.option("-n, --dry-run", "Show plan without installing")
+		.option("--install-path <path>", "Override install directory")
+		.option("-g, --global", "Install global dependencies")
+		.action(async (opts) => {
+			await installCommand(process.cwd(), {
+				prod: opts.prod,
+				frozen: opts.frozen,
+				force: opts.force,
+				dryRun: opts.dryRun,
+				installPath: opts.installPath,
+				global: opts.global,
+			});
 		});
-	});
 
-program
-	.command("remove <name>")
-	.description("Remove a dependency")
-	.option("-f, --force", "Skip confirmation")
-	.option("--keep-files", "Leave installed files in place")
-	.option("-n, --dry-run", "Preview the removal without changing anything")
-	.option("-g, --global", "Remove from global dependencies")
-	.action(async (name: string, opts) => {
-		await removeCommand(name, process.cwd(), {
-			force: opts.force,
-			keepFiles: opts.keepFiles,
-			dryRun: opts.dryRun,
-			global: opts.global,
+	program
+		.command("update [name]")
+		.description("Update dependencies to latest versions")
+		.option("-n, --dry-run", "Preview version bumps without applying")
+		.option("-g, --global", "Update global dependencies")
+		.action(async (name: string | undefined, opts) => {
+			await updateCommand(process.cwd(), name, {
+				dryRun: opts.dryRun,
+				global: opts.global,
+			});
 		});
-	});
 
-program
-	.command("verify")
-	.description("Verify installed dependencies against lockfile")
-	.option("--json", "Output results as JSON")
-	.option("-g, --global", "Verify global dependencies")
-	.action(async (opts) => {
-		await verifyCommand(process.cwd(), { global: opts.global, json: opts.json });
-	});
-
-program
-	.command("list")
-	.description("List installed dependencies")
-	.option("--json", "Output results as JSON")
-	.option("-g, --global", "List global dependencies")
-	.action(async (opts) => {
-		await listCommand(process.cwd(), { json: opts.json, global: opts.global });
-	});
-
-program
-	.command("scan <paths...>")
-	.description("Scan skills, agents, and commands for undeclared dependencies")
-	.option("--check", "Exit 1 if undeclared deps found (pre-commit mode)")
-	.option("--apply", "Auto-update frontmatter with detected deps (regex only)")
-	.option("--llm", "Use LLM for deep dependency detection (requires ANTHROPIC_API_KEY)")
-	.option("--json", "Output results as JSON")
-	.action(async (paths: string[], opts) => {
-		await scanCommand(paths, {
-			check: opts.check,
-			apply: opts.apply,
-			llm: opts.llm,
-			json: opts.json,
+	program
+		.command("remove <name>")
+		.description("Remove a dependency")
+		.option("-f, --force", "Skip confirmation")
+		.option("--keep-files", "Leave installed files in place")
+		.option("-n, --dry-run", "Preview the removal without changing anything")
+		.option("-g, --global", "Remove from global dependencies")
+		.action(async (name: string, opts) => {
+			await removeCommand(name, process.cwd(), {
+				force: opts.force,
+				keepFiles: opts.keepFiles,
+				dryRun: opts.dryRun,
+				global: opts.global,
+			});
 		});
-	});
 
-program
-	.command("teach")
-	.description("Install the skilltree skill to all detected coding agents")
-	.option("--agent <name>", "Install to a specific agent only")
-	.action(async (opts) => {
-		await teachCommand({ agent: opts.agent });
-	});
-
-// Vendor commands
-program
-	.command("vendor")
-	.description("Copy all deps as real files for git commit (distribution mode)")
-	.option("--frozen", "Use lockfile only, error if out of sync")
-	.option("-n, --dry-run", "Show plan without making changes")
-	.action(async (opts) => {
-		await vendorCommand(process.cwd(), {
-			frozen: opts.frozen,
-			dryRun: opts.dryRun,
+	program
+		.command("verify")
+		.description("Verify installed dependencies against lockfile")
+		.option("--json", "Output results as JSON")
+		.option("-g, --global", "Verify global dependencies")
+		.action(async (opts) => {
+			await verifyCommand(process.cwd(), { global: opts.global, json: opts.json });
 		});
-	});
 
-program
-	.command("unvendor")
-	.description("Exit vendor mode, restore normal symlinked installs")
-	.option("-f, --force", "Discard modified vendored files")
-	.option("-n, --dry-run", "Show what would happen without making changes")
-	.action(async (opts) => {
-		await unvendorCommand(process.cwd(), { force: opts.force, dryRun: opts.dryRun });
-	});
-
-const deps = program.command("deps").description("Dependency graph commands");
-
-deps
-	.command("tree")
-	.description("Show dependency tree")
-	.option("--json", "Output tree as JSON")
-	.option("-g, --global", "Show global dependency tree")
-	.action(async (opts) => {
-		await depsTreeCommand(process.cwd(), { global: opts.global, json: opts.json });
-	});
-
-const registry = program.command("registry").description("Registry management commands");
-
-registry
-	.command("init")
-	.description("Seed popular community registries for skill discovery")
-	.option("--skip-update", "Add registries without indexing")
-	.action(async (opts) => {
-		await registryInitCommand({ skipUpdate: opts.skipUpdate });
-	});
-
-registry
-	.command("add <url>")
-	.description(
-		"Register a git repo as a searchable registry\n\nExamples:\n  skilltree registry add github.com/VoltAgent/awesome-agent-skills\n  skilltree registry add github.com/trailofbits/skills --name security",
-	)
-	.option("--name <alias>", "Custom name for the registry")
-	.action(async (url: string, opts) => {
-		await registryAddCommand(url, { name: opts.name });
-	});
-
-registry
-	.command("remove <name>")
-	.description("Remove a registered registry")
-	.action(async (name: string) => {
-		await registryRemoveCommand(name);
-	});
-
-registry
-	.command("list")
-	.description("List all registered registries")
-	.option("--json", "Output results as JSON")
-	.action(async (opts) => {
-		await registryListCommand(undefined, undefined, { json: opts.json });
-	});
-
-registry
-	.command("update [name]")
-	.description("Fetch registry repos and rebuild search indexes")
-	.option("--json", "Output results as JSON")
-	.action(async (name: string | undefined, opts) => {
-		await registryUpdateCommand(name, undefined, undefined, { json: opts.json });
-	});
-
-registry
-	.command("index")
-	.description("Generate skillkit-index.yaml for this repo")
-	.option("--check", "Check if index is up to date (exit 1 if stale)")
-	.action(async (opts) => {
-		await indexCommand({ check: opts.check });
-	});
-
-program
-	.command("search <query>")
-	.description("Search registries for skills, agents, and commands")
-	.option("--registry <name>", "Search only one registry")
-	.option("-t, --type <type>", "Filter by entity type (skill, agent, or command)")
-	.option("--json", "Output results as JSON")
-	.action(async (query: string, opts) => {
-		await searchCommand(query, {
-			registry: opts.registry,
-			type: opts.type,
-			json: opts.json,
+	program
+		.command("list")
+		.description("List installed dependencies")
+		.option("--json", "Output results as JSON")
+		.option("-g, --global", "List global dependencies")
+		.action(async (opts) => {
+			await listCommand(process.cwd(), { json: opts.json, global: opts.global });
 		});
-	});
 
-program
-	.command("info <name>")
-	.description("Show detailed information about a skill, agent, or command")
-	.option("--json", "Output results as JSON")
-	.action(async (name: string, opts) => {
-		await infoCommand(name, { json: opts.json });
-	});
+	program
+		.command("scan <paths...>")
+		.description("Scan skills, agents, and commands for undeclared dependencies")
+		.option("--check", "Exit 1 if undeclared deps found (pre-commit mode)")
+		.option("--apply", "Auto-update frontmatter with detected deps (regex only)")
+		.option("--llm", "Use LLM for deep dependency detection (requires ANTHROPIC_API_KEY)")
+		.option("--json", "Output results as JSON")
+		.action(async (paths: string[], opts) => {
+			await scanCommand(paths, {
+				check: opts.check,
+				apply: opts.apply,
+				llm: opts.llm,
+				json: opts.json,
+			});
+		});
 
-program
-	.command("completion [shell]")
-	.description("Output shell completion script (zsh or bash)")
-	.option("--install", "Write the script to the conventional location instead of stdout")
-	.action(async (shell?: string, opts?: { install?: boolean }) => {
-		await completionCommand(shell, { install: opts?.install });
-	});
+	program
+		.command("teach")
+		.description("Install the skilltree skill to all detected coding agents")
+		.option("--agent <name>", "Install to a specific agent only")
+		.action(async (opts) => {
+			await teachCommand({ agent: opts.agent });
+		});
 
-// Hidden subcommand backing dynamic shell completion. Emits one suggestion
-// per line on stdout. See `src/commands/_complete.ts` for the rules: never
-// throws, never prints diagnostics — must be safe to call on every <TAB>.
-program
-	.command("_complete <kind>", { hidden: true })
-	.description("(internal) Emit dynamic completion suggestions")
-	.option("-g, --global", "Read from the global manifest")
-	.action(async (kind: string, opts) => {
-		await completeCommand(kind, { global: opts.global });
-	});
+	// Vendor commands
+	program
+		.command("vendor")
+		.description("Copy all deps as real files for git commit (distribution mode)")
+		.option("--frozen", "Use lockfile only, error if out of sync")
+		.option("-n, --dry-run", "Show plan without making changes")
+		.action(async (opts) => {
+			await vendorCommand(process.cwd(), {
+				frozen: opts.frozen,
+				dryRun: opts.dryRun,
+			});
+		});
 
-const targets = program.command("targets").description("Manage install targets (coding agents)");
+	program
+		.command("unvendor")
+		.description("Exit vendor mode, restore normal symlinked installs")
+		.option("-f, --force", "Discard modified vendored files")
+		.option("-n, --dry-run", "Show what would happen without making changes")
+		.action(async (opts) => {
+			await unvendorCommand(process.cwd(), { force: opts.force, dryRun: opts.dryRun });
+		});
 
-targets
-	.command("list")
-	.description("Show known agents with detected and configured status")
-	.option("--json", "Output results as JSON")
-	.option("-g, --global", "Show global targets")
-	.action(async (opts) => {
-		await targetsListCommand(process.cwd(), { global: opts.global, json: opts.json });
-	});
+	const deps = program.command("deps").description("Dependency graph commands");
 
-targets
-	.command("add <target>")
-	.description("Add an agent or path to install_targets")
-	.option("-g, --global", "Add to global manifest")
-	.action(async (target: string, opts) => {
-		await targetsAddCommand(target, process.cwd(), { global: opts.global });
-	});
+	deps
+		.command("tree")
+		.description("Show dependency tree")
+		.option("--json", "Output tree as JSON")
+		.option("-g, --global", "Show global dependency tree")
+		.action(async (opts) => {
+			await depsTreeCommand(process.cwd(), { global: opts.global, json: opts.json });
+		});
 
-targets
-	.command("remove <target>")
-	.description("Remove an agent or path from install_targets")
-	.option("-g, --global", "Remove from global manifest")
-	.action(async (target: string, opts) => {
-		await targetsRemoveCommand(target, process.cwd(), { global: opts.global });
-	});
+	const registry = program.command("registry").description("Registry management commands");
 
-targets
-	.command("detect")
-	.description("Scan for installed agents and add missing ones")
-	.option("-g, --global", "Detect for global manifest")
-	.action(async (opts) => {
-		await targetsDetectCommand(process.cwd(), { global: opts.global });
-	});
+	registry
+		.command("init")
+		.description("Seed popular community registries for skill discovery")
+		.option("--skip-update", "Add registries without indexing")
+		.action(async (opts) => {
+			await registryInitCommand({ skipUpdate: opts.skipUpdate });
+		});
 
-targets
-	.command("migrate")
-	.description("Convert dev_install_path to install_targets")
-	.option("-g, --global", "Migrate global manifest")
-	.action(async (opts) => {
-		await targetsMigrateCommand(process.cwd(), { global: opts.global });
-	});
+	registry
+		.command("add <url>")
+		.description(
+			"Register a git repo as a searchable registry\n\nExamples:\n  skilltree registry add github.com/VoltAgent/awesome-agent-skills\n  skilltree registry add github.com/trailofbits/skills --name security",
+		)
+		.option("--name <alias>", "Custom name for the registry")
+		.action(async (url: string, opts) => {
+			await registryAddCommand(url, { name: opts.name });
+		});
 
-const cache = program.command("cache").description("Cache management commands");
+	registry
+		.command("remove <name>")
+		.description("Remove a registered registry")
+		.action(async (name: string) => {
+			await registryRemoveCommand(name);
+		});
 
-cache
-	.command("clean")
-	.description("Remove cached repositories")
-	.option("--json", "Output results as JSON")
-	.action(async (opts) => {
-		await cacheCleanCommand({ json: opts.json });
-	});
+	registry
+		.command("list")
+		.description("List all registered registries")
+		.option("--json", "Output results as JSON")
+		.action(async (opts) => {
+			await registryListCommand(undefined, undefined, { json: opts.json });
+		});
 
-// Global error handler: print clean error messages, no stack traces
-program.parseAsync().catch((err: unknown) => {
-	const message = err instanceof Error ? err.message : String(err);
-	console.error(pc.red(`✘ ${message}`));
-	process.exit(1);
-});
+	registry
+		.command("update [name]")
+		.description("Fetch registry repos and rebuild search indexes")
+		.option("--json", "Output results as JSON")
+		.action(async (name: string | undefined, opts) => {
+			await registryUpdateCommand(name, undefined, undefined, { json: opts.json });
+		});
+
+	registry
+		.command("index")
+		.description("Generate skillkit-index.yaml for this repo")
+		.option("--check", "Check if index is up to date (exit 1 if stale)")
+		.action(async (opts) => {
+			await indexCommand({ check: opts.check });
+		});
+
+	program
+		.command("search <query>")
+		.description("Search registries for skills, agents, and commands")
+		.option("--registry <name>", "Search only one registry")
+		.option("-t, --type <type>", "Filter by entity type (skill, agent, or command)")
+		.option("--json", "Output results as JSON")
+		.action(async (query: string, opts) => {
+			await searchCommand(query, {
+				registry: opts.registry,
+				type: opts.type,
+				json: opts.json,
+			});
+		});
+
+	program
+		.command("info <name>")
+		.description("Show detailed information about a skill, agent, or command")
+		.option("--json", "Output results as JSON")
+		.action(async (name: string, opts) => {
+			await infoCommand(name, { json: opts.json });
+		});
+
+	program
+		.command("completion [shell]")
+		.description("Output shell completion script (zsh or bash)")
+		.option("--install", "Write the script to the conventional location instead of stdout")
+		.action(async (shell?: string, opts?: { install?: boolean }) => {
+			await completionCommand(shell, { install: opts?.install });
+		});
+
+	// Hidden subcommand backing dynamic shell completion. Emits one suggestion
+	// per line on stdout. See `src/commands/_complete.ts` for the rules: never
+	// throws, never prints diagnostics — must be safe to call on every <TAB>.
+	program
+		.command("_complete <kind>", { hidden: true })
+		.description("(internal) Emit dynamic completion suggestions")
+		.option("-g, --global", "Read from the global manifest")
+		.action(async (kind: string, opts) => {
+			await completeCommand(kind, { global: opts.global });
+		});
+
+	const targets = program.command("targets").description("Manage install targets (coding agents)");
+
+	targets
+		.command("list")
+		.description("Show known agents with detected and configured status")
+		.option("--json", "Output results as JSON")
+		.option("-g, --global", "Show global targets")
+		.action(async (opts) => {
+			await targetsListCommand(process.cwd(), { global: opts.global, json: opts.json });
+		});
+
+	targets
+		.command("add <target>")
+		.description("Add an agent or path to install_targets")
+		.option("-g, --global", "Add to global manifest")
+		.action(async (target: string, opts) => {
+			await targetsAddCommand(target, process.cwd(), { global: opts.global });
+		});
+
+	targets
+		.command("remove <target>")
+		.description("Remove an agent or path from install_targets")
+		.option("-g, --global", "Remove from global manifest")
+		.action(async (target: string, opts) => {
+			await targetsRemoveCommand(target, process.cwd(), { global: opts.global });
+		});
+
+	targets
+		.command("detect")
+		.description("Scan for installed agents and add missing ones")
+		.option("-g, --global", "Detect for global manifest")
+		.action(async (opts) => {
+			await targetsDetectCommand(process.cwd(), { global: opts.global });
+		});
+
+	targets
+		.command("migrate")
+		.description("Convert dev_install_path to install_targets")
+		.option("-g, --global", "Migrate global manifest")
+		.action(async (opts) => {
+			await targetsMigrateCommand(process.cwd(), { global: opts.global });
+		});
+
+	const cache = program.command("cache").description("Cache management commands");
+
+	cache
+		.command("clean")
+		.description("Remove cached repositories")
+		.option("--json", "Output results as JSON")
+		.action(async (opts) => {
+			await cacheCleanCommand({ json: opts.json });
+		});
+
+	return program;
+}
+
+// Auto-run only when invoked directly (not when imported by tests).
+// `import.meta.main` is set by Bun for the entry script and the
+// compiled-binary entry point; it's false during test runs that import
+// this module via `import { buildProgram } from ...`.
+if (import.meta.main) {
+	buildProgram()
+		.parseAsync()
+		.catch((err: unknown) => {
+			const message = err instanceof Error ? err.message : String(err);
+			console.error(pc.red(`✘ ${message}`));
+			process.exit(1);
+		});
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
 	registryListCommand,
 	registryRemoveCommand,
 	registryUpdateCommand,
+	resolveRegistryAddUrl,
 } from "./commands/registry.js";
 import { removeCommand } from "./commands/remove.js";
 import { scanCommand } from "./commands/scan.js";
@@ -51,7 +52,9 @@ export function buildProgram(): Command {
 
 	program
 		.command("init")
-		.description("Initialize a new skilltree project")
+		.description(
+			"Initialize a new skilltree project\n\nRelated:\n  registry init   — seed popular community registries to install skills from\n  targets detect  — auto-discover installed coding agents on this machine",
+		)
 		.option("-g, --global", "Initialize global dependencies")
 		.option(
 			"--scan",
@@ -210,20 +213,24 @@ export function buildProgram(): Command {
 
 	registry
 		.command("init")
-		.description("Seed popular community registries for skill discovery")
+		.description(
+			"Seed popular community registries for skill discovery\n\nRelated:\n  init            — initialize a new skilltree project (run this first)\n  targets detect  — auto-discover installed coding agents on this machine",
+		)
 		.option("--skip-update", "Add registries without indexing")
 		.action(async (opts) => {
 			await registryInitCommand({ skipUpdate: opts.skipUpdate });
 		});
 
 	registry
-		.command("add <url>")
+		.command("add [url]")
 		.description(
-			"Register a git repo as a searchable registry\n\nExamples:\n  skilltree registry add github.com/VoltAgent/awesome-agent-skills\n  skilltree registry add github.com/trailofbits/skills --name security",
+			"Register a git repo as a searchable registry\n\nThe URL can be passed positionally or via --repo (so muscle memory from `add` transfers).\n\nExamples:\n  skilltree registry add github.com/VoltAgent/awesome-agent-skills\n  skilltree registry add --repo github.com/trailofbits/skills --name security",
 		)
+		.option("-r, --repo <url>", "Git repository URL (alias for the positional <url>)")
 		.option("--name <alias>", "Custom name for the registry")
-		.action(async (url: string, opts) => {
-			await registryAddCommand(url, { name: opts.name });
+		.action(async (url: string | undefined, opts) => {
+			const resolvedUrl = resolveRegistryAddUrl(url, opts.repo);
+			await registryAddCommand(resolvedUrl, { name: opts.name });
 		});
 
 	registry
@@ -327,7 +334,9 @@ export function buildProgram(): Command {
 
 	targets
 		.command("detect")
-		.description("Scan for installed agents and add missing ones")
+		.description(
+			"Scan for installed agents and add missing ones\n\nRelated:\n  init            — initialize a new skilltree project (run this first)\n  registry init   — seed popular community registries to install skills from",
+		)
 		.option("-g, --global", "Detect for global manifest")
 		.action(async (opts) => {
 			await targetsDetectCommand(process.cwd(), { global: opts.global });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,9 +126,10 @@ program
 program
 	.command("verify")
 	.description("Verify installed dependencies against lockfile")
+	.option("--json", "Output results as JSON")
 	.option("-g, --global", "Verify global dependencies")
 	.action(async (opts) => {
-		await verifyCommand(process.cwd(), { global: opts.global });
+		await verifyCommand(process.cwd(), { global: opts.global, json: opts.json });
 	});
 
 program
@@ -190,9 +191,10 @@ const deps = program.command("deps").description("Dependency graph commands");
 deps
 	.command("tree")
 	.description("Show dependency tree")
+	.option("--json", "Output tree as JSON")
 	.option("-g, --global", "Show global dependency tree")
 	.action(async (opts) => {
-		await depsTreeCommand(process.cwd(), { global: opts.global });
+		await depsTreeCommand(process.cwd(), { global: opts.global, json: opts.json });
 	});
 
 const registry = program.command("registry").description("Registry management commands");
@@ -233,8 +235,9 @@ registry
 registry
 	.command("update [name]")
 	.description("Fetch registry repos and rebuild search indexes")
-	.action(async (name?: string) => {
-		await registryUpdateCommand(name);
+	.option("--json", "Output results as JSON")
+	.action(async (name: string | undefined, opts) => {
+		await registryUpdateCommand(name, undefined, undefined, { json: opts.json });
 	});
 
 registry
@@ -291,9 +294,10 @@ const targets = program.command("targets").description("Manage install targets (
 targets
 	.command("list")
 	.description("Show known agents with detected and configured status")
+	.option("--json", "Output results as JSON")
 	.option("-g, --global", "Show global targets")
 	.action(async (opts) => {
-		await targetsListCommand(process.cwd(), { global: opts.global });
+		await targetsListCommand(process.cwd(), { global: opts.global, json: opts.json });
 	});
 
 targets
@@ -333,8 +337,9 @@ const cache = program.command("cache").description("Cache management commands");
 cache
 	.command("clean")
 	.description("Remove cached repositories")
-	.action(async () => {
-		await cacheCleanCommand();
+	.option("--json", "Output results as JSON")
+	.action(async (opts) => {
+		await cacheCleanCommand({ json: opts.json });
 	});
 
 // Global error handler: print clean error messages, no stack traces

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,11 +114,13 @@ program
 	.description("Remove a dependency")
 	.option("-f, --force", "Skip confirmation")
 	.option("--keep-files", "Leave installed files in place")
+	.option("-n, --dry-run", "Preview the removal without changing anything")
 	.option("-g, --global", "Remove from global dependencies")
 	.action(async (name: string, opts) => {
 		await removeCommand(name, process.cwd(), {
 			force: opts.force,
 			keepFiles: opts.keepFiles,
+			dryRun: opts.dryRun,
 			global: opts.global,
 		});
 	});
@@ -182,8 +184,9 @@ program
 	.command("unvendor")
 	.description("Exit vendor mode, restore normal symlinked installs")
 	.option("-f, --force", "Discard modified vendored files")
+	.option("-n, --dry-run", "Show what would happen without making changes")
 	.action(async (opts) => {
-		await unvendorCommand(process.cwd(), { force: opts.force });
+		await unvendorCommand(process.cwd(), { force: opts.force, dryRun: opts.dryRun });
 	});
 
 const deps = program.command("deps").description("Dependency graph commands");

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -1,13 +1,64 @@
-import { rm } from "node:fs/promises";
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
 import { getCacheDir } from "../core/git.js";
 import { success } from "../core/ui.js";
 
-export async function cacheCleanCommand(): Promise<void> {
-	const cacheDir = getCacheDir();
+export interface CacheCleanOptions {
+	json?: boolean;
+	/** Test override; defaults to {@link getCacheDir}. */
+	cacheDir?: string;
+}
+
+interface CacheCleanResult {
+	cleaned: boolean;
+	path: string;
+	bytesFreed: number;
+}
+
+/**
+ * Best-effort recursive byte count. Returns 0 for any I/O error so the caller
+ * never has to distinguish "missing" from "transient stat failure".
+ */
+async function measureDirSize(path: string): Promise<number> {
+	try {
+		const s = await stat(path);
+		if (!s.isDirectory()) return s.size;
+		const entries = await readdir(path, { withFileTypes: true });
+		const sizes = await Promise.all(entries.map((entry) => measureDirSize(join(path, entry.name))));
+		return sizes.reduce((a, b) => a + b, 0);
+	} catch {
+		return 0;
+	}
+}
+
+export async function cacheCleanCommand(opts?: CacheCleanOptions): Promise<void> {
+	const cacheDir = opts?.cacheDir ?? getCacheDir();
+
+	// Only walk the cache when the caller actually wants the byte count —
+	// otherwise this is O(N files) of stats with the result discarded.
+	const bytesFreed = opts?.json ? await measureDirSize(cacheDir) : 0;
+
+	let cleaned = false;
 	try {
 		await rm(cacheDir, { recursive: true });
-		success(`Removed cache at ${cacheDir}`);
+		cleaned = true;
 	} catch {
+		// Already absent — both paths converge on "nothing left to clean".
+	}
+
+	if (opts?.json) {
+		const result: CacheCleanResult = {
+			cleaned,
+			path: cacheDir,
+			bytesFreed: cleaned ? bytesFreed : 0,
+		};
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+
+	if (cleaned) {
+		success(`Removed cache at ${cacheDir}`);
+	} else {
 		console.log("Cache is already clean.");
 	}
 }

--- a/src/commands/deps.ts
+++ b/src/commands/deps.ts
@@ -2,10 +2,21 @@ import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { readGlobalManifest, readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { dim, pc } from "../core/ui.js";
+import type { EntityType, Lockfile, LockfileEntry } from "../types.js";
 
 export interface DepsOptions {
 	global?: boolean;
 	globalDir?: string; // test override
+	json?: boolean;
+}
+
+interface JsonTreeNode {
+	name: string;
+	type: EntityType;
+	version?: string;
+	source?: string;
+	deduped?: boolean;
+	dependencies: JsonTreeNode[];
 }
 
 export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<void> {
@@ -27,6 +38,18 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 		...Object.keys(manifest["dev-dependencies"] ?? {}),
 	]);
 
+	if (opts?.json) {
+		const printedJson = new Set<string>();
+		const tree: JsonTreeNode[] = [];
+		for (const root of roots) {
+			const entry = lockfile.packages[root];
+			if (!entry) continue;
+			tree.push(buildJsonTree(root, entry, lockfile, printedJson));
+		}
+		console.log(JSON.stringify(tree, null, 2));
+		return;
+	}
+
 	const printed = new Set<string>();
 
 	for (const root of roots) {
@@ -34,6 +57,36 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 		if (!entry) continue;
 		printTree(root, entry, lockfile, "", true, true, printed);
 	}
+}
+
+function buildJsonTree(
+	name: string,
+	entry: LockfileEntry,
+	lockfile: Lockfile,
+	printed: Set<string>,
+): JsonTreeNode {
+	const node: JsonTreeNode = {
+		name,
+		type: entry.type,
+		dependencies: [],
+	};
+	if (entry.version) node.version = entry.version;
+	if (entry.source) node.source = entry.source;
+
+	if (printed.has(name)) {
+		// Mirror the human renderer: don't recurse into already-printed subtrees.
+		// Consumers walk on `deduped` instead of duplicating the whole subtree.
+		node.deduped = true;
+		return node;
+	}
+	printed.add(name);
+
+	for (const depName of entry.dependencies) {
+		const depEntry = lockfile.packages[depName];
+		if (!depEntry) continue;
+		node.dependencies.push(buildJsonTree(depName, depEntry, lockfile, printed));
+	}
+	return node;
 }
 
 function printTree(

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -32,6 +32,39 @@ export interface RegistryAddOptions {
 }
 
 /**
+ * `registry add` accepts the URL either positionally or via `--repo` (alias)
+ * so muscle memory transfers from the regular `add` command. This helper is
+ * the single source of truth for that resolution: it returns the URL,
+ * throws if neither was provided, and throws if both were given with
+ * different values. Identical values are accepted (idempotent).
+ *
+ * Uses presence checks (=== undefined) rather than truthy checks to honour
+ * the CLAUDE.md hardening pattern: a user passing `--repo ""` should get
+ * "URL required" not silently lose the flag to a `??` shortcut.
+ */
+export function resolveRegistryAddUrl(
+	positional: string | undefined,
+	repoFlag: string | undefined,
+): string {
+	const hasPositional = positional !== undefined;
+	const hasFlag = repoFlag !== undefined;
+
+	if (hasPositional && hasFlag && positional !== repoFlag) {
+		throw new Error(
+			`conflicting URLs: positional "${positional}" vs --repo "${repoFlag}". Pass only one.`,
+		);
+	}
+
+	const url = hasPositional ? positional : repoFlag;
+	if (url === undefined || url === "") {
+		throw new Error(
+			"a registry URL is required. Pass it positionally (`registry add <url>`) or via --repo.",
+		);
+	}
+	return url;
+}
+
+/**
  * Infer a registry name from a git URL.
  * Uses the last path segment of the normalized URL.
  */

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -146,14 +146,32 @@ export async function registryListCommand(
 	}
 }
 
+export interface RegistryUpdateOptions {
+	json?: boolean;
+}
+
+interface RegistryUpdateResult {
+	name: string;
+	repo: string;
+	entities: number;
+	skills: number;
+	agents: number;
+	commands: number;
+}
+
 export async function registryUpdateCommand(
 	name?: string,
 	configPath?: string,
 	cacheDir?: string,
+	opts?: RegistryUpdateOptions,
 ): Promise<void> {
 	const registries = await listRegistries(configPath);
 
 	if (registries.length === 0) {
+		if (opts?.json) {
+			console.log("[]");
+			return;
+		}
 		console.log("No registries configured. Run 'skilltree registry add <url>' to add one.");
 		return;
 	}
@@ -164,8 +182,12 @@ export async function registryUpdateCommand(
 		throw new Error(`Registry "${name}" not found`);
 	}
 
+	const results: RegistryUpdateResult[] = [];
+
 	for (const reg of targets) {
-		process.stdout.write(`Updating ${pc.cyan(reg.name)}... `);
+		// Suppress per-registry chatter in JSON mode so stdout stays a single
+		// parseable document.
+		if (!opts?.json) process.stdout.write(`Updating ${pc.cyan(reg.name)}... `);
 		const repoDir = await ensureRegistryRepo(reg.name, reg.repo, cacheDir);
 		const entities = await scanRegistry(repoDir);
 
@@ -181,9 +203,24 @@ export async function registryUpdateCommand(
 		};
 		await writeRegistryIndex(index, cacheDir);
 
-		const breakdown = [`${skills} skills`, `${agents} agents`];
-		if (commands > 0) breakdown.push(`${commands} commands`);
-		console.log(pc.green(`${entities.length} entities`) + dim(` (${breakdown.join(", ")})`));
+		results.push({
+			name: reg.name,
+			repo: reg.repo,
+			entities: entities.length,
+			skills,
+			agents,
+			commands,
+		});
+
+		if (!opts?.json) {
+			const breakdown = [`${skills} skills`, `${agents} agents`];
+			if (commands > 0) breakdown.push(`${commands} commands`);
+			console.log(pc.green(`${entities.length} entities`) + dim(` (${breakdown.join(", ")})`));
+		}
+	}
+
+	if (opts?.json) {
+		console.log(JSON.stringify(results, null, 2));
 	}
 }
 

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -16,14 +16,15 @@ import {
 	writeManifest,
 } from "../core/manifest.js";
 import { getGlobalDir, getGlobalInstallBase } from "../core/paths.js";
-import { dim, success } from "../core/ui.js";
-import type { Lockfile } from "../types.js";
+import { dim, dryRunBanner, pc, success } from "../core/ui.js";
+import type { Lockfile, Manifest } from "../types.js";
 
 export interface RemoveOptions {
 	force?: boolean;
 	keepFiles?: boolean;
 	global?: boolean;
 	globalDir?: string; // test override
+	dryRun?: boolean;
 }
 
 export async function removeCommand(
@@ -38,6 +39,14 @@ export async function removeCommand(
 	const lockfile = isGlobal ? await readGlobalLockfile(globalDir) : await readLockfile(dir);
 
 	validateRemoveTarget(name, manifest, lockfile, isGlobal);
+
+	if (options.dryRun) {
+		// In a preview we deliberately do NOT prompt for confirmation — there is
+		// nothing to confirm and the user is just trying to see consequences.
+		await previewRemove(name, manifest, lockfile, isGlobal, dir, options.keepFiles);
+		return;
+	}
+
 	await confirmIfDependents(name, lockfile, options);
 
 	// Remove from manifest
@@ -61,6 +70,43 @@ export async function removeCommand(
 			await writeGlobalLockfile(lockfile, globalDir);
 		} else {
 			await writeLockfile(dir, lockfile);
+		}
+	}
+}
+
+async function previewRemove(
+	name: string,
+	manifest: Manifest,
+	lockfile: Lockfile | null,
+	isGlobal: boolean,
+	dir: string,
+	keepFiles?: boolean,
+): Promise<void> {
+	const manifestName = isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW;
+	dryRunBanner();
+	console.log(`Would remove ${pc.cyan(name)} from ${manifestName}`);
+
+	if (!lockfile) return;
+
+	const installBase = isGlobal ? getGlobalInstallBase() : join(dir, getDevInstallPath(manifest));
+
+	const entry = lockfile.packages[name];
+	if (entry && !keepFiles) {
+		const targetPath = getTargetPath({ name, type: entry.type }, installBase);
+		console.log(dim(`Would remove installed files at ${targetPath}`));
+	}
+
+	// Pure call — no clone needed. `excludeName` lets findOrphans answer
+	// "what would be orphaned IF we removed this dep?" without mutating state.
+	const orphans = findOrphans(lockfile, manifest, { excludeName: name });
+	for (const orphan of orphans) {
+		const orphanEntry = lockfile.packages[orphan];
+		if (!orphanEntry) continue;
+		if (keepFiles) {
+			console.log(dim(`Would drop orphaned transitive dependency: ${orphan} (files kept)`));
+		} else {
+			const targetPath = getTargetPath({ name: orphan, type: orphanEntry.type }, installBase);
+			console.log(dim(`Would remove orphaned transitive dependency: ${orphan} (${targetPath})`));
 		}
 	}
 }
@@ -184,11 +230,18 @@ function findOrphans(
 		dependencies?: Record<string, unknown>;
 		"dev-dependencies"?: Record<string, unknown>;
 	},
+	options?: { excludeName?: string },
 ): string[] {
+	// `excludeName` lets dry-run callers ask "what would be orphaned if we
+	// removed this name?" without mutating the manifest or lockfile. The
+	// excluded name is treated as both removed-from-manifest AND removed-as-
+	// reachable, so anything only kept alive by it surfaces as an orphan.
+	const exclude = options?.excludeName;
 	const manifestKeys = new Set([
 		...Object.keys(manifest.dependencies ?? {}),
 		...Object.keys(manifest["dev-dependencies"] ?? {}),
 	]);
+	if (exclude) manifestKeys.delete(exclude);
 
 	const reachable = new Set<string>();
 
@@ -209,7 +262,7 @@ function findOrphans(
 		}
 	}
 
-	return Object.keys(lockfile.packages).filter((key) => !reachable.has(key));
+	return Object.keys(lockfile.packages).filter((key) => !reachable.has(key) && key !== exclude);
 }
 
 async function promptYesNo(question: string): Promise<boolean> {

--- a/src/commands/targets.ts
+++ b/src/commands/targets.ts
@@ -12,6 +12,8 @@ interface TargetsOpts {
 	global?: boolean;
 	globalDir?: string;
 	homeDir?: string;
+	/** Only honoured by `targetsListCommand`. Other targets verbs ignore it. */
+	json?: boolean;
 }
 
 /**
@@ -37,29 +39,61 @@ function ensureInstallTargets(manifest: Manifest): string[] {
 	return manifest.install_targets;
 }
 
+interface TargetsListRow {
+	name: string;
+	path: string;
+	detected: boolean;
+	configured: boolean;
+}
+
+function buildTargetsListRows(
+	targets: string[],
+	detected: string[],
+	knownAgents: string[],
+): TargetsListRow[] {
+	const rows: TargetsListRow[] = [];
+	// Known agents — always listed so consumers see "available but not configured" too
+	for (const name of knownAgents) {
+		rows.push({
+			name,
+			path: resolveTarget(name),
+			detected: detected.includes(name),
+			configured: targets.includes(name),
+		});
+	}
+	// Custom (non-agent) entries from install_targets — paths configured by
+	// the user. Dedupe by name so a hand-edited manifest with repeated paths
+	// doesn't produce duplicate rows; `targetsAddCommand` already guards on
+	// insert, but we can't trust that for arbitrary YAML edits.
+	const seen = new Set<string>(knownAgents);
+	for (const target of targets) {
+		if (seen.has(target)) continue;
+		seen.add(target);
+		rows.push({ name: target, path: target, detected: false, configured: true });
+	}
+	return rows;
+}
+
 export async function targetsListCommand(dir: string, opts?: TargetsOpts): Promise<void> {
 	const manifest = await loadManifestOrThrow(dir, opts);
 	const targets = manifest.install_targets ?? [];
 	const detected = await detectInstalledAgents(opts?.homeDir);
 	const knownAgents = getKnownAgentNames();
 
-	console.log("Detected     In targets   Name        Path");
+	const rows = buildTargetsListRows(targets, detected, knownAgents);
 
-	// Show known agents
-	for (const name of knownAgents) {
-		const isDetected = detected.includes(name);
-		const isTarget = targets.includes(name);
-		const dir = resolveTarget(name);
-		const detectedCol = isDetected ? "  ✔" : "   ";
-		const targetCol = isTarget ? "  ✔" : "   ";
-		console.log(`${detectedCol.padEnd(13)}${targetCol.padEnd(13)}${name.padEnd(12)}${dir}`);
+	if (opts?.json) {
+		console.log(JSON.stringify(rows, null, 2));
+		return;
 	}
 
-	// Show custom paths
-	for (const target of targets) {
-		if (!knownAgents.includes(target)) {
-			console.log(`${"   ".padEnd(13)}${"  ✔".padEnd(13)}${target.padEnd(12)}${target}`);
-		}
+	console.log("Detected     In targets   Name        Path");
+	for (const row of rows) {
+		const detectedCol = row.detected ? "  ✔" : "   ";
+		const targetCol = row.configured ? "  ✔" : "   ";
+		console.log(
+			`${detectedCol.padEnd(13)}${targetCol.padEnd(13)}${row.name.padEnd(12)}${row.path}`,
+		);
 	}
 }
 

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -21,7 +21,15 @@ import {
 	validateManifestOrThrow,
 	writeManifest,
 } from "../core/manifest.js";
-import { dim, header, pc, success, throwOnResolutionErrors, warn } from "../core/ui.js";
+import {
+	dim,
+	dryRunBanner,
+	header,
+	pc,
+	success,
+	throwOnResolutionErrors,
+	warn,
+} from "../core/ui.js";
 import type { Lockfile } from "../types.js";
 
 export interface VendorOptions {
@@ -120,7 +128,12 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 	);
 }
 
-export async function unvendorCommand(dir: string, options?: { force?: boolean }): Promise<void> {
+export interface UnvendorOptions {
+	force?: boolean;
+	dryRun?: boolean;
+}
+
+export async function unvendorCommand(dir: string, options?: UnvendorOptions): Promise<void> {
 	const manifest = await loadManifestOrThrow(dir);
 
 	if (!manifest.vendor) {
@@ -131,6 +144,31 @@ export async function unvendorCommand(dir: string, options?: { force?: boolean }
 	const devInstallPath = getDevInstallPath(manifest);
 	const installBase = join(dir, devInstallPath);
 	const lockfile = await readLockfile(dir);
+
+	if (options?.dryRun) {
+		// Always surface modified files in dry-run, even with --force — the
+		// user is asking "what would happen?", and showing what --force is
+		// silently overriding is exactly that. Without --force we phrase it
+		// as "would abort"; with --force we phrase it as "would discard".
+		dryRunBanner();
+		if (lockfile) {
+			const modified = await getModifiedVendoredFiles(lockfile, installBase);
+			if (modified.length > 0) {
+				const list = modified.join(", ");
+				const count = `${modified.length} vendored file${modified.length > 1 ? "s" : ""}`;
+				if (options?.force) {
+					warn(`Would discard modifications to ${count}: ${list}`);
+				} else {
+					warn(`Real run would abort: ${count} modified: ${list}`);
+				}
+			}
+			console.log(dim(`Would delete vendored files from ${devInstallPath}/`));
+		}
+		console.log(dim(`Would update ${MANIFEST_NEW} (vendor: false)`));
+		const ignoreEntries = getSkillAgentIgnoreEntries(devInstallPath);
+		console.log(dim(`Would re-add .gitignore entries: ${ignoreEntries.join(", ")}`));
+		return;
+	}
 
 	if (lockfile) {
 		if (!options?.force) {
@@ -153,7 +191,15 @@ export async function unvendorCommand(dir: string, options?: { force?: boolean }
 	success(`Unvendored. Run ${pc.cyan("`skilltree install`")} to restore normal mode.`);
 }
 
-async function checkModifiedVendoredFiles(lockfile: Lockfile, installBase: string): Promise<void> {
+/**
+ * Compare each vendored entry's on-disk integrity against the lockfile.
+ * Pure: returns the list of modified entry names, mutates nothing, throws
+ * nothing. Both `unvendor` (real run) and `unvendor --dry-run` consume this.
+ */
+async function getModifiedVendoredFiles(
+	lockfile: Lockfile,
+	installBase: string,
+): Promise<string[]> {
 	const modified: string[] = [];
 	for (const [key, entry] of Object.entries(lockfile.packages)) {
 		if (!entry.integrity) continue;
@@ -168,7 +214,11 @@ async function checkModifiedVendoredFiles(lockfile: Lockfile, installBase: strin
 			// Missing file — not modified, just gone
 		}
 	}
+	return modified;
+}
 
+async function checkModifiedVendoredFiles(lockfile: Lockfile, installBase: string): Promise<void> {
+	const modified = await getModifiedVendoredFiles(lockfile, installBase);
 	if (modified.length > 0) {
 		throw new Error(
 			`${modified.length} vendored file${modified.length > 1 ? "s" : ""} modified: ${modified.join(", ")}\nRun \`skilltree vendor\` to overwrite with fresh copies, or \`skilltree unvendor --force\` to discard changes.`,

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -11,6 +11,7 @@ import { pc, warn } from "../core/ui.js";
 export interface VerifyOptions {
 	global?: boolean;
 	globalDir?: string; // test override
+	json?: boolean;
 }
 
 export async function verifyCommand(dir: string, opts?: VerifyOptions): Promise<void> {
@@ -41,6 +42,13 @@ export async function verifyCommand(dir: string, opts?: VerifyOptions): Promise<
 		integrityMap,
 		isGlobal ? globalDir : dir,
 	);
+
+	if (opts?.json) {
+		// Machine-readable shape: array of {name, status}. No diagnostics, no
+		// colors — consumers branch on `status` themselves.
+		console.log(JSON.stringify(statuses, null, 2));
+		return;
+	}
 
 	for (const status of statuses) {
 		console.log(`  ${status.name.padEnd(25)} ${formatStatusIcon(status.status)}`);

--- a/src/core/ui.ts
+++ b/src/core/ui.ts
@@ -21,6 +21,9 @@ export const cmd = (msg: string) => pc.cyan(msg);
 /** Format a section header */
 export const header = (msg: string) => console.log(pc.bold(msg));
 
+/** Standard banner printed at the top of any command's --dry-run output. */
+export const dryRunBanner = () => console.log(pc.yellow("Dry run — no changes will be made.\n"));
+
 /** Styled table header row (bold + underline) */
 export const tableHeader = (msg: string) => console.log(pc.bold(pc.underline(msg)));
 

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -1,0 +1,441 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`CLI help snapshots top-level --help is stable 1`] = `
+"Usage: skilltree [options] [command]
+
+Dependency manager for AI agent skills
+
+Options:
+  -V, --version                 output the version number
+  -h, --help                    display help for command
+
+Commands:
+  init [options]                Initialize a new skilltree project
+  add [options] <name>          Add a dependency
+  install [options]             Resolve and install dependencies
+  update [options] [name]       Update dependencies to latest versions
+  remove [options] <name>       Remove a dependency
+  verify [options]              Verify installed dependencies against lockfile
+  list [options]                List installed dependencies
+  scan [options] <paths...>     Scan skills, agents, and commands for undeclared
+                                dependencies
+  teach [options]               Install the skilltree skill to all detected
+                                coding agents
+  vendor [options]              Copy all deps as real files for git commit
+                                (distribution mode)
+  unvendor [options]            Exit vendor mode, restore normal symlinked
+                                installs
+  deps                          Dependency graph commands
+  registry                      Registry management commands
+  search [options] <query>      Search registries for skills, agents, and
+                                commands
+  info [options] <name>         Show detailed information about a skill, agent,
+                                or command
+  completion [options] [shell]  Output shell completion script (zsh or bash)
+  targets                       Manage install targets (coding agents)
+  cache                         Cache management commands
+  help [command]                display help for command
+"
+`;
+
+exports[`CLI help snapshots \`init --help\` is stable 1`] = `
+"Usage: skilltree init [options]
+
+Initialize a new skilltree project
+
+Options:
+  -g, --global  Initialize global dependencies
+  --scan        Scan the repo for existing skills, agents, and commands and
+                register them as local deps
+  -y, --yes     With --scan, include all discovered entries without prompting
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`add --help\` is stable 1`] = `
+"Usage: skilltree add [options] <name>
+
+Add a dependency
+
+Options:
+  -r, --repo <url>            Git repository URL
+  --source <alias>            Source alias (from sources: map)
+  -p, --path <path>           Path within the repository
+  -v, --version <constraint>  Semver version constraint
+  -l, --local <path>          Local filesystem path
+  -D, --dev                   Add as dev dependency
+  -t, --type <type>           Entity type (skill, agent, or command)
+  --registry <name>           Resolve from this registry (when no --repo)
+  -g, --global                Add to global dependencies
+  -y, --yes                   Skip the glob-mode confirmation prompt
+  -h, --help                  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`install --help\` is stable 1`] = `
+"Usage: skilltree install [options]
+
+Resolve and install dependencies
+
+Options:
+  --prod                 Install production dependencies only
+  --frozen               Use lockfile only, error if out of sync
+  -f, --force            Overwrite locally modified files
+  -n, --dry-run          Show plan without installing
+  --install-path <path>  Override install directory
+  -g, --global           Install global dependencies
+  -h, --help             display help for command
+"
+`;
+
+exports[`CLI help snapshots \`update --help\` is stable 1`] = `
+"Usage: skilltree update [options] [name]
+
+Update dependencies to latest versions
+
+Options:
+  -n, --dry-run  Preview version bumps without applying
+  -g, --global   Update global dependencies
+  -h, --help     display help for command
+"
+`;
+
+exports[`CLI help snapshots \`remove --help\` is stable 1`] = `
+"Usage: skilltree remove [options] <name>
+
+Remove a dependency
+
+Options:
+  -f, --force    Skip confirmation
+  --keep-files   Leave installed files in place
+  -n, --dry-run  Preview the removal without changing anything
+  -g, --global   Remove from global dependencies
+  -h, --help     display help for command
+"
+`;
+
+exports[`CLI help snapshots \`verify --help\` is stable 1`] = `
+"Usage: skilltree verify [options]
+
+Verify installed dependencies against lockfile
+
+Options:
+  --json        Output results as JSON
+  -g, --global  Verify global dependencies
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`list --help\` is stable 1`] = `
+"Usage: skilltree list [options]
+
+List installed dependencies
+
+Options:
+  --json        Output results as JSON
+  -g, --global  List global dependencies
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`scan --help\` is stable 1`] = `
+"Usage: skilltree scan [options] <paths...>
+
+Scan skills, agents, and commands for undeclared dependencies
+
+Options:
+  --check     Exit 1 if undeclared deps found (pre-commit mode)
+  --apply     Auto-update frontmatter with detected deps (regex only)
+  --llm       Use LLM for deep dependency detection (requires ANTHROPIC_API_KEY)
+  --json      Output results as JSON
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`teach --help\` is stable 1`] = `
+"Usage: skilltree teach [options]
+
+Install the skilltree skill to all detected coding agents
+
+Options:
+  --agent <name>  Install to a specific agent only
+  -h, --help      display help for command
+"
+`;
+
+exports[`CLI help snapshots \`vendor --help\` is stable 1`] = `
+"Usage: skilltree vendor [options]
+
+Copy all deps as real files for git commit (distribution mode)
+
+Options:
+  --frozen       Use lockfile only, error if out of sync
+  -n, --dry-run  Show plan without making changes
+  -h, --help     display help for command
+"
+`;
+
+exports[`CLI help snapshots \`unvendor --help\` is stable 1`] = `
+"Usage: skilltree unvendor [options]
+
+Exit vendor mode, restore normal symlinked installs
+
+Options:
+  -f, --force    Discard modified vendored files
+  -n, --dry-run  Show what would happen without making changes
+  -h, --help     display help for command
+"
+`;
+
+exports[`CLI help snapshots \`deps --help\` is stable 1`] = `
+"Usage: skilltree deps [options] [command]
+
+Dependency graph commands
+
+Options:
+  -h, --help      display help for command
+
+Commands:
+  tree [options]  Show dependency tree
+  help [command]  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`deps tree --help\` is stable 1`] = `
+"Usage: skilltree deps tree [options]
+
+Show dependency tree
+
+Options:
+  --json        Output tree as JSON
+  -g, --global  Show global dependency tree
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry --help\` is stable 1`] = `
+"Usage: skilltree registry [options] [command]
+
+Registry management commands
+
+Options:
+  -h, --help               display help for command
+
+Commands:
+  init [options]           Seed popular community registries for skill discovery
+  add [options] <url>      Register a git repo as a searchable registry
+
+  Examples:
+    skilltree registry add github.com/VoltAgent/awesome-agent-skills
+    skilltree registry add github.com/trailofbits/skills --name security
+  remove <name>            Remove a registered registry
+  list [options]           List all registered registries
+  update [options] [name]  Fetch registry repos and rebuild search indexes
+  index [options]          Generate skillkit-index.yaml for this repo
+  help [command]           display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry init --help\` is stable 1`] = `
+"Usage: skilltree registry init [options]
+
+Seed popular community registries for skill discovery
+
+Options:
+  --skip-update  Add registries without indexing
+  -h, --help     display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry add --help\` is stable 1`] = `
+"Usage: skilltree registry add [options] <url>
+
+Register a git repo as a searchable registry
+
+Examples:
+  skilltree registry add github.com/VoltAgent/awesome-agent-skills
+  skilltree registry add github.com/trailofbits/skills --name security
+
+Options:
+  --name <alias>  Custom name for the registry
+  -h, --help      display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry remove --help\` is stable 1`] = `
+"Usage: skilltree registry remove [options] <name>
+
+Remove a registered registry
+
+Options:
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry list --help\` is stable 1`] = `
+"Usage: skilltree registry list [options]
+
+List all registered registries
+
+Options:
+  --json      Output results as JSON
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry update --help\` is stable 1`] = `
+"Usage: skilltree registry update [options] [name]
+
+Fetch registry repos and rebuild search indexes
+
+Options:
+  --json      Output results as JSON
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`registry index --help\` is stable 1`] = `
+"Usage: skilltree registry index [options]
+
+Generate skillkit-index.yaml for this repo
+
+Options:
+  --check     Check if index is up to date (exit 1 if stale)
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`search --help\` is stable 1`] = `
+"Usage: skilltree search [options] <query>
+
+Search registries for skills, agents, and commands
+
+Options:
+  --registry <name>  Search only one registry
+  -t, --type <type>  Filter by entity type (skill, agent, or command)
+  --json             Output results as JSON
+  -h, --help         display help for command
+"
+`;
+
+exports[`CLI help snapshots \`info --help\` is stable 1`] = `
+"Usage: skilltree info [options] <name>
+
+Show detailed information about a skill, agent, or command
+
+Options:
+  --json      Output results as JSON
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`completion --help\` is stable 1`] = `
+"Usage: skilltree completion [options] [shell]
+
+Output shell completion script (zsh or bash)
+
+Options:
+  --install   Write the script to the conventional location instead of stdout
+  -h, --help  display help for command
+"
+`;
+
+exports[`CLI help snapshots \`targets --help\` is stable 1`] = `
+"Usage: skilltree targets [options] [command]
+
+Manage install targets (coding agents)
+
+Options:
+  -h, --help                 display help for command
+
+Commands:
+  list [options]             Show known agents with detected and configured
+                             status
+  add [options] <target>     Add an agent or path to install_targets
+  remove [options] <target>  Remove an agent or path from install_targets
+  detect [options]           Scan for installed agents and add missing ones
+  migrate [options]          Convert dev_install_path to install_targets
+  help [command]             display help for command
+"
+`;
+
+exports[`CLI help snapshots \`targets list --help\` is stable 1`] = `
+"Usage: skilltree targets list [options]
+
+Show known agents with detected and configured status
+
+Options:
+  --json        Output results as JSON
+  -g, --global  Show global targets
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`targets add --help\` is stable 1`] = `
+"Usage: skilltree targets add [options] <target>
+
+Add an agent or path to install_targets
+
+Options:
+  -g, --global  Add to global manifest
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`targets remove --help\` is stable 1`] = `
+"Usage: skilltree targets remove [options] <target>
+
+Remove an agent or path from install_targets
+
+Options:
+  -g, --global  Remove from global manifest
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`targets detect --help\` is stable 1`] = `
+"Usage: skilltree targets detect [options]
+
+Scan for installed agents and add missing ones
+
+Options:
+  -g, --global  Detect for global manifest
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`targets migrate --help\` is stable 1`] = `
+"Usage: skilltree targets migrate [options]
+
+Convert dev_install_path to install_targets
+
+Options:
+  -g, --global  Migrate global manifest
+  -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`cache --help\` is stable 1`] = `
+"Usage: skilltree cache [options] [command]
+
+Cache management commands
+
+Options:
+  -h, --help       display help for command
+
+Commands:
+  clean [options]  Remove cached repositories
+  help [command]   display help for command
+"
+`;
+
+exports[`CLI help snapshots \`cache clean --help\` is stable 1`] = `
+"Usage: skilltree cache clean [options]
+
+Remove cached repositories
+
+Options:
+  --json      Output results as JSON
+  -h, --help  display help for command
+"
+`;

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -11,6 +11,10 @@ Options:
 
 Commands:
   init [options]                Initialize a new skilltree project
+
+  Related:
+    registry init   — seed popular community registries to install skills from
+    targets detect  — auto-discover installed coding agents on this machine
   add [options] <name>          Add a dependency
   install [options]             Resolve and install dependencies
   update [options] [name]       Update dependencies to latest versions
@@ -42,6 +46,10 @@ exports[`CLI help snapshots \`init --help\` is stable 1`] = `
 "Usage: skilltree init [options]
 
 Initialize a new skilltree project
+
+Related:
+  registry init   — seed popular community registries to install skills from
+  targets detect  — auto-discover installed coding agents on this machine
 
 Options:
   -g, --global  Initialize global dependencies
@@ -223,11 +231,17 @@ Options:
 
 Commands:
   init [options]           Seed popular community registries for skill discovery
-  add [options] <url>      Register a git repo as a searchable registry
+
+  Related:
+    init            — initialize a new skilltree project (run this first)
+    targets detect  — auto-discover installed coding agents on this machine
+  add [options] [url]      Register a git repo as a searchable registry
+
+  The URL can be passed positionally or via --repo (so muscle memory from \`add\` transfers).
 
   Examples:
     skilltree registry add github.com/VoltAgent/awesome-agent-skills
-    skilltree registry add github.com/trailofbits/skills --name security
+    skilltree registry add --repo github.com/trailofbits/skills --name security
   remove <name>            Remove a registered registry
   list [options]           List all registered registries
   update [options] [name]  Fetch registry repos and rebuild search indexes
@@ -241,6 +255,10 @@ exports[`CLI help snapshots \`registry init --help\` is stable 1`] = `
 
 Seed popular community registries for skill discovery
 
+Related:
+  init            — initialize a new skilltree project (run this first)
+  targets detect  — auto-discover installed coding agents on this machine
+
 Options:
   --skip-update  Add registries without indexing
   -h, --help     display help for command
@@ -248,17 +266,21 @@ Options:
 `;
 
 exports[`CLI help snapshots \`registry add --help\` is stable 1`] = `
-"Usage: skilltree registry add [options] <url>
+"Usage: skilltree registry add [options] [url]
 
 Register a git repo as a searchable registry
 
+The URL can be passed positionally or via --repo (so muscle memory from \`add\`
+transfers).
+
 Examples:
   skilltree registry add github.com/VoltAgent/awesome-agent-skills
-  skilltree registry add github.com/trailofbits/skills --name security
+  skilltree registry add --repo github.com/trailofbits/skills --name security
 
 Options:
-  --name <alias>  Custom name for the registry
-  -h, --help      display help for command
+  -r, --repo <url>  Git repository URL (alias for the positional <url>)
+  --name <alias>    Custom name for the registry
+  -h, --help        display help for command
 "
 `;
 
@@ -354,6 +376,10 @@ Commands:
   add [options] <target>     Add an agent or path to install_targets
   remove [options] <target>  Remove an agent or path from install_targets
   detect [options]           Scan for installed agents and add missing ones
+
+  Related:
+    init            — initialize a new skilltree project (run this first)
+    registry init   — seed popular community registries to install skills from
   migrate [options]          Convert dev_install_path to install_targets
   help [command]             display help for command
 "
@@ -397,6 +423,10 @@ exports[`CLI help snapshots \`targets detect --help\` is stable 1`] = `
 "Usage: skilltree targets detect [options]
 
 Scan for installed agents and add missing ones
+
+Related:
+  init            — initialize a new skilltree project (run this first)
+  registry init   — seed popular community registries to install skills from
 
 Options:
   -g, --global  Detect for global manifest

--- a/tests/cli/flag-parity.test.ts
+++ b/tests/cli/flag-parity.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import type { Command } from "commander";
+import { buildProgram } from "../../src/cli.js";
+
+/**
+ * Parity guards: assert that every command in a given category exposes the
+ * expected flag. Catches the failure mode where someone adds a new
+ * mutating command but forgets to wire `-n, --dry-run`, or a new
+ * read-shaped command that forgets `--json`.
+ *
+ * The allowlists below are the source of truth — when adding a new
+ * command, add it to the appropriate set (or explicitly note why it
+ * doesn't fit the pattern).
+ */
+
+/**
+ * Commands whose primary effect is to mutate the filesystem or manifest /
+ * lockfile state. Each MUST accept `-n, --dry-run`.
+ *
+ * Excluded by design:
+ * - `init`: creates a new manifest; preview mode would be near-empty
+ * - `add`: a single-file mutation users iterate on; preview is low-value
+ * - `targets {add,remove,detect,migrate}`: small, transactional manifest edits
+ * - `registry {add,remove,update,init}`: out-of-band cache mutations,
+ *   not project state — preview unclear
+ */
+const MUTATING_COMMANDS = ["install", "update", "remove", "vendor", "unvendor"];
+
+/**
+ * Commands whose primary effect is to read state and produce output.
+ * Each MUST accept `--json` so scripted consumers can parse the result.
+ *
+ * Excluded by design:
+ * - `info`: not yet machine-introspectable across project + global state
+ * - `completion`, `teach`, `registry index`, `registry add/remove`,
+ *   `targets add/remove/detect/migrate`: not list-shaped output
+ */
+const READSHAPED_COMMANDS = [
+	"verify",
+	"list",
+	"scan",
+	"search",
+	"info",
+	"registry list",
+	"registry update",
+	"targets list",
+	"deps tree",
+	"cache clean",
+];
+
+/**
+ * Commands that operate over project OR global state and need a way to
+ * select which. Each MUST accept `-g, --global`.
+ *
+ * Excluded by design:
+ * - `scan`, `search`, `vendor`, `unvendor`: don't have a global concept
+ * - `registry {*}`: registries are user-global, not project-vs-global
+ * - `info`: registry-shaped (logged as a separate item in BACKLOG)
+ * - `completion`, `teach`, `cache clean`: process- or env-level, no scope
+ */
+const STATEFUL_COMMANDS = [
+	"init",
+	"add",
+	"install",
+	"update",
+	"remove",
+	"verify",
+	"list",
+	"deps tree",
+	"targets list",
+	"targets add",
+	"targets remove",
+	"targets detect",
+	"targets migrate",
+];
+
+function* walkCommands(
+	program: Command,
+	prefix: string[] = [],
+): Generator<{ path: string; command: Command }> {
+	for (const cmd of program.commands) {
+		if (cmd.name() === "help") continue;
+		// See note on `_hidden` in tests/cli/help-snapshot.test.ts
+		// biome-ignore lint/suspicious/noExplicitAny: documented private-field access
+		if ((cmd as any)._hidden) continue;
+		const path = [...prefix, cmd.name()];
+		yield { path: path.join(" "), command: cmd };
+		if (cmd.commands.length > 0) {
+			yield* walkCommands(cmd, path);
+		}
+	}
+}
+
+function findCommand(program: Command, path: string): Command | undefined {
+	const parts = path.split(" ");
+	let current: Command = program;
+	for (const part of parts) {
+		const next = current.commands.find((c) => c.name() === part);
+		if (!next) return undefined;
+		current = next;
+	}
+	return current;
+}
+
+function commandHasOption(command: Command, longFlag: string): boolean {
+	return command.options.some((o) => o.long === longFlag);
+}
+
+describe("CLI flag parity", () => {
+	const program = buildProgram();
+
+	describe("--dry-run on mutating commands", () => {
+		for (const path of MUTATING_COMMANDS) {
+			test(`\`${path}\` accepts -n, --dry-run`, () => {
+				const cmd = findCommand(program, path);
+				expect(cmd, `command \`${path}\` not found in program`).toBeDefined();
+				if (!cmd) return;
+				expect(commandHasOption(cmd, "--dry-run")).toBe(true);
+				const opt = cmd.options.find((o) => o.long === "--dry-run");
+				expect(opt?.short).toBe("-n");
+			});
+		}
+	});
+
+	describe("--json on read-shaped commands", () => {
+		for (const path of READSHAPED_COMMANDS) {
+			test(`\`${path}\` accepts --json`, () => {
+				const cmd = findCommand(program, path);
+				expect(cmd, `command \`${path}\` not found in program`).toBeDefined();
+				if (!cmd) return;
+				expect(commandHasOption(cmd, "--json")).toBe(true);
+			});
+		}
+	});
+
+	describe("-g, --global on stateful commands", () => {
+		for (const path of STATEFUL_COMMANDS) {
+			test(`\`${path}\` accepts -g, --global`, () => {
+				const cmd = findCommand(program, path);
+				expect(cmd, `command \`${path}\` not found in program`).toBeDefined();
+				if (!cmd) return;
+				expect(commandHasOption(cmd, "--global")).toBe(true);
+				const opt = cmd.options.find((o) => o.long === "--global");
+				expect(opt?.short).toBe("-g");
+			});
+		}
+	});
+
+	describe("no command in MUTATING_COMMANDS uses -n for something else", () => {
+		// Soft check: across the whole tree, if a command exposes -n, it MUST
+		// be --dry-run. Catches accidental short-flag overload (the central
+		// concern of issue #23).
+		for (const { path, command } of walkCommands(program)) {
+			const dashN = command.options.find((o) => o.short === "-n");
+			if (dashN) {
+				test(`\`${path}\`'s -n maps to --dry-run`, () => {
+					expect(dashN.long).toBe("--dry-run");
+				});
+			}
+		}
+	});
+});

--- a/tests/cli/help-snapshot.test.ts
+++ b/tests/cli/help-snapshot.test.ts
@@ -40,9 +40,21 @@ function* walkCommands(
 /**
  * Capture a command's help text. Uses Commander's helpInformation() which
  * is a pure string-returning API — no stdout writes, no spawning.
+ *
+ * Per-line trailing whitespace is stripped: Commander column-aligns
+ * multi-line descriptions with ~33 spaces of left padding, which means
+ * blank "continuation" lines arrive whitespace-padded. The repo's
+ * `trailing-whitespace` pre-commit hook then trims those at commit time,
+ * so the snapshot file on disk and CI's freshly-generated output diverge
+ * by whitespace only. Normalize at snapshot time to keep both sides
+ * byte-identical.
  */
 function helpText(command: Command): string {
-	return command.helpInformation();
+	return command
+		.helpInformation()
+		.split("\n")
+		.map((line) => line.replace(/[ \t]+$/, ""))
+		.join("\n");
 }
 
 describe("CLI help snapshots", () => {

--- a/tests/cli/help-snapshot.test.ts
+++ b/tests/cli/help-snapshot.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { Command } from "commander";
+import { buildProgram } from "../../src/cli.js";
+
+/**
+ * Snapshot every command's --help output. Future flag additions, removals,
+ * renames, or description changes must update the snapshot — making the
+ * change a deliberate review item rather than silent drift.
+ *
+ * If a snapshot needs intentional updating: run with `bun test --update-snapshots`.
+ */
+
+/**
+ * Walk the program tree and yield every (path, command) pair, where path
+ * is the user-facing command path (e.g. "registry update"). Skips hidden
+ * commands (e.g. `_complete`) and the implicit `help` command Commander
+ * adds automatically.
+ */
+function* walkCommands(
+	program: Command,
+	prefix: string[] = [],
+): Generator<{ path: string; command: Command }> {
+	for (const cmd of program.commands) {
+		if (cmd.name() === "help") continue;
+		// Commander 14 stores the `{ hidden: true }` flag in a private `_hidden`
+		// field on Command (only `Option.hidden` is public). Stable across the
+		// v8-v14 API window — set via `.command(name, { hidden: true })` (we use
+		// it for `_complete`).
+		// biome-ignore lint/suspicious/noExplicitAny: documented private-field access
+		if ((cmd as any)._hidden) continue;
+		const path = [...prefix, cmd.name()];
+		yield { path: path.join(" "), command: cmd };
+		// Recurse into sub-command groups (deps, registry, targets, cache)
+		if (cmd.commands.length > 0) {
+			yield* walkCommands(cmd, path);
+		}
+	}
+}
+
+/**
+ * Capture a command's help text. Uses Commander's helpInformation() which
+ * is a pure string-returning API — no stdout writes, no spawning.
+ */
+function helpText(command: Command): string {
+	return command.helpInformation();
+}
+
+describe("CLI help snapshots", () => {
+	const program = buildProgram();
+
+	test("top-level --help is stable", () => {
+		expect(helpText(program)).toMatchSnapshot();
+	});
+
+	for (const { path, command } of walkCommands(program)) {
+		test(`\`${path} --help\` is stable`, () => {
+			expect(helpText(command)).toMatchSnapshot();
+		});
+	}
+});

--- a/tests/commands/cache.test.ts
+++ b/tests/commands/cache.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cacheCleanCommand } from "../../src/commands/cache.js";
+
+let tempDir: string;
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+function captureLogs(): { logs: string[]; restore: () => void } {
+	const logs: string[] = [];
+	const original = console.log;
+	console.log = (...args: unknown[]) => logs.push(args.join(" "));
+	return {
+		logs,
+		restore: () => {
+			console.log = original;
+		},
+	};
+}
+
+describe("cacheCleanCommand --json", () => {
+	test("emits {cleaned: true, path, bytesFreed} after removing a populated cache", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-cache-"));
+		const fakeCache = join(tempDir, "cache");
+		await mkdir(fakeCache, { recursive: true });
+		await writeFile(join(fakeCache, "blob.txt"), "x".repeat(1024), "utf-8");
+
+		const { logs, restore } = captureLogs();
+		try {
+			await cacheCleanCommand({ json: true, cacheDir: fakeCache });
+		} finally {
+			restore();
+		}
+
+		expect(logs).toHaveLength(1);
+		const parsed = JSON.parse(logs[0] ?? "");
+		expect(parsed.cleaned).toBe(true);
+		expect(parsed.path).toBe(fakeCache);
+		expect(typeof parsed.bytesFreed).toBe("number");
+		expect(parsed.bytesFreed).toBeGreaterThanOrEqual(1024);
+	});
+
+	test("emits {cleaned: false, path, bytesFreed: 0} when cache is already absent", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-cache-"));
+		const fakeCache = join(tempDir, "no-such-cache");
+
+		const { logs, restore } = captureLogs();
+		try {
+			await cacheCleanCommand({ json: true, cacheDir: fakeCache });
+		} finally {
+			restore();
+		}
+
+		expect(logs).toHaveLength(1);
+		const parsed = JSON.parse(logs[0] ?? "");
+		expect(parsed.cleaned).toBe(false);
+		expect(parsed.path).toBe(fakeCache);
+		expect(parsed.bytesFreed).toBe(0);
+	});
+});
+
+describe("cacheCleanCommand human output", () => {
+	test("removes a populated cache and reports success", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-cache-"));
+		const fakeCache = join(tempDir, "cache");
+		await mkdir(fakeCache, { recursive: true });
+		await writeFile(join(fakeCache, "blob.txt"), "data", "utf-8");
+
+		const { logs, restore } = captureLogs();
+		try {
+			await cacheCleanCommand({ cacheDir: fakeCache });
+		} finally {
+			restore();
+		}
+
+		expect(logs.some((l) => l.includes("Removed cache"))).toBe(true);
+	});
+
+	test("reports already-clean when cache is absent", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-cache-"));
+		const fakeCache = join(tempDir, "no-such-cache");
+
+		const { logs, restore } = captureLogs();
+		try {
+			await cacheCleanCommand({ cacheDir: fakeCache });
+		} finally {
+			restore();
+		}
+
+		expect(logs.some((l) => l.includes("already clean"))).toBe(true);
+	});
+});

--- a/tests/commands/deps-tree.test.ts
+++ b/tests/commands/deps-tree.test.ts
@@ -156,6 +156,110 @@ describe("deps tree rendering", () => {
 		expect(lines[1]).toBe("└── child@2.0.0 (skill)");
 	});
 
+	test("--json emits a nested object tree per root", async () => {
+		const dir = await makeTempDir();
+
+		await createLocalSkill(join(dir, "skills"), "leaf");
+		await createLocalSkill(join(dir, "skills"), "mid", ["leaf"]);
+		await createLocalSkill(join(dir, "skills"), "top", ["mid"]);
+
+		await writeManifest(
+			dir,
+			"dependencies:\n  top:\n    local: ./skills/top\n  mid:\n    local: ./skills/mid\n  leaf:\n    local: ./skills/leaf\n",
+		);
+
+		await installCommand(dir, {});
+
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+
+		// Single JSON line — array of root entries
+		expect(lines).toHaveLength(1);
+		const parsed = JSON.parse(lines[0] ?? "");
+		expect(Array.isArray(parsed)).toBe(true);
+
+		// "top" is a root and should have a nested "mid → leaf" subtree
+		const topRoot = parsed.find((r: { name: string }) => r.name === "top");
+		expect(topRoot).toBeDefined();
+		expect(topRoot.type).toBe("skill");
+		expect(topRoot.source).toBe("local");
+		expect(Array.isArray(topRoot.dependencies)).toBe(true);
+		expect(topRoot.dependencies).toHaveLength(1);
+		expect(topRoot.dependencies[0].name).toBe("mid");
+		expect(topRoot.dependencies[0].dependencies[0].name).toBe("leaf");
+	});
+
+	test("--json emits [] for an empty manifest", async () => {
+		const dir = await makeTempDir();
+		await writeManifest(dir, "dependencies: {}\n");
+		await installCommand(dir, {});
+
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0] ?? "")).toEqual([]);
+	});
+
+	test("--json marks deduped entries", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "shared");
+		await createLocalSkill(join(dir, "skills"), "left", ["shared"]);
+		await createLocalSkill(join(dir, "skills"), "right", ["shared"]);
+		await createLocalSkill(join(dir, "skills"), "root", ["left", "right"]);
+
+		await writeManifest(
+			dir,
+			"dependencies:\n  root:\n    local: ./skills/root\n  left:\n    local: ./skills/left\n  right:\n    local: ./skills/right\n  shared:\n    local: ./skills/shared\n",
+		);
+
+		await installCommand(dir, {});
+
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+
+		const parsed = JSON.parse(lines[0] ?? "");
+		// Find any "shared" appearance below the first one — it should be marked deduped
+		const findShared = (
+			node: { name: string; deduped?: boolean; dependencies: unknown[] },
+			seen: { count: number },
+		): boolean => {
+			if (node.name === "shared") {
+				seen.count += 1;
+				if (seen.count > 1 && node.deduped !== true) return false;
+			}
+			for (const child of node.dependencies as Array<{
+				name: string;
+				deduped?: boolean;
+				dependencies: unknown[];
+			}>) {
+				if (!findShared(child, seen)) return false;
+			}
+			return true;
+		};
+		const seen = { count: 0 };
+		for (const root of parsed) findShared(root, seen);
+		expect(seen.count).toBeGreaterThanOrEqual(2);
+	});
+
 	test("renders │ continuation for non-last children with subtrees", async () => {
 		const dir = await makeTempDir();
 

--- a/tests/commands/registry.test.ts
+++ b/tests/commands/registry.test.ts
@@ -13,6 +13,7 @@ import {
 	registryListCommand,
 	registryRemoveCommand,
 	registryUpdateCommand,
+	resolveRegistryAddUrl,
 } from "../../src/commands/registry.js";
 import { getRegistryIndexPath, writeRegistryIndex } from "../../src/core/registry-cache.js";
 import { readConfig, writeConfig } from "../../src/core/registry-config.js";
@@ -125,6 +126,48 @@ describe("registryAddCommand", () => {
 		await expect(registryAddCommand("github.com/other/vibes", {}, configPath)).rejects.toThrow(
 			"--name",
 		);
+	});
+});
+
+/**
+ * The `--repo` alias for the positional URL is wired in `src/cli.ts` (the
+ * function still takes a single URL parameter — the CLI layer collapses
+ * positional + `--repo` into one). These tests cover the resolver function
+ * exposed alongside `registryAddCommand` so the alias logic is unit-testable
+ * without spinning up Commander.
+ */
+describe("resolveRegistryAddUrl", () => {
+	test("accepts positional URL only", () => {
+		expect(resolveRegistryAddUrl("github.com/foo/bar", undefined)).toBe("github.com/foo/bar");
+	});
+
+	test("accepts --repo only", () => {
+		expect(resolveRegistryAddUrl(undefined, "github.com/foo/bar")).toBe("github.com/foo/bar");
+	});
+
+	test("accepts both when they match exactly (idempotent)", () => {
+		expect(resolveRegistryAddUrl("github.com/foo/bar", "github.com/foo/bar")).toBe(
+			"github.com/foo/bar",
+		);
+	});
+
+	test("errors when neither positional nor --repo is provided", () => {
+		expect(() => resolveRegistryAddUrl(undefined, undefined)).toThrow(/required/i);
+	});
+
+	test("errors when positional and --repo conflict", () => {
+		expect(() => resolveRegistryAddUrl("github.com/foo/bar", "github.com/baz/qux")).toThrow(
+			/conflict/i,
+		);
+	});
+
+	test("treats empty string as missing (not silently truthy-skip)", () => {
+		// Honours CLAUDE.md "presence check ≠ value check" pattern. A user
+		// passing `--repo ""` deserves an explicit error, not a silent fall-
+		// through to a positional that wasn't provided.
+		expect(() => resolveRegistryAddUrl(undefined, "")).toThrow(/required/i);
+		expect(() => resolveRegistryAddUrl("", undefined)).toThrow(/required/i);
+		expect(() => resolveRegistryAddUrl("", "")).toThrow(/required/i);
 	});
 });
 

--- a/tests/commands/registry.test.ts
+++ b/tests/commands/registry.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import simpleGit from "simple-git";
 import {
 	DEFAULT_REGISTRIES,
 	inferRegistryName,
@@ -11,10 +12,12 @@ import {
 	registryInitCommand,
 	registryListCommand,
 	registryRemoveCommand,
+	registryUpdateCommand,
 } from "../../src/commands/registry.js";
 import { getRegistryIndexPath, writeRegistryIndex } from "../../src/core/registry-cache.js";
 import { readConfig, writeConfig } from "../../src/core/registry-config.js";
 import type { RegistryIndex } from "../../src/types.js";
+import { createTestRepo } from "../helpers/git-fixtures.js";
 
 let tempDir: string;
 
@@ -249,6 +252,68 @@ describe("registryListCommand", () => {
 
 		const output = logs.join("\n");
 		expect(output.toLowerCase()).toContain("no registries");
+	});
+});
+
+describe("registryUpdateCommand", () => {
+	test("--json emits a result array per touched registry", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+
+		// Build a real local repo and bare clone of it
+		const repoDir = await createTestRepo(dir, "repo", [
+			{ path: "skills/a", name: "a" },
+			{ path: "skills/b", name: "b" },
+			{ path: "agents/x.md", name: "x", isAgent: true },
+		]);
+		const bareDir = join(dir, "bare.git");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		await writeConfig({ registries: [{ name: "fixture", repo: `file://${bareDir}` }] }, configPath);
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		const originalWrite = process.stdout.write;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		process.stdout.write = () => true;
+		try {
+			await registryUpdateCommand(undefined, configPath, cacheDir, { json: true });
+		} finally {
+			console.log = originalLog;
+			process.stdout.write = originalWrite;
+		}
+
+		expect(logs).toHaveLength(1);
+		const parsed = JSON.parse(logs[0] ?? "");
+		expect(Array.isArray(parsed)).toBe(true);
+		expect(parsed).toHaveLength(1);
+		const result = parsed[0];
+		expect(result.name).toBe("fixture");
+		expect(result.repo).toBe(`file://${bareDir}`);
+		expect(typeof result.entities).toBe("number");
+		expect(result.entities).toBe(3);
+		expect(result.skills).toBe(2);
+		expect(result.agents).toBe(1);
+		expect(result.commands).toBe(0);
+	});
+
+	test("--json emits [] when no registries configured", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		await writeConfig({ registries: [] }, configPath);
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await registryUpdateCommand(undefined, configPath, undefined, { json: true });
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(logs).toHaveLength(1);
+		expect(JSON.parse(logs[0] ?? "")).toEqual([]);
 	});
 });
 

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -151,6 +151,71 @@ describe("removeCommand", () => {
 		expect(lockfile?.packages.grandchild).toBeUndefined();
 	});
 
+	test("--dry-run leaves manifest unchanged and previews what would be removed", async () => {
+		const dir = await setup();
+		await addCommand("my-skill", { repo: "github.com/user/repo", path: "skills/my-skill" }, dir);
+
+		const installDir = join(dir, ".claude", "skills", "my-skill");
+		await mkdir(installDir, { recursive: true });
+		await writeFile(join(installDir, "SKILL.md"), "# test\n");
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			"lockfile_version: 1\npackages:\n  my-skill:\n    type: skill\n    group: prod\n    repo: github.com/user/repo\n    path: skills/my-skill\n    version: 1.0.0\n    commit: abc\n    dependencies: []\n",
+		);
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await removeCommand("my-skill", dir, { force: true, dryRun: true });
+		} finally {
+			console.log = originalLog;
+		}
+
+		// Manifest still has the dep
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["my-skill"]).toBeDefined();
+
+		// Files still exist
+		const stats = await stat(installDir);
+		expect(stats.isDirectory()).toBe(true);
+
+		// Lockfile still has the entry
+		const lockfile = await readLockfile(dir);
+		expect(lockfile?.packages["my-skill"]).toBeDefined();
+
+		// Output advertises dry-run + names what would be touched
+		const output = logs.join("\n");
+		expect(output.toLowerCase()).toContain("dry run");
+		expect(output).toContain("my-skill");
+	});
+
+	test("--dry-run skips the dependents-confirmation prompt", async () => {
+		const dir = await setup();
+		await addCommand("base", { repo: "github.com/user/repo", path: "skills/base" }, dir);
+
+		// Lockfile makes "consumer" depend on "base" — without --force this would
+		// prompt. --dry-run should not prompt either (nothing to confirm in a
+		// preview).
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			"lockfile_version: 1\npackages:\n  base:\n    type: skill\n    group: prod\n    repo: github.com/user/repo\n    path: skills/base\n    version: 1.0.0\n    commit: abc\n    dependencies: []\n  consumer:\n    type: skill\n    group: prod\n    repo: github.com/user/repo\n    path: skills/consumer\n    version: 1.0.0\n    commit: abc\n    dependencies:\n      - base\n",
+		);
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			// No --force; if dry-run didn't bypass the prompt this would hang on stdin
+			await removeCommand("base", dir, { dryRun: true });
+		} finally {
+			console.log = originalLog;
+		}
+
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.base).toBeDefined();
+	});
+
 	test("orphan cleanup removes installed files of orphans", async () => {
 		const dir = await setup();
 		await addCommand("parent", { repo: "github.com/user/repo", path: "skills/parent" }, dir);

--- a/tests/commands/targets.test.ts
+++ b/tests/commands/targets.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
 	targetsAddCommand,
 	targetsDetectCommand,
+	targetsListCommand,
 	targetsMigrateCommand,
 	targetsRemoveCommand,
 } from "../../src/commands/targets.js";
@@ -149,6 +150,93 @@ describe("targetsDetectCommand", () => {
 		await writeManifestFile(dir, "dev_install_path: .claude\ndependencies: {}\n");
 
 		await expect(targetsDetectCommand(dir)).rejects.toThrow("targets migrate");
+	});
+});
+
+describe("targetsListCommand", () => {
+	test("--json emits an array of {name, path, detected, configured} rows", async () => {
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+
+		// Empty fake home so nothing is "detected"
+		const fakeHome = join(dir, "fake-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await targetsListCommand(dir, { json: true, homeDir: fakeHome });
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(logs).toHaveLength(1);
+		const parsed = JSON.parse(logs[0] ?? "");
+		expect(Array.isArray(parsed)).toBe(true);
+		// Should include at least claude (configured) and any other known agents (not configured)
+		const claude = parsed.find((r: { name: string }) => r.name === "claude");
+		expect(claude).toBeDefined();
+		expect(claude.configured).toBe(true);
+		expect(claude.detected).toBe(false);
+		expect(typeof claude.path).toBe("string");
+		// Every row has the four fields with the right types
+		for (const row of parsed) {
+			expect(typeof row.name).toBe("string");
+			expect(typeof row.path).toBe("string");
+			expect(typeof row.detected).toBe("boolean");
+			expect(typeof row.configured).toBe("boolean");
+		}
+	});
+
+	test("--json dedupes hand-edited duplicate custom paths", async () => {
+		const dir = await makeTempDir();
+		// User-authored manifest with a repeated custom path. `targetsAddCommand`
+		// rejects this on insert, but a manually-edited YAML file can still
+		// reach the list path — the renderer must not double-emit.
+		await writeManifestFile(
+			dir,
+			"install_targets:\n  - claude\n  - ./custom-a\n  - ./custom-a\ndependencies: {}\n",
+		);
+		const fakeHome = join(dir, "fake-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await targetsListCommand(dir, { json: true, homeDir: fakeHome });
+		} finally {
+			console.log = originalLog;
+		}
+
+		const parsed = JSON.parse(logs[0] ?? "");
+		const customRows = parsed.filter((r: { name: string }) => r.name === "./custom-a");
+		expect(customRows).toHaveLength(1);
+	});
+
+	test("--json includes custom path targets", async () => {
+		const dir = await makeTempDir();
+		await writeManifestFile(
+			dir,
+			"install_targets:\n  - claude\n  - ./my-custom\ndependencies: {}\n",
+		);
+		const fakeHome = join(dir, "fake-home");
+		await mkdir(fakeHome, { recursive: true });
+
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await targetsListCommand(dir, { json: true, homeDir: fakeHome });
+		} finally {
+			console.log = originalLog;
+		}
+
+		const parsed = JSON.parse(logs[0] ?? "");
+		const custom = parsed.find((r: { name: string }) => r.name === "./my-custom");
+		expect(custom).toBeDefined();
+		expect(custom.configured).toBe(true);
 	});
 });
 

--- a/tests/commands/verify.test.ts
+++ b/tests/commands/verify.test.ts
@@ -130,4 +130,34 @@ describe("verifyCommand", () => {
 			verifyCommand(dir, { global: true, globalDir: join(dir, "nonexistent") }),
 		).rejects.toThrow("No global manifest");
 	});
+
+	test("--json emits an array of {name, status} rows", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "skill-a");
+		await createLocalSkill(join(dir, "skills"), "skill-b");
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			"dependencies:\n  skill-a:\n    local: ./skills/skill-a\n  skill-b:\n    local: ./skills/skill-b\n",
+		);
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await verifyCommand(dir, { json: true });
+		} finally {
+			restore();
+		}
+
+		// Single JSON line
+		expect(logs).toHaveLength(1);
+		const parsed = JSON.parse(logs[0] ?? "");
+		expect(Array.isArray(parsed)).toBe(true);
+		expect(parsed).toHaveLength(2);
+		const names = parsed.map((r: { name: string }) => r.name).sort();
+		expect(names).toEqual(["skill-a", "skill-b"]);
+		for (const row of parsed) {
+			expect(typeof row.name).toBe("string");
+			expect(typeof row.status).toBe("string");
+		}
+	});
 });

--- a/tests/e2e/vendor-e2e.test.ts
+++ b/tests/e2e/vendor-e2e.test.ts
@@ -150,6 +150,42 @@ describe("vendor e2e", () => {
 		expect(gitignore).toContain(".claude/agents/");
 	});
 
+	test("unvendor --dry-run leaves vendored files, manifest, and gitignore untouched", async () => {
+		const dir = await makeTempDir();
+		await setupProject(dir);
+
+		// Vendor first
+		await vendorCommand(dir, {});
+
+		const skillPath = join(dir, ".claude", "skills", "my-skill");
+		expect(existsSync(skillPath)).toBe(true);
+		const gitignoreBefore = await readFile(join(dir, ".gitignore"), "utf-8");
+
+		// Capture stdout so we can assert dry-run advertised itself
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => logs.push(args.join(" "));
+		try {
+			await unvendorCommand(dir, { dryRun: true });
+		} finally {
+			console.log = originalLog;
+		}
+
+		// Files still present
+		expect(existsSync(skillPath)).toBe(true);
+
+		// Manifest still in vendor mode
+		const manifest = await readManifest(dir);
+		expect(manifest.vendor).toBe(true);
+
+		// .gitignore unchanged
+		const gitignoreAfter = await readFile(join(dir, ".gitignore"), "utf-8");
+		expect(gitignoreAfter).toBe(gitignoreBefore);
+
+		const output = logs.join("\n");
+		expect(output.toLowerCase()).toContain("dry run");
+	});
+
 	test("unvendor when not vendored warns and does nothing", async () => {
 		const dir = await makeTempDir();
 		await setupProject(dir);


### PR DESCRIPTION
## Summary

Closes the **non-breaking** subset of #23 across four PatchModes plus a BACKLOG entry for the rest.

- **`--json` parity** on `verify`, `targets list`, `deps tree`, `registry update`, `cache clean` (item 4)
- **`-n, --dry-run` parity** on `remove` and `unvendor` (item 6)
- **Help-output snapshot tests** + **flag-parity tests** for `--dry-run` / `--json` / `--global` so future drift is intentional ("Test coverage to add")
- **`registry add --repo` alias** for the positional URL (item 8)
- **Help cross-references** between `init`, `registry init`, `targets detect` (item 7)
- **BACKLOG entries** for the deferred breaking changes and design questions

## Out of scope (logged to BACKLOG)

| Item | Why deferred |
|------|--------------|
| `-f/--force` short-flag overload remap | Breaking — needs deprecation cycle |
| `registry add --name` → `--as` | Breaking — needs deprecation cycle |
| Canonical positional name (`<target>` vs `<agent>`) | Breaking — needs deprecation cycle |
| `info --global` | Issue's premise was wrong — `info` queries registry indexes, not project state. Real ask is "show install status" which is a feature, not a flag. |
| `update --frozen` | Semantically overlaps existing `--dry-run`. Issue itself calls it "effectively a no-op verification." Needs design pass. |
| `cache clean` swallows real I/O errors | Pre-existing bug surfaced during PM1 review; not a regression. |

See `docs/BACKLOG.md` for the full deferred list.

## Notable refactors

- `src/cli.ts` now exports `buildProgram(): Command` so the snapshot/parity tests can introspect the Commander tree without spawning the binary. Auto-run is gated on `import.meta.main` (verified to work for both `bun src/cli.ts` and `bun build --compile`).
- `findOrphans` in `src/commands/remove.ts` now takes an `excludeName` option, eliminating the need for `dry-run` callers to JSON-clone the lockfile.
- `checkModifiedVendoredFiles` split into a pure `getModifiedVendoredFiles` so both real-run (throws) and dry-run (informs) can consume it.
- New `dryRunBanner()` helper in `src/core/ui.ts` to keep the banner wording consistent across commands.

## Test plan

- [x] `bun test` — 972 pass, 0 fail (32 snapshots)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Manual smoke: `bun src/cli.ts --version`, `bun src/cli.ts list --json` against a fixture project
- [x] `bun src/cli.ts registry add --repo github.com/foo/bar` (new alias works)
- [x] `bun src/cli.ts registry add --help` (cross-refs visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)