### PR TITLE
fix(targets): keep .gitignore in sync on add/remove/detect

### DIFF
--- a/src/commands/targets.ts
+++ b/src/commands/targets.ts
@@ -4,6 +4,11 @@ import {
 	pathToAgentName,
 	resolveTarget,
 } from "../core/agents.js";
+import {
+	addGitignoreEntries,
+	getSkillAgentIgnoreEntriesForTarget,
+	removeGitignoreEntries,
+} from "../core/gitignore.js";
 import { loadManifestOrThrow, writeManifest } from "../core/manifest.js";
 import { success, warn } from "../core/ui.js";
 import type { Manifest } from "../types.js";
@@ -116,7 +121,16 @@ export async function targetsAddCommand(
 
 	targets.push(target);
 	await writeManifest(dir, manifest);
+
+	// Keep .gitignore in sync — installer writes to the new target's dir, so
+	// it must be ignored. Fixes #33: previously only `init` touched gitignore,
+	// leaving anything added later un-ignored. `addGitignoreEntries` is a no-op
+	// for entries that already exist, so re-adding is safe.
+	const added = await addGitignoreEntries(dir, getSkillAgentIgnoreEntriesForTarget(target));
 	success(`Added ${target} to install_targets.`);
+	if (added.length > 0) {
+		success(`Updated .gitignore (added ${added.join(", ")})`);
+	}
 }
 
 export async function targetsRemoveCommand(
@@ -140,7 +154,23 @@ export async function targetsRemoveCommand(
 
 	targets.splice(idx, 1);
 	await writeManifest(dir, manifest);
+
+	// Keep .gitignore in sync — but only remove entries that no remaining
+	// target still needs. Two targets can resolve to the same install dir
+	// (e.g., a literal path that aliases a known agent), so we compute the
+	// set still in use and subtract. Fixes #33.
+	const stillNeeded = new Set<string>();
+	for (const remaining of targets) {
+		for (const entry of getSkillAgentIgnoreEntriesForTarget(remaining)) {
+			stillNeeded.add(entry);
+		}
+	}
+	const candidates = getSkillAgentIgnoreEntriesForTarget(target).filter((e) => !stillNeeded.has(e));
+	const removed = await removeGitignoreEntries(dir, candidates);
 	success(`Removed ${target} from install_targets.`);
+	if (removed.length > 0) {
+		success(`Updated .gitignore (removed ${removed.join(", ")})`);
+	}
 }
 
 export async function targetsDetectCommand(dir: string, opts?: TargetsOpts): Promise<void> {
@@ -149,18 +179,24 @@ export async function targetsDetectCommand(dir: string, opts?: TargetsOpts): Pro
 
 	const detected = await detectInstalledAgents(opts?.homeDir);
 	const targets = ensureInstallTargets(manifest);
-	let added = 0;
+	const newlyAdded: string[] = [];
 
 	for (const agent of detected) {
 		if (!targets.includes(agent)) {
 			targets.push(agent);
-			added++;
+			newlyAdded.push(agent);
 		}
 	}
 
-	if (added > 0) {
+	if (newlyAdded.length > 0) {
 		await writeManifest(dir, manifest);
-		success(`Added ${added} agent(s) to install_targets.`);
+		// Same #33 fix: keep .gitignore in sync for every newly added agent.
+		const ignoreEntries = newlyAdded.flatMap((t) => getSkillAgentIgnoreEntriesForTarget(t));
+		const addedToIgnore = await addGitignoreEntries(dir, ignoreEntries);
+		success(`Added ${newlyAdded.length} agent(s) to install_targets.`);
+		if (addedToIgnore.length > 0) {
+			success(`Updated .gitignore (added ${addedToIgnore.join(", ")})`);
+		}
 	} else {
 		console.log("All detected agents already in install_targets.");
 	}

--- a/tests/commands/targets.test.ts
+++ b/tests/commands/targets.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -302,5 +302,171 @@ describe("targetsMigrateCommand", () => {
 		// Manifest unchanged
 		const manifest = await readManifest(dir);
 		expect(manifest.install_targets).toEqual(["claude"]);
+	});
+});
+
+describe("targets ↔ .gitignore sync (issue #33)", () => {
+	async function readGitignore(dir: string): Promise<string> {
+		return readFile(join(dir, ".gitignore"), "utf-8");
+	}
+
+	async function gitignoreExists(dir: string): Promise<boolean> {
+		try {
+			await stat(join(dir, ".gitignore"));
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	describe("targetsAddCommand", () => {
+		test("adds the new target's entries to .gitignore (codex → .agents/)", async () => {
+			// Regression: targets add was disconnected from gitignore, so files
+			// installed under the new target's dir got committed.
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+			await writeFile(
+				join(dir, ".gitignore"),
+				".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+			);
+
+			await targetsAddCommand("codex", dir);
+
+			const content = await readGitignore(dir);
+			expect(content).toContain(".agents/skills/");
+			expect(content).toContain(".agents/agents/");
+			expect(content).toContain(".agents/commands/");
+		});
+
+		test("adds a literal-path target's entries to .gitignore", async () => {
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+			await writeFile(join(dir, ".gitignore"), ".claude/skills/\n");
+
+			await targetsAddCommand("./custom", dir);
+
+			const content = await readGitignore(dir);
+			expect(content).toContain("./custom/skills/");
+			expect(content).toContain("./custom/agents/");
+			expect(content).toContain("./custom/commands/");
+		});
+
+		test("creates .gitignore if absent", async () => {
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+			expect(await gitignoreExists(dir)).toBe(false);
+
+			await targetsAddCommand("codex", dir);
+
+			expect(await gitignoreExists(dir)).toBe(true);
+			const content = await readGitignore(dir);
+			expect(content).toContain(".agents/skills/");
+		});
+
+		test("idempotent: re-adding a target after remove does not duplicate gitignore lines", async () => {
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+			await writeFile(
+				join(dir, ".gitignore"),
+				".claude/skills/\n.claude/agents/\n.claude/commands/\n.agents/skills/\n.agents/agents/\n.agents/commands/\n",
+			);
+
+			await targetsRemoveCommand("codex", dir);
+			await targetsAddCommand("codex", dir);
+
+			const content = await readGitignore(dir);
+			const matches = content.match(/^\.agents\/skills\/$/gm);
+			expect(matches?.length).toBe(1);
+		});
+	});
+
+	describe("targetsRemoveCommand", () => {
+		test("removes the target's entries from .gitignore", async () => {
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+			await writeFile(
+				join(dir, ".gitignore"),
+				".claude/skills/\n.claude/agents/\n.claude/commands/\n.agents/skills/\n.agents/agents/\n.agents/commands/\n",
+			);
+
+			await targetsRemoveCommand("codex", dir);
+
+			const content = await readGitignore(dir);
+			expect(content).not.toContain(".agents/skills/");
+			expect(content).not.toContain(".agents/agents/");
+			expect(content).not.toContain(".agents/commands/");
+			// claude entries preserved
+			expect(content).toContain(".claude/skills/");
+		});
+
+		test("preserves entries still owned by another remaining target", async () => {
+			// If a literal path target happens to point at the same dir as a
+			// known agent (e.g., user added `./.claude` plus `claude`), removing
+			// one must NOT yank the entry the other still needs.
+			const dir = await makeTempDir();
+			await writeManifestFile(
+				dir,
+				"install_targets:\n  - claude\n  - ./.claude\ndependencies: {}\n",
+			);
+			await writeFile(
+				join(dir, ".gitignore"),
+				".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+			);
+
+			await targetsRemoveCommand("./.claude", dir);
+
+			const content = await readGitignore(dir);
+			// Still owned by `claude`
+			expect(content).toContain(".claude/skills/");
+		});
+
+		test("does not create .gitignore if absent (no-op when the file isn't there)", async () => {
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+			// No .gitignore file exists
+			expect(await gitignoreExists(dir)).toBe(false);
+
+			await targetsRemoveCommand("codex", dir);
+
+			expect(await gitignoreExists(dir)).toBe(false);
+		});
+
+		test("no-op for gitignore when target's entries aren't present", async () => {
+			// User hand-edited .gitignore and removed the codex entries already.
+			// Removing codex from manifest must not error or scramble the file.
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+			const initial = ".claude/skills/\n.claude/agents/\n.claude/commands/\n";
+			await writeFile(join(dir, ".gitignore"), initial);
+
+			await targetsRemoveCommand("codex", dir);
+
+			const content = await readGitignore(dir);
+			expect(content).toBe(initial);
+		});
+	});
+
+	describe("targetsDetectCommand", () => {
+		test("adds gitignore entries for newly detected agents", async () => {
+			// Same root cause as add/remove: detect was mutating install_targets
+			// without ever touching .gitignore.
+			const dir = await makeTempDir();
+			await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+			await writeFile(
+				join(dir, ".gitignore"),
+				".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+			);
+
+			const fakeHome = join(dir, "fake-home");
+			await mkdir(join(fakeHome, ".claude"), { recursive: true });
+			await mkdir(join(fakeHome, ".codex"), { recursive: true });
+
+			await targetsDetectCommand(dir, { homeDir: fakeHome });
+
+			const content = await readGitignore(dir);
+			expect(content).toContain(".agents/skills/");
+			expect(content).toContain(".agents/agents/");
+			expect(content).toContain(".agents/commands/");
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Closes #33.

> Reopened from #36 — the original PR closed automatically when its base branch (#35's branch) was deleted as part of #35 merging to main. Rebased onto main; same commit content, no conflicts.

`skilltree targets add` / `remove` / `detect` mutate `install_targets` but never touch `.gitignore`. So:

- `targets add foo` → installer writes to foo's dir, but no gitignore entry. Files get committed.
- `targets remove foo` → entries linger as orphans.
- `targets detect` → same gap as `add`, just for auto-detection.

This PR makes all three keep `.gitignore` in sync, using the `getSkillAgentIgnoreEntriesForTarget` helper that landed in main via #35.

## Fix

- `add` calls `addGitignoreEntries` with the new target's entries.
- `detect` does the same for every newly added agent.
- `remove` calls `removeGitignoreEntries` only for entries no remaining target still owns (so two targets pointing at the same dir don't yank each other's lines).

## Tests

9 new assertions in `tests/commands/targets.test.ts` covering `add` (codex → `.agents/`, custom path, gitignore-creation, idempotency on re-add) / `remove` (entry removal, shared-dir preservation, no-create-on-absent, no-op when entries already absent) / `detect` (gitignore entries for newly detected agents).

Test plan run on this branch (rebased onto main):

- [x] `bun test` — 1026 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)