### PR TITLE
fix(remove): clean files from all install_targets, not just the first

### DIFF
--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -10,7 +10,7 @@ import {
 	writeLockfile,
 } from "../core/lockfile.js";
 import {
-	getDevInstallPath,
+	getInstallTargets,
 	loadManifestOrThrow,
 	validateManifestOrThrow,
 	warnLegacyInstallPath,
@@ -66,12 +66,12 @@ export async function removeCommand(
 	}
 	success(`Removed ${name} from ${isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW}`);
 
-	const installBase = isGlobal ? getGlobalInstallBase() : join(dir, getDevInstallPath(manifest));
+	const installBases = resolveInstallBases(manifest, dir, isGlobal);
 
 	// Remove installed files + orphans
 	if (lockfile) {
-		await deleteEntityFiles(name, lockfile, installBase, options.keepFiles);
-		await cleanOrphans(lockfile, manifest, installBase, options.keepFiles);
+		await deleteEntityFiles(name, lockfile, installBases, options.keepFiles);
+		await cleanOrphans(lockfile, manifest, installBases, options.keepFiles);
 
 		if (isGlobal) {
 			await writeGlobalLockfile(lockfile, globalDir);
@@ -79,6 +79,21 @@ export async function removeCommand(
 			await writeLockfile(dir, lockfile);
 		}
 	}
+}
+
+/**
+ * All install base directories (absolute paths) configured by the manifest.
+ *
+ * `remove` must clean files from EVERY configured target, not just the first
+ * one — otherwise non-default targets (.agents/, .cursor/, .gemini/, ...) keep
+ * orphan copies of the removed dep.
+ */
+function resolveInstallBases(manifest: Manifest, dir: string, isGlobal: boolean): string[] {
+	if (isGlobal) {
+		const targets = getInstallTargets(manifest, { global: true });
+		return targets.length > 0 ? targets : [getGlobalInstallBase()];
+	}
+	return getInstallTargets(manifest).map((t) => join(dir, t));
 }
 
 async function previewRemove(
@@ -95,12 +110,16 @@ async function previewRemove(
 
 	if (!lockfile) return;
 
-	const installBase = isGlobal ? getGlobalInstallBase() : join(dir, getDevInstallPath(manifest));
+	// Mirror the live path: preview every configured install target so users
+	// see all the dirs that would be touched, not just `.claude/`.
+	const installBases = resolveInstallBases(manifest, dir, isGlobal);
 
 	const entry = lockfile.packages[name];
 	if (entry && !keepFiles) {
-		const targetPath = getTargetPath({ name, type: entry.type }, installBase);
-		console.log(dim(`Would remove installed files at ${targetPath}`));
+		for (const installBase of installBases) {
+			const targetPath = getTargetPath({ name, type: entry.type }, installBase);
+			console.log(dim(`Would remove installed files at ${targetPath}`));
+		}
 	}
 
 	// Pure call — no clone needed. `excludeName` lets findOrphans answer
@@ -112,8 +131,10 @@ async function previewRemove(
 		if (keepFiles) {
 			console.log(dim(`Would drop orphaned transitive dependency: ${orphan} (files kept)`));
 		} else {
-			const targetPath = getTargetPath({ name: orphan, type: orphanEntry.type }, installBase);
-			console.log(dim(`Would remove orphaned transitive dependency: ${orphan} (${targetPath})`));
+			for (const installBase of installBases) {
+				const targetPath = getTargetPath({ name: orphan, type: orphanEntry.type }, installBase);
+				console.log(dim(`Would remove orphaned transitive dependency: ${orphan} (${targetPath})`));
+			}
 		}
 	}
 }
@@ -179,7 +200,7 @@ function removeFromManifest(
 async function deleteEntityFiles(
 	name: string,
 	lockfile: Lockfile,
-	installBase: string,
+	installBases: string[],
 	keepFiles?: boolean,
 ): Promise<void> {
 	if (keepFiles) return;
@@ -187,12 +208,14 @@ async function deleteEntityFiles(
 	if (!entry) return;
 
 	delete lockfile.packages[name];
-	const targetPath = getTargetPath({ name, type: entry.type }, installBase);
-	try {
-		await rm(targetPath, { recursive: true });
-		console.log(dim(`Removed installed files at ${targetPath}`));
-	} catch {
-		// Already removed
+	for (const installBase of installBases) {
+		const targetPath = getTargetPath({ name, type: entry.type }, installBase);
+		try {
+			await rm(targetPath, { recursive: true });
+			console.log(dim(`Removed installed files at ${targetPath}`));
+		} catch {
+			// Already removed
+		}
 	}
 }
 
@@ -202,7 +225,7 @@ async function cleanOrphans(
 		dependencies?: Record<string, unknown>;
 		"dev-dependencies"?: Record<string, unknown>;
 	},
-	installBase: string,
+	installBases: string[],
 	keepFiles?: boolean,
 ): Promise<void> {
 	const orphans = findOrphans(lockfile, manifest);
@@ -210,11 +233,13 @@ async function cleanOrphans(
 		const entry = lockfile.packages[orphan];
 		delete lockfile.packages[orphan];
 		if (!keepFiles && entry) {
-			const targetPath = getTargetPath({ name: orphan, type: entry.type }, installBase);
-			try {
-				await rm(targetPath, { recursive: true });
-			} catch {
-				// Already removed
+			for (const installBase of installBases) {
+				const targetPath = getTargetPath({ name: orphan, type: entry.type }, installBase);
+				try {
+					await rm(targetPath, { recursive: true });
+				} catch {
+					// Already removed
+				}
 			}
 			console.log(dim(`Removed orphaned transitive dependency: ${orphan}`));
 		}

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -216,6 +216,96 @@ describe("removeCommand", () => {
 		expect(manifest.dependencies?.base).toBeDefined();
 	});
 
+	test("removes installed files from every install_targets directory", async () => {
+		// Regression: `remove` previously cleaned only the first/default install
+		// path, leaving orphan copies in other configured targets (e.g.
+		// .agents/, .cursor/, .gemini/) when install_targets had >1 entry.
+		const dir = await setup();
+		// Manually write a multi-target manifest (initCommand writes a fresh one)
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			[
+				"name: multi",
+				"install_targets:",
+				"  - claude",
+				"  - codex",
+				"  - cursor",
+				"  - gemini",
+				"dependencies:",
+				"  my-skill:",
+				"    repo: github.com/user/repo",
+				"    version: '*'",
+				"    path: skills/my-skill",
+				"dev-dependencies: {}",
+				"",
+			].join("\n"),
+		);
+
+		// Simulate `install` by placing files in every target directory
+		const targets = [".claude", ".agents", ".cursor", ".gemini"];
+		for (const t of targets) {
+			const installDir = join(dir, t, "skills", "my-skill");
+			await mkdir(installDir, { recursive: true });
+			await writeFile(join(installDir, "SKILL.md"), "# test\n");
+		}
+
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			"lockfile_version: 1\npackages:\n  my-skill:\n    type: skill\n    group: prod\n    repo: github.com/user/repo\n    path: skills/my-skill\n    version: 1.0.0\n    commit: abc\n    dependencies: []\n",
+		);
+
+		await removeCommand("my-skill", dir, { force: true });
+
+		// All four target directories should no longer contain the skill
+		for (const t of targets) {
+			await expect(stat(join(dir, t, "skills", "my-skill"))).rejects.toThrow();
+		}
+	});
+
+	test("orphan cleanup removes installed files of orphans across all targets", async () => {
+		// Regression: orphan cleanup must also iterate every install target.
+		const dir = await setup();
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			[
+				"name: multi-orphan",
+				"install_targets:",
+				"  - claude",
+				"  - codex",
+				"dependencies:",
+				"  parent:",
+				"    repo: github.com/user/repo",
+				"    version: '*'",
+				"    path: skills/parent",
+				"dev-dependencies: {}",
+				"",
+			].join("\n"),
+		);
+
+		// Simulate install of parent + transitive child in both targets
+		const targets = [".claude", ".agents"];
+		for (const t of targets) {
+			for (const name of ["parent", "child"]) {
+				const installDir = join(dir, t, "skills", name);
+				await mkdir(installDir, { recursive: true });
+				await writeFile(join(installDir, "SKILL.md"), `# ${name}\n`);
+			}
+		}
+
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			"lockfile_version: 1\npackages:\n  parent:\n    type: skill\n    group: prod\n    repo: github.com/user/repo\n    path: skills/parent\n    version: 1.0.0\n    commit: abc\n    dependencies:\n      - child\n  child:\n    type: skill\n    group: prod\n    repo: github.com/user/repo\n    path: skills/child\n    version: 1.0.0\n    commit: abc\n    dependencies: []\n",
+		);
+
+		await removeCommand("parent", dir, { force: true });
+
+		// Both parent and orphan child files should be gone in every target
+		for (const t of targets) {
+			await expect(stat(join(dir, t, "skills", "parent"))).rejects.toThrow();
+			await expect(stat(join(dir, t, "skills", "child"))).rejects.toThrow();
+		}
+	});
+
 	test("orphan cleanup removes installed files of orphans", async () => {
 		const dir = await setup();
 		await addCommand("parent", { repo: "github.com/user/repo", path: "skills/parent" }, dir);


### PR DESCRIPTION
## Summary

- `skilltree remove <name>` only cleaned `.claude/` when a project declared multiple `install_targets`, leaving orphan copies in `.agents/`, `.cursor/`, `.gemini/`, etc. A subsequent `skilltree install` did not clean them up either.
- Root cause: `removeCommand` resolved a single install base via the deprecated `getDevInstallPath(manifest)` instead of iterating `getInstallTargets(manifest)` like `install` already does.
- Fix: new `resolveInstallBases(manifest, dir, isGlobal)` helper returns every configured base; `deleteEntityFiles` and `cleanOrphans` now loop over all of them. Lockfile mutation still happens once.

## Reproduction (before fix)

```
$ skilltree init                       # detects claude, codex, cursor, gemini
$ skilltree add pdf  --repo https://github.com/anthropics/skills --path skills/pdf
$ skilltree add docx --repo https://github.com/anthropics/skills --path skills/docx
$ skilltree install
$ skilltree remove docx
✔ Removed docx from skilltree.yml
Removed installed files at .../.claude/skills/docx
$ ls .agents/skills .cursor/skills .gemini/skills
docx  pdf       # ← orphans
docx  pdf
docx  pdf
```

## After fix

```
$ skilltree remove docx
✔ Removed docx from skilltree.yml
Removed installed files at .../.claude/skills/docx
Removed installed files at .../.agents/skills/docx
Removed installed files at .../.cursor/skills/docx
Removed installed files at .../.gemini/skills/docx
```

## Test plan

- [x] Two regression tests added in `tests/commands/remove.test.ts`:
  - `removes installed files from every install_targets directory` (primary dep)
  - `orphan cleanup removes installed files of orphans across all targets` (transitive)
- [x] Both fail on `main` (`Expected promise that rejects, Received: resolved`) and pass with the fix.
- [x] Full suite green: `bun test` → 887/887 pass.
- [x] `make check` (lint + format + typecheck + tests) green.
- [x] End-to-end repro on a fresh `/tmp` project with the rebuilt binary confirms cleanup across all four target dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)