### PR TITLE
fix(init): resolve .gitignore entries through agent registry

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,7 +8,7 @@ import {
 	GLOBAL_MANIFEST,
 	MANIFEST_NEW,
 } from "../core/filenames.js";
-import { addGitignoreEntries, getSkillAgentIgnoreEntries } from "../core/gitignore.js";
+import { addGitignoreEntries, getSkillAgentIgnoreEntriesForTarget } from "../core/gitignore.js";
 import { serializeManifest, writeGlobalManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { type LocalEntry, scanLocalRepo } from "../core/repo-scanner.js";
@@ -84,11 +84,13 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 	await writeFile(manifestPath, serializeManifest(manifest), "utf-8");
 	success(`Created ${MANIFEST_NEW}`);
 
-	// Update .gitignore for all targets
+	// Update .gitignore for all targets. Resolve through the agent registry
+	// (`getSkillAgentIgnoreEntriesForTarget`) so codex/copilot — whose install
+	// dirs (`.agents`, `.github`) differ from `.${name}` — get the right
+	// entries. Regression guard for #32.
 	const ignoreEntries: string[] = [];
 	for (const target of installTargets) {
-		const resolvedDir = target.startsWith(".") || target.startsWith("/") ? target : `.${target}`;
-		ignoreEntries.push(...getSkillAgentIgnoreEntries(resolvedDir));
+		ignoreEntries.push(...getSkillAgentIgnoreEntriesForTarget(target));
 	}
 	// Deduplicate
 	const uniqueEntries = [...new Set(ignoreEntries)];

--- a/src/core/gitignore.ts
+++ b/src/core/gitignore.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { resolveTarget } from "./agents.js";
 
 /**
  * Add entries to .gitignore (deduplication: skips entries that already exist).
@@ -65,4 +66,17 @@ export async function removeGitignoreEntries(dir: string, entries: string[]): Pr
 export function getSkillAgentIgnoreEntries(installPath: string): string[] {
 	const base = installPath.replace(/\/$/, "");
 	return [`${base}/skills/`, `${base}/agents/`, `${base}/commands/`];
+}
+
+/**
+ * Get the gitignore entries for an install target (agent name or literal path).
+ *
+ * Resolves the target through the agent registry — the same helper the
+ * installer uses — so gitignore can never drift from the actual install
+ * directory. For agents whose registered `dir` differs from `.${name}`
+ * (e.g., codex → .agents, copilot → .github), this is the only correct
+ * way to compute gitignore entries. Regression guard for #32.
+ */
+export function getSkillAgentIgnoreEntriesForTarget(target: string): string[] {
+	return getSkillAgentIgnoreEntries(resolveTarget(target));
 }

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -44,6 +44,40 @@ describe("initCommand", () => {
 		expect(content).toContain(".claude/agents/");
 	});
 
+	test("codex target writes .agents/ entries (not .codex/)", async () => {
+		// Regression for #32: init was string-prefixing a dot to the target name
+		// (".codex"), but the codex install dir is actually ".agents". The
+		// resulting .gitignore protected the wrong directory and let installed
+		// artifacts leak into git.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "home");
+		await mkdir(join(fakeHome, ".codex"), { recursive: true });
+
+		await initCommand(dir, { homeDir: fakeHome });
+
+		const content = await readFile(join(dir, ".gitignore"), "utf-8");
+		expect(content).toContain(".agents/skills/");
+		expect(content).toContain(".agents/agents/");
+		expect(content).toContain(".agents/commands/");
+		expect(content).not.toContain(".codex/skills/");
+	});
+
+	test("copilot target writes .github/ entries (not .copilot/)", async () => {
+		// Regression for #32: same root cause — copilot's install dir is
+		// ".github", but init was writing ".copilot/skills/" to gitignore.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "home");
+		await mkdir(join(fakeHome, ".copilot"), { recursive: true });
+
+		await initCommand(dir, { homeDir: fakeHome });
+
+		const content = await readFile(join(dir, ".gitignore"), "utf-8");
+		expect(content).toContain(".github/skills/");
+		expect(content).toContain(".github/agents/");
+		expect(content).toContain(".github/commands/");
+		expect(content).not.toContain(".copilot/skills/");
+	});
+
 	test("appends to existing .gitignore without duplicating entries", async () => {
 		const dir = await makeTempDir();
 		const fakeHome = join(dir, "empty-home");

--- a/tests/core/gitignore.test.ts
+++ b/tests/core/gitignore.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { AGENT_REGISTRY } from "../../src/core/agents.js";
+import {
+	getSkillAgentIgnoreEntries,
+	getSkillAgentIgnoreEntriesForTarget,
+} from "../../src/core/gitignore.js";
+
+describe("getSkillAgentIgnoreEntries", () => {
+	test("strips trailing slash and emits skills/agents/commands entries", () => {
+		expect(getSkillAgentIgnoreEntries(".claude")).toEqual([
+			".claude/skills/",
+			".claude/agents/",
+			".claude/commands/",
+		]);
+		expect(getSkillAgentIgnoreEntries(".claude/")).toEqual([
+			".claude/skills/",
+			".claude/agents/",
+			".claude/commands/",
+		]);
+	});
+});
+
+describe("getSkillAgentIgnoreEntriesForTarget", () => {
+	test("codex resolves through the agent registry to .agents/, not .codex/", () => {
+		// Regression for #32: init.ts was synthesizing `.${target}` instead of
+		// looking up the registry, so codex (dir: ".agents") got the wrong
+		// gitignore entries written.
+		const entries = getSkillAgentIgnoreEntriesForTarget("codex");
+		expect(entries).toEqual([".agents/skills/", ".agents/agents/", ".agents/commands/"]);
+		expect(entries.some((e) => e.startsWith(".codex/"))).toBe(false);
+	});
+
+	test("copilot resolves through the agent registry to .github/, not .copilot/", () => {
+		// Regression for #32: same root cause as the codex case — copilot's
+		// registered dir is ".github".
+		const entries = getSkillAgentIgnoreEntriesForTarget("copilot");
+		expect(entries).toEqual([".github/skills/", ".github/agents/", ".github/commands/"]);
+		expect(entries.some((e) => e.startsWith(".copilot/"))).toBe(false);
+	});
+
+	test("agents whose dir matches dot-name are unaffected", () => {
+		expect(getSkillAgentIgnoreEntriesForTarget("claude")).toEqual([
+			".claude/skills/",
+			".claude/agents/",
+			".claude/commands/",
+		]);
+		expect(getSkillAgentIgnoreEntriesForTarget("cursor")[0]).toBe(".cursor/skills/");
+		expect(getSkillAgentIgnoreEntriesForTarget("gemini")[0]).toBe(".gemini/skills/");
+		expect(getSkillAgentIgnoreEntriesForTarget("windsurf")[0]).toBe(".windsurf/skills/");
+	});
+
+	test("literal path target is honored (passes through resolveTarget)", () => {
+		expect(getSkillAgentIgnoreEntriesForTarget("./my-agent")).toEqual([
+			"./my-agent/skills/",
+			"./my-agent/agents/",
+			"./my-agent/commands/",
+		]);
+	});
+
+	test("every registered agent: gitignore entries share a prefix with the install dir", () => {
+		// Lock the gitignore-to-install-dir invariant for every entry in the
+		// registry. If a future agent is added with `dir !== `.${name}``, this
+		// test prevents the same class of bug from re-appearing.
+		for (const [name, entry] of Object.entries(AGENT_REGISTRY)) {
+			const ignoreEntries = getSkillAgentIgnoreEntriesForTarget(name);
+			for (const ig of ignoreEntries) {
+				expect(ig.startsWith(`${entry.dir}/`)).toBe(true);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes #32.

`init` synthesized the gitignore directory for each install target as `` `.${target}` ``. For agents whose registered `dir` differs from that convention — `codex` → `.agents`, `copilot` → `.github` — the gitignore protected the wrong directory while the installer wrote files to the correct one. Result: installed artifacts un-ignored and at risk of being committed.

The agent registry was already correct (and matches what OpenAI Codex and GitHub Copilot CLI document upstream — see issue #32 for the citations). Only the gitignore writer was drifting.

## Fix

Add `getSkillAgentIgnoreEntriesForTarget(target)` in `src/core/gitignore.ts` that resolves through `resolveTarget` — the same helper the installer uses — and route `init` through it. Two paths, one source of truth.

```ts
// before:
const resolvedDir = target.startsWith(".") || target.startsWith("/") ? target : `.${target}`;
ignoreEntries.push(...getSkillAgentIgnoreEntries(resolvedDir));

// after:
ignoreEntries.push(...getSkillAgentIgnoreEntriesForTarget(target));
```

## Tests

- `tests/core/gitignore.test.ts` (new):
  - codex resolves to `.agents/skills/`, not `.codex/...`
  - copilot resolves to `.github/skills/`, not `.copilot/...`
  - claude/cursor/gemini/windsurf unaffected
  - literal-path target is honored
  - **parametrized registry-coverage test**: asserts every `AGENT_REGISTRY` entry produces ignore entries that begin with its declared `dir`. This locks the invariant so any future agent with a non-matching `dir` will fail at test time, not in user repos.
- `tests/commands/init.test.ts` extended with codex/copilot integration assertions over the actual `.gitignore` written by `initCommand`.

Test plan run on this branch:

- [x] `bun test` — 1017 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — clean
- [x] Manual repro from #32 (init → install → check gitignore vs actual install dirs) now produces a gitignore that covers every install target

🤖 Generated with [Claude Code](https://claude.com/claude-code)