### PR TITLE
fix(graph): allow skill → command and skill → agent dependencies

### DIFF
--- a/docs/specs/decisions.md
+++ b/docs/specs/decisions.md
@@ -27,12 +27,12 @@ YAML keys must be unique, but a skill and agent can share a name (e.g., `workflo
 
 - No filesystem collision: skills install to `skills/`, agents to `agents/`, commands to `commands/`
 - Frontmatter `dependencies` use actual names, not aliases
-- Disambiguation in frontmatter: `dependencies: [workflow-builder]` **always resolves to the skill** when both skill and agent share the name. Skills can only depend on skills (type constraint forces it). Agents default to skill (common pattern).
+- Disambiguation in frontmatter: `dependencies: [workflow-builder]` **always resolves to the skill** when both skill and agent share the name. The probe order in same-origin/same-repo lookup checks `skills/` first, then `agents/`, then `commands/`, so the skill wins.
 - **Known limitation:** There is no frontmatter syntax to target a same-name agent. If an agent needs to depend on another agent that shares a name with a skill, the agent must be renamed to have a unique name. This is an acceptable constraint -- the collision is rare (1 in 42 entities in the real codebase), and renaming is a one-time fix.
 - Resolution context registers entities under actual name + type
 
 **Test scenarios that must pass:**
-- Skill depending on `workflow-builder` resolves to the skill (type constraint)
+- Skill depending on `workflow-builder` resolves to the skill (probe order: `skills/` checked before `agents/`)
 - Agent depending on `workflow-builder` resolves to the skill (precedence rule)
 - Agent depending on a dep that only the agent (not the skill) provides still works correctly
 - `deps tree` shows both entities correctly with their types

--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -348,15 +348,6 @@ Fix: Remove one of these dependency edges in the skill frontmatter.
 ```
 
 ```
-Error: Invalid dependency type
-
-  skill:api-development cannot depend on agent:backend-developer.
-  Skills can only depend on other skills.
-
-Fix: Remove backend-developer from api-development's dependencies.
-```
-
-```
 Error: Duplicate entity resolution
 
   Both "workflow-builder" and "another-skill" resolve to skill:workflow-builder.

--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -157,11 +157,17 @@ install location.
 | Agent | Single `.md` file with YAML frontmatter | `.claude/agents/{name}.md` |
 | Command | Single `.md` file with YAML frontmatter (Claude Code slash commands) | `.claude/commands/{name}.md` |
 
-**Type constraint:** Skills can only depend on skills. Agents can depend
-on skills (and other agents). Commands can depend on skills (same
-relaxation as agents). Agents and commands have the same on-disk shape
-(single `.md`); the difference is install location and how Claude Code
-loads them — slash commands are user-invoked via `/<name>`.
+**Cross-type dependencies:** Any entity may depend on any other entity.
+Skills, agents, and commands install to disjoint trees (`skills/`,
+`agents/`, `commands/`), so there is no filesystem-collision concern.
+Cycles are detected by topological sort and rejected separately.
+Slash commands are reusable workflows, so a skill that prescribes a
+workflow can legitimately declare the command(s) it invokes —
+e.g. `development-methodology` referencing `/code-refinement-with-hypothesis`.
+
+Agents and commands have the same on-disk shape (single `.md`); the
+difference is install location and how Claude Code loads them — slash
+commands are user-invoked via `/<name>`.
 
 ### Dependencies: Remote vs Local
 
@@ -292,7 +298,7 @@ workflow-builder-agent:         # YAML key = alias
 
 No filesystem collision (skills, agents, and commands install to different directories).
 
-**Frontmatter disambiguation:** When `dependencies: [workflow-builder]` appears in frontmatter and both a skill and agent match, **skill always takes precedence** (skills depending on skills is the only option; agents depending on skills is the common pattern). There is no frontmatter syntax to target a same-name agent -- this is a known limitation. If an agent needs to depend on another agent that shares a name with a skill, the agent must be renamed to have a unique name. See [decisions.md](decisions.md) #7 for full rules and test scenarios.
+**Frontmatter disambiguation:** When `dependencies: [workflow-builder]` appears in frontmatter and both a skill and agent match, **skill always takes precedence**. The probe order in same-origin/same-repo lookup checks `skills/` first, then `agents/`, then `commands/`, so a same-named skill always wins. There is no frontmatter syntax to target a same-name agent -- this is a known limitation. If an agent needs to depend on another agent that shares a name with a skill, the agent must be renamed to have a unique name. See [decisions.md](decisions.md) #7 for full rules and test scenarios.
 
 ## Commands
 
@@ -481,7 +487,7 @@ Plugins coexist without conflict (different namespaces, different storage). For 
 - Git operations with bare repo caching
 - Tag listing, semver resolution, constraint intersection
 - Dependency graph with composite keys + growing resolution context
-- Topological sort (Kahn's), cycle detection, chain health, type constraints
+- Topological sort (Kahn's), cycle detection, chain health
 - `skilltree.lock` generation
 
 ### Phase 3: Installation

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -95,7 +95,6 @@ export async function resolveAll(
 	await checkStaleTagManifests(state);
 	await processDeps(expanded.dependencies, "prod", state);
 	await processDeps(expanded["dev-dependencies"], "dev", state);
-	validateTypeConstraints(state);
 
 	const installOrder = topologicalSort(state.entities, state.resolutionContext, state.errors);
 
@@ -309,7 +308,7 @@ async function resolveLocalEntity(
 	registerEntity(entity, state);
 
 	for (const transDepName of frontmatterDeps) {
-		await resolveTransitive(transDepName, type, group, compositeKey, state);
+		await resolveTransitive(transDepName, group, compositeKey, state);
 	}
 }
 
@@ -413,18 +412,17 @@ async function resolveRemoteEntity(
 	registerEntity(entity, state);
 
 	for (const transDepName of frontmatterDeps) {
-		await resolveTransitive(transDepName, type, group, compositeKey, state);
+		await resolveTransitive(transDepName, group, compositeKey, state);
 	}
 }
 
 async function resolveTransitive(
 	depName: string,
-	parentType: EntityType,
 	parentGroup: DependencyGroup,
 	parentCompositeKey: string,
 	state: ResolutionState,
 ): Promise<void> {
-	if (checkExistingResolution(depName, parentType, parentGroup, parentCompositeKey, state)) return;
+	if (useExistingResolution(depName, parentGroup, state)) return;
 	if (await tryResolveFromManifest(depName, parentGroup, state)) return;
 	if (await tryResolveFromLocalSource(depName, parentGroup, parentCompositeKey, state)) return;
 	if (await tryResolveFromOriginManifest(depName, parentGroup, parentCompositeKey, state)) return;
@@ -432,27 +430,22 @@ async function resolveTransitive(
 	addUnresolvedError(depName, parentCompositeKey, state);
 }
 
-function checkExistingResolution(
+/**
+ * If `depName` is already resolved, promote it from `dev` to `prod` when the
+ * current parent reaches it through `prod`, and signal "skip further
+ * resolution" via `true`. Decision #11 (group assignment) — a transitive dep
+ * reachable from both groups is `prod`.
+ */
+function useExistingResolution(
 	depName: string,
-	parentType: EntityType,
 	parentGroup: DependencyGroup,
-	parentCompositeKey: string,
 	state: ResolutionState,
 ): boolean {
 	if (!state.resolutionContext.has(depName)) return false;
-
 	const existingKey = state.resolutionContext.get(depName);
-	if (existingKey) {
-		const existing = state.entities.get(existingKey);
-		if (existing && parentGroup === "prod" && existing.group === "dev") {
-			existing.group = "prod";
-		}
-		if (parentType === "skill" && existing && existing.type !== "skill") {
-			const parentName = state.entities.get(parentCompositeKey)?.name;
-			state.errors.push(
-				`Error: Invalid dependency type\n\n  skill:${parentName} cannot depend on ${existing.type}:${depName}.\n  Skills can only depend on other skills.\n\nFix: Remove ${depName} from ${parentName}'s dependencies.`,
-			);
-		}
+	const existing = existingKey ? state.entities.get(existingKey) : undefined;
+	if (existing && parentGroup === "prod" && existing.group === "dev") {
+		existing.group = "prod";
 	}
 	return true;
 }
@@ -891,23 +884,6 @@ async function resolveFromLocalSource(
 		}
 	}
 	return false;
-}
-
-function validateTypeConstraints(state: ResolutionState): void {
-	for (const [, entity] of state.entities) {
-		if (entity.type !== "skill") continue;
-		for (const depName of entity.dependencies) {
-			const depKey = state.resolutionContext.get(depName);
-			if (!depKey) continue;
-			const dep = state.entities.get(depKey);
-			if (dep && dep.type !== "skill") {
-				const errMsg = `Error: Invalid dependency type\n\n  skill:${entity.name} cannot depend on ${dep.type}:${depName}.\n  Skills can only depend on other skills.\n\nFix: Remove ${depName} from ${entity.name}'s dependencies.`;
-				if (!state.errors.includes(errMsg)) {
-					state.errors.push(errMsg);
-				}
-			}
-		}
-	}
 }
 
 export function topologicalSort(

--- a/tests/core/command-type-bugs.test.ts
+++ b/tests/core/command-type-bugs.test.ts
@@ -152,42 +152,6 @@ describe("H2: same-name skill + command collision", () => {
 });
 
 /**
- * H3 — The skill→non-skill type-constraint error is pushed from two
- * places: `checkExistingResolution` (transitive path) and
- * `validateTypeConstraints` (post-pass). validateTypeConstraints has a
- * `state.errors.includes(errMsg)` dedup guard. checkExistingResolution
- * doesn't. Confirm whether the same edge produces one error or two.
- */
-describe("H3: type-constraint error duplication", () => {
-	test("a skill→command edge produces exactly one error message", async () => {
-		const dir = await makeTempDir("skilltree-h3-");
-		await mkdir(join(dir, "my-skill"), { recursive: true });
-		await writeFile(
-			join(dir, "my-skill", "SKILL.md"),
-			"---\nname: my-skill\ndependencies:\n  - review\n---\nBody\n",
-		);
-		await mkdir(join(dir, "commands"), { recursive: true });
-		await writeFile(join(dir, "commands", "review.md"), "---\nname: review\n---\nBody\n");
-
-		const result = await resolveAll(
-			{
-				dependencies: {
-					"my-skill": { local: "./my-skill" },
-					review: { local: "./commands/review.md", type: "command" },
-				},
-			},
-			dir,
-		);
-
-		// Count how many error strings mention the same edge.
-		const edgeErrors = result.errors.filter(
-			(e) => e.includes("skill:my-skill") && e.includes("command:review"),
-		);
-		expect(edgeErrors.length).toBe(1);
-	});
-});
-
-/**
  * H6 — `--scan` (scanLocalRepo) must not pick up installed artifacts
  * under `.claude/commands/` as if they were sources. The walker skips
  * hidden directories; verify that property still holds for the new

--- a/tests/core/command-type.test.ts
+++ b/tests/core/command-type.test.ts
@@ -15,8 +15,6 @@
  *  - repo and registry scanners label discovered files correctly
  *  - the gitignore helper covers `commands/` alongside skills+agents
  *  - lockfile round-trip preserves `type: command`
- *  - skills cannot depend on commands (extends the existing
- *    skill→agent invariant)
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
@@ -242,12 +240,14 @@ describe("lockfile round-trip for commands", () => {
 	});
 });
 
-describe("graph type-constraint extends to commands", () => {
-	test("a skill that depends on a command produces a clear type-constraint error", async () => {
+describe("skill→command dependencies are allowed (issue #45)", () => {
+	test("a skill can declare a slash command as a dependency", async () => {
+		// The development-methodology skill prescribes running
+		// /code-refinement-with-hypothesis as part of PatchMode. That kind
+		// of dependency is real — slash commands are reusable workflows
+		// that skills naturally compose.
 		const dir = await makeTempDir("skilltree-cmd-deps-");
 
-		// Build a local skill that declares a command as a dependency.
-		// The resolver should refuse: skills can only depend on skills.
 		await mkdir(join(dir, "my-skill"), { recursive: true });
 		await writeFile(
 			join(dir, "my-skill", "SKILL.md"),
@@ -266,10 +266,64 @@ describe("graph type-constraint extends to commands", () => {
 			dir,
 		);
 
-		const errorText = result.errors.join("\n");
-		expect(errorText).toContain("skill:my-skill");
-		expect(errorText).toContain("command:review");
-		expect(errorText).toContain("Skills can only depend on other skills");
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:my-skill")).toBeDefined();
+		expect(result.entities.get("command:review")).toBeDefined();
+	});
+
+	test("skill → command → command transitive chain resolves (issue #45 motivating case)", async () => {
+		// Mirrors the real chain that surfaced the bug:
+		//   development-methodology (skill)
+		//     └── code-refinement-with-hypothesis (command)
+		//           └── hypothesis (command)
+		// The skill must be able to depend on a command, AND that command's
+		// own frontmatter `dependencies:` (a skilltree extension) must be
+		// followed transitively. Both edges used to fail the type check.
+		const dir = await makeTempDir("skilltree-skill-cmd-cmd-");
+
+		await mkdir(join(dir, "dev-methodology"), { recursive: true });
+		await writeFile(
+			join(dir, "dev-methodology", "SKILL.md"),
+			"---\nname: dev-methodology\ndependencies:\n  - refine-with-hypothesis\n---\nUse /refine-with-hypothesis as a harden step.\n",
+		);
+		await mkdir(join(dir, "commands"), { recursive: true });
+		await writeFile(
+			join(dir, "commands", "refine-with-hypothesis.md"),
+			"---\nname: refine-with-hypothesis\ndependencies:\n  - hypothesize\n---\nLoop /hypothesize until clean.\n",
+		);
+		await writeFile(
+			join(dir, "commands", "hypothesize.md"),
+			"---\nname: hypothesize\n---\nGenerate hypotheses.\n",
+		);
+
+		const result = await resolveAll(
+			{
+				dependencies: {
+					"dev-methodology": { local: "./dev-methodology" },
+					"refine-with-hypothesis": {
+						local: "./commands/refine-with-hypothesis.md",
+						type: "command",
+					},
+					hypothesize: { local: "./commands/hypothesize.md", type: "command" },
+				},
+			},
+			dir,
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:dev-methodology")).toBeDefined();
+		expect(result.entities.get("command:refine-with-hypothesis")).toBeDefined();
+		expect(result.entities.get("command:hypothesize")).toBeDefined();
+
+		// Topological order: transitive `hypothesize` must precede its
+		// parent `refine-with-hypothesis`, which must precede `dev-methodology`.
+		const order = result.installOrder;
+		expect(order.indexOf("command:hypothesize")).toBeLessThan(
+			order.indexOf("command:refine-with-hypothesis"),
+		);
+		expect(order.indexOf("command:refine-with-hypothesis")).toBeLessThan(
+			order.indexOf("skill:dev-methodology"),
+		);
 	});
 });
 

--- a/tests/core/graph-comprehensive.test.ts
+++ b/tests/core/graph-comprehensive.test.ts
@@ -184,22 +184,24 @@ describe("resolveAll: same-repo transitive resolution for remote deps", () => {
 	});
 });
 
-describe("resolveAll: type constraints", () => {
-	test("skill depending on agent produces error", async () => {
+describe("resolveAll: cross-type dependencies (issue #45)", () => {
+	test("skill depending on agent resolves cleanly", async () => {
 		const dir = await makeTempDir();
-		await createLocalSkill(join(dir, "skills"), "bad-skill", ["my-agent"]);
+		await createLocalSkill(join(dir, "skills"), "my-skill", ["my-agent"]);
 		await mkdir(join(dir, "agents"), { recursive: true });
 		await writeFile(join(dir, "agents", "my-agent.md"), "---\nname: my-agent\n---\n\n# Agent\n");
 
 		const manifest: Manifest = {
 			dependencies: {
-				"bad-skill": { local: "./skills/bad-skill" },
+				"my-skill": { local: "./skills/my-skill" },
 				"my-agent": { local: "./agents/my-agent.md", type: "agent" },
 			},
 		};
 
 		const result = await resolveAll(manifest, dir);
-		expect(result.errors.some((e) => e.includes("cannot depend on agent"))).toBe(true);
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:my-skill")).toBeDefined();
+		expect(result.entities.get("agent:my-agent")).toBeDefined();
 	});
 
 	test("agent depending on skill is valid", async () => {

--- a/tests/core/graph-local-source.test.ts
+++ b/tests/core/graph-local-source.test.ts
@@ -183,9 +183,11 @@ describe("same-origin resolution for local sources", () => {
 
 		const result = await resolveAll(manifest, projectDir);
 
-		// Skills can't depend on agents — should get type constraint error
-		// This is correct behavior per spec
-		expect(result.errors.some((e) => e.includes("Invalid dependency type"))).toBe(true);
+		// Skill→agent is allowed (issue #45). The transitive agent must
+		// resolve from the same local source via the candidate probe.
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:python-coding")).toBeDefined();
+		expect(result.entities.get("agent:code-reviewer")).toBeDefined();
 	});
 
 	test("same-origin works with tilde-expanded paths", async () => {

--- a/tests/core/graph.test.ts
+++ b/tests/core/graph.test.ts
@@ -337,24 +337,85 @@ describe("resolveAll with local deps", () => {
 		expect(shared?.group).toBe("prod");
 	});
 
-	test("type constraint: skill cannot depend on agent", async () => {
+	test("dev→prod promotion is type-agnostic: a command first reached via dev gets promoted (issue #45)", async () => {
+		// useExistingResolution does not branch on entity type when promoting
+		// a transitive dep from dev to prod — verify that holds for commands
+		// now that skill→command is allowed.
 		const dir = await makeTempDir();
-		// Create an agent file
 		const { mkdir: mkdirFs } = await import("node:fs/promises");
-		await mkdirFs(join(dir, "agents"), { recursive: true });
-		await writeFile(join(dir, "agents", "my-agent.md"), "---\nname: my-agent\n---\n\n# Agent\n");
-		// Create a skill that depends on the agent
-		await createLocalSkill(join(dir, "skills"), "bad-skill", ["my-agent"]);
+		await createLocalSkill(join(dir, "skills"), "prod-user", ["shared-cmd"]);
+		await createLocalSkill(join(dir, "skills"), "dev-user", ["shared-cmd"]);
+		await mkdirFs(join(dir, "commands"), { recursive: true });
+		await writeFile(join(dir, "commands", "shared-cmd.md"), "---\nname: shared-cmd\n---\nBody\n");
+
+		// Order matters: dev-dependencies process AFTER dependencies in
+		// resolveAll. Put the dev parent first to make sure the command
+		// is reached *first* via dev — the prod sweep then promotes it.
+		const manifest: Manifest = {
+			dependencies: {
+				"prod-user": { local: "./skills/prod-user" },
+			},
+			"dev-dependencies": {
+				"dev-user": { local: "./skills/dev-user" },
+				"shared-cmd": { local: "./commands/shared-cmd.md", type: "command" },
+			},
+		};
+
+		const result = await resolveAll(manifest, dir);
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("command:shared-cmd")?.group).toBe("prod");
+	});
+
+	test("same-name skill+command: a transitive `foo` resolves to the skill, not the command (issue #45)", async () => {
+		// With skill→command now allowed, a manifest can legitimately declare
+		// both `skill:foo` and `command:foo`. Decision #7 says skill wins for
+		// disambiguation; the registerEntity skill-priority guard enforces it
+		// regardless of registration order.
+		const dir = await makeTempDir();
+		const { mkdir: mkdirFs } = await import("node:fs/promises");
+		await createLocalSkill(join(dir, "skills"), "parent", ["foo"]);
+		await createLocalSkill(join(dir, "skills"), "foo");
+		await mkdirFs(join(dir, "commands"), { recursive: true });
+		await writeFile(join(dir, "commands", "foo.md"), "---\nname: foo\n---\nBody\n");
 
 		const manifest: Manifest = {
 			dependencies: {
-				"bad-skill": { local: "./skills/bad-skill" },
+				parent: { local: "./skills/parent" },
+				foo: { local: "./skills/foo" },
+				"foo-cmd": { local: "./commands/foo.md", type: "command", name: "foo" },
+			},
+		};
+
+		const result = await resolveAll(manifest, dir);
+		expect(result.errors).toEqual([]);
+		// parent's transitive `foo` must hit the skill, not the command —
+		// proven by the skill being in the install order ahead of parent.
+		const order = result.installOrder;
+		expect(order).toContain("skill:foo");
+		expect(order).toContain("command:foo");
+		expect(order.indexOf("skill:foo")).toBeLessThan(order.indexOf("skill:parent"));
+	});
+
+	test("skill can depend on agent (issue #45)", async () => {
+		// Slash commands and agents are reusable, composable workflows; a
+		// skill that prescribes a workflow naturally references them.
+		const dir = await makeTempDir();
+		const { mkdir: mkdirFs } = await import("node:fs/promises");
+		await mkdirFs(join(dir, "agents"), { recursive: true });
+		await writeFile(join(dir, "agents", "my-agent.md"), "---\nname: my-agent\n---\n\n# Agent\n");
+		await createLocalSkill(join(dir, "skills"), "my-skill", ["my-agent"]);
+
+		const manifest: Manifest = {
+			dependencies: {
+				"my-skill": { local: "./skills/my-skill" },
 				"my-agent": { local: "./agents/my-agent.md", type: "agent" },
 			},
 		};
 
 		const result = await resolveAll(manifest, dir);
-		expect(result.errors.some((e) => e.includes("cannot depend on agent"))).toBe(true);
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:my-skill")).toBeDefined();
+		expect(result.entities.get("agent:my-agent")).toBeDefined();
 	});
 });
 


### PR DESCRIPTION
Closes #45.

## Summary

The asymmetric `skill → non-skill` type constraint blocked legitimate
real-world dependencies — most concretely, the `development-methodology`
skill that ships with `dependencies: [code-refinement-with-hypothesis]`
in its frontmatter and prescribes invoking that slash command in its
PatchMode workflow.

The old constraint was asymmetric (agent→command and command→skill
were already allowed) with no principled reason — slash commands aren't
"applications" in any meaningful sense; they're packaged reusable
workflows that skills naturally compose. There's also no
filesystem-collision risk: skills, agents, and commands install to
disjoint trees.

## What changes

- **graph.ts**: drop `validateTypeConstraints()` post-pass and the
  inner skill→non-skill check in `checkExistingResolution`. Rename the
  latter to `useExistingResolution` — the function's real job (after
  the constraint goes) is "short-circuit resolution and promote
  dev→prod", not "check". Drop the now-dead `parentType: EntityType`
  parameter that was only carried for the constraint check.
- **spec.md / decisions.md / reference.md**: update the cross-type
  dependency rules; clarify that skill-takes-precedence comes from
  `registerEntity`'s skill-priority guard (probe order), not from the
  removed constraint; delete the stale "Invalid dependency type" error
  block.
- **Tests**: 4 existing tests flipped from "errors" to "succeeds";
  1 H3 dedup test deleted (it pinned the constraint, no longer
  relevant); new coverage:
  - `skill → command → command` transitive chain mirroring the real
    motivating case (development-methodology → code-refinement-with-hypothesis → hypothesis).
  - Type-agnostic `dev → prod` promotion for a transitive command.
  - Same-name `skill:foo` + `command:foo` — skill wins via probe order.

## Hypothesis review

Ran `/hypothesis` on the diff (4 hypotheses, all DISPROVEN):
1. Cycle detection across types — `topologicalSort` uses composite keys
   (`skill:A`, `command:B`); cross-type cycles still caught by Kahn's
   residue.
2. Same-name skill+command — `registerEntity` has a skill-priority
   guard at graph.ts:242; skill always wins regardless of registration
   order. (Coverage gap closed by new test.)
3. Group promotion across types — `useExistingResolution` and `--prod`
   filtering are both type-agnostic. (Coverage gap closed by new test.)
4. Remote-repo skill→command — `tryResolveFromOriginManifest` preserves
   `type` from upstream; `tryResolveFromSameRepo` falls back to
   `inferTypeFromGit` which correctly infers `command` from `commands/`
   path.

## Test plan

- [x] Full suite: 1058 tests pass, 0 fail (was 1056 — three new
      coverage tests added net of the H3 dedup deletion).
- [x] `skilltree install` for the `development-methodology` skill
      depending on `code-refinement-with-hypothesis` succeeds.
- [x] No remaining "Invalid dependency type" / "Skills can only depend"
      string in source or docs.
- [x] biome + tsc + pre-commit hooks all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)