### PR TITLE
ci(publish): retry verify step on npm propagation race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,9 +56,20 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify published packages
+        # Retry with backoff: npm registry CDN propagation can take 30–90s.
+        # A fixed 10s sleep raced propagation and produced spurious E404
+        # failures on otherwise-successful releases (see #39).
+        # Six attempts × 15s = ~90s cap, with per-attempt log so a reader
+        # can see the step is waiting, not stuck.
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          echo "Waiting for npm to propagate..."
-          sleep 10
-          npm view skilltree-pm@${VERSION} version
-          echo "Successfully verified skilltree-pm@${VERSION} on npm"
+          for i in 1 2 3 4 5 6; do
+            if npm view "skilltree-pm@${VERSION}" version 2>/dev/null; then
+              echo "✔ Verified skilltree-pm@${VERSION} on npm (attempt ${i})"
+              exit 0
+            fi
+            echo "Not visible yet (attempt ${i}/6) — waiting 15s..."
+            sleep 15
+          done
+          echo "::error::skilltree-pm@${VERSION} not visible on npm after ~90s"
+          exit 1


### PR DESCRIPTION
## Summary

Closes #39.

`Verify published packages` slept 10 seconds before calling `npm view`, racing npm registry CDN propagation. When propagation took longer than 10s (which is common — npm CDN can take 30–90s) the step failed with E404 even though the publish itself succeeded. The Release run got marked red on a healthy release.

Recurring failures on this exact step (from `gh run list`):

| Tag | Run | Result |
|---|---|---|
| v0.24.4 | 25267121134 | Package on npm, verify E404 |
| v0.24.0 | 25264382714 | Same |
| v0.9.0  | 23968217069 | Same |
| v0.8.0  | 23967184999 | Same |

## Fix

Replace the fixed `sleep 10` with a 6-attempt × 15s retry loop (~90s cap):

```yaml
- name: Verify published packages
  run: |
    VERSION=$(node -p "require('./package.json').version")
    for i in 1 2 3 4 5 6; do
      if npm view "skilltree-pm@${VERSION}" version 2>/dev/null; then
        echo "✔ Verified skilltree-pm@${VERSION} on npm (attempt ${i})"
        exit 0
      fi
      echo "Not visible yet (attempt ${i}/6) — waiting 15s..."
      sleep 15
    done
    echo "::error::skilltree-pm@${VERSION} not visible on npm after ~90s"
    exit 1
```

- **Happy path unchanged**: when the package is visible immediately, attempt 1 succeeds and the step is no slower than before (in practice slightly faster — no upfront 10s sleep).
- **Slow-propagation path**: loop transparently waits with a per-attempt log so a reader can see the step is waiting, not stuck.
- **Real publish failure preserved**: if the package is still missing after ~90s, emit a proper `::error::` annotation and exit 1.

## Validation

I ran the loop locally with three scenarios (using a function-stubbed `npm view`):

| Scenario | Behavior |
|---|---|
| Package visible immediately | Exits 0 on attempt 1, single-line success log |
| Visible after 2 misses | 2 "not visible yet" lines, then exits 0 on attempt 3 |
| Never visible | 6 attempts, `::error::` annotation, exit 1 |

YAML parses cleanly (verified by extracting the embedded `run:` script via the `yaml` parser). Pre-commit hooks (`check-yaml`, `commitizen check`) all pass.

## Test plan after merge

- [ ] Next release should land green — confirm by checking the Release workflow's `Verify published packages` step shows "✔ Verified" on attempt 1.
- [ ] If a slow-propagation day happens, the step logs "Not visible yet" lines instead of failing on first miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)