### PR TITLE
fix(scan): detect XML and call-form Skill references

### DIFF
--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -26,6 +26,15 @@ const PATTERNS = [
 	// or a quoting/bracketing character — not a word/identifier character or another
 	// `/`. Lookahead `(?!/)` blocks multi-segment paths like /usr/local/share.
 	/(?<![/\w])\/([a-z][a-z0-9-]+)\b(?!\/)/g,
+	// XML-style Skill tag: <Skill name="foo"/>, <Skill name="foo"></Skill>,
+	// <Skill name='foo'>, and attribute-order-tolerant forms like
+	// <Skill type="skill" name="foo" version="1.0" />. Anchored on the literal
+	// tag name `Skill` so unrelated tags with a `name=` attribute don't match.
+	// Issue #34.
+	/<Skill\s+[^>]*?\bname=["']([a-z0-9][a-z0-9-]*)["'][^>]*?>/gi,
+	// Call-form invocation: Skill(name="foo") / Skill( name = 'foo' ).
+	// Issue #34.
+	/\bSkill\s*\(\s*name\s*=\s*["']([a-z0-9][a-z0-9-]*)["']\s*\)/g,
 ];
 
 /**

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -131,6 +131,29 @@ describe("scanCommand", () => {
 		}
 	});
 
+	test("--check exits 1 when only XML-form Skill references are present (issue #34)", async () => {
+		// Regression for #34: `<Skill name="..."/>` content used to slip past
+		// the regex scanner, giving false-confidence green from --check.
+		const dir = await makeTempDir();
+		await createSkill(dir, "my-skill", [], 'See <Skill name="docker-dev"/> for setup.');
+
+		let exitCode: number | undefined;
+		const originalExit = process.exit;
+		process.exit = ((code: number) => {
+			exitCode = code;
+			throw new Error(`exit ${code}`);
+		}) as typeof process.exit;
+
+		try {
+			await scanCommand([join(dir, "my-skill")], { check: true });
+		} catch {
+			// Expected — our mock throws to stop execution
+		} finally {
+			process.exit = originalExit;
+		}
+		expect(exitCode).toBe(1);
+	});
+
 	test("--apply updates frontmatter with undeclared deps", async () => {
 		const dir = await makeTempDir();
 		const skillDir = await createSkill(dir, "my-skill", [], "Use the `testing` skill.");

--- a/tests/core/scanner.test.ts
+++ b/tests/core/scanner.test.ts
@@ -276,6 +276,95 @@ describe("scanFile", () => {
 	});
 });
 
+describe("scanFile — XML / call-form Skill references (issue #34)", () => {
+	test('detects XML self-closing form: <Skill name="foo"/>', async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(
+			dir,
+			"my-skill",
+			'For containers, see <Skill name="docker-dev"/>.',
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("docker-dev");
+		expect(result?.undeclared).toContain("docker-dev");
+	});
+
+	test('detects XML open/close form: <Skill name="foo"></Skill>', async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(
+			dir,
+			"my-skill",
+			'See <Skill name="docker-dev"></Skill> for details.',
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("docker-dev");
+	});
+
+	test("detects single-quoted XML form: <Skill name='foo'/>", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(dir, "my-skill", "See <Skill name='docker-dev'/> for setup.");
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("docker-dev");
+	});
+
+	test("detects XML form with extra attributes (attribute order tolerant)", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(
+			dir,
+			"my-skill",
+			'See <Skill type="skill" name="docker-dev" version="1.0" /> for setup.',
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("docker-dev");
+	});
+
+	test('detects call form: Skill(name="foo")', async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(
+			dir,
+			"my-skill",
+			'Invoke via Skill(name="docker-dev") to bootstrap.',
+		);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("docker-dev");
+	});
+
+	test("does not match unrelated XML tags with name= attribute", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(
+			dir,
+			"my-skill",
+			'A <Section name="docker-dev"/> in the doc, <Component name="other-thing"/>.',
+		);
+
+		const result = await scanFile(filePath);
+		// Only `<Skill name=...>` should be picked up — unrelated tags must not
+		// match. (The other regex patterns may still match natural-language
+		// references in the same doc; this test isolates the XML pattern by
+		// using nothing else suggestive.)
+		expect(result?.detected).not.toContain("docker-dev");
+		expect(result?.detected).not.toContain("other-thing");
+	});
+
+	test("respects declared deps with XML-only references", async () => {
+		// Regression for #34: with the new XML pattern, declared deps must still
+		// be honored (no false-positive undeclared on a properly declared XML ref).
+		const dir = await makeTempDir();
+		const filePath = await writeSkill(dir, "my-skill", 'See <Skill name="docker-dev"/>.', [
+			"docker-dev",
+		]);
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("docker-dev");
+		expect(result?.undeclared).not.toContain("docker-dev");
+	});
+});
+
 describe("scanFile — slash-command references", () => {
 	async function writeCommand(
 		dir: string,


### PR DESCRIPTION
## Summary

Closes #34.

The regex scanner covered natural-language patterns ("Use the X skill", "**LOAD** \`X\` skill", slash commands) but missed two forms that appear in real SKILL.md content:

1. **XML-style:** `<Skill name="docker-dev"/>`, `<Skill name='docker-dev'></Skill>`, and attribute-order-tolerant variants like `<Skill type="skill" name="docker-dev" />`.
2. **Call-form:** `Skill(name="docker-dev")` — Anthropic's tool-call DSL.

A SKILL.md using only these forms slipped past `scan --check` with a clean bill, leaving the transitive dep undeclared.

## Fix

Add two patterns to `PATTERNS` in `src/core/scanner.ts`:

```ts
/<Skill\s+[^>]*?\bname=["']([a-z0-9][a-z0-9-]*)["'][^>]*?>/gi
/\bSkill\s*\(\s*name\s*=\s*["']([a-z0-9][a-z0-9-]*)["']\s*\)/g
```

Both anchor on the literal `Skill` tag/identifier so unrelated XML tags (`<Section name="foo"/>`) and unrelated call-style references don't match. Existing self-reference, length, and stopword filters apply automatically (the regex output flows through the same dedupe + filter step as every other pattern).

## Tests

7 new unit tests in `tests/core/scanner.test.ts`:

| Form | Test |
|---|---|
| `<Skill name="foo"/>` | self-closing |
| `<Skill name="foo"></Skill>` | open/close |
| `<Skill name='foo'/>` | single-quoted |
| `<Skill type="skill" name="foo" version="1.0" />` | attribute-order-tolerant |
| `Skill(name="foo")` | call-form |
| `<Section name="docker-dev"/>` | negative — unrelated tag does NOT match |
| Declared XML ref | `undeclared` correctly empty |

Plus an integration test in `tests/commands/scan.test.ts`: a SKILL.md with only an XML-form ref makes `scan --check` exit 1 (was exit 0 before — the false-confidence green from the bug report).

Test plan run on this branch:

- [x] `bun test` — 1017 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — clean

## Out of scope

The `@mention` form (`@docker-dev` in prose) is intentionally **not** added in this PR — the bug report flagged it as a likely false-positive source ("the @example user", "@deprecated", etc.). That's better suited to LLM-mode (`scan --llm`) where context disambiguates. Happy to follow up if there's appetite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)