### PR TITLE
fix(deps,lockfile): preserve tree topology under duplicates; reject cyclic lockfiles

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -205,8 +205,16 @@ export function buildProgram(): Command {
 		.description("Show dependency tree")
 		.option("--json", "Output tree as JSON")
 		.option("-g, --global", "Show global dependency tree")
+		.option(
+			"--dedupe",
+			"Stop recursion under already-printed subtrees (terse, cargo-tree default style)",
+		)
 		.action(async (opts) => {
-			await depsTreeCommand(process.cwd(), { global: opts.global, json: opts.json });
+			await depsTreeCommand(process.cwd(), {
+				global: opts.global,
+				json: opts.json,
+				dedupe: opts.dedupe,
+			});
 		});
 
 	const registry = program.command("registry").description("Registry management commands");

--- a/src/commands/deps.ts
+++ b/src/commands/deps.ts
@@ -8,6 +8,14 @@ export interface DepsOptions {
 	global?: boolean;
 	globalDir?: string; // test override
 	json?: boolean;
+	/**
+	 * Suppress recursion under already-printed subtrees. The legacy "stop on
+	 * duplicate" behavior (cargo tree's default). Default `false` — every
+	 * top-level subtree is rendered self-contained, with duplicates marked
+	 * `(*)` (cli) or `deduped: true` (json) but their `dependencies` still
+	 * populated. (Issue #47)
+	 */
+	dedupe?: boolean;
 }
 
 interface JsonTreeNode {
@@ -18,6 +26,10 @@ interface JsonTreeNode {
 	deduped?: boolean;
 	dependencies: JsonTreeNode[];
 }
+
+/** cargo-tree convention: marks a node whose canonical print is elsewhere. */
+const DUPLICATE_MARKER = "(*)";
+const DEDUPED_LABEL = "deduped";
 
 export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<void> {
 	const isGlobal = !!opts?.global;
@@ -38,13 +50,15 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 		...Object.keys(manifest["dev-dependencies"] ?? {}),
 	]);
 
+	const dedupe = opts?.dedupe === true;
+
 	if (opts?.json) {
 		const printedJson = new Set<string>();
 		const tree: JsonTreeNode[] = [];
 		for (const root of roots) {
 			const entry = lockfile.packages[root];
 			if (!entry) continue;
-			tree.push(buildJsonTree(root, entry, lockfile, printedJson));
+			tree.push(buildJsonTree(root, entry, lockfile, printedJson, true, dedupe));
 		}
 		console.log(JSON.stringify(tree, null, 2));
 		return;
@@ -55,7 +69,7 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 	for (const root of roots) {
 		const entry = lockfile.packages[root];
 		if (!entry) continue;
-		printTree(root, entry, lockfile, "", true, true, printed);
+		printTree(root, entry, lockfile, "", true, true, printed, dedupe);
 	}
 }
 
@@ -64,6 +78,8 @@ function buildJsonTree(
 	entry: LockfileEntry,
 	lockfile: Lockfile,
 	printed: Set<string>,
+	isRoot: boolean,
+	dedupe: boolean,
 ): JsonTreeNode {
 	const node: JsonTreeNode = {
 		name,
@@ -73,18 +89,21 @@ function buildJsonTree(
 	if (entry.version) node.version = entry.version;
 	if (entry.source) node.source = entry.source;
 
-	if (printed.has(name)) {
-		// Mirror the human renderer: don't recurse into already-printed subtrees.
-		// Consumers walk on `deduped` instead of duplicating the whole subtree.
+	const alreadyPrinted = printed.has(name);
+	// Top-level entries are direct project deps; never mark them deduped
+	// regardless of whether they were already printed transitively.
+	if (alreadyPrinted && !isRoot) {
 		node.deduped = true;
-		return node;
+		// `--dedupe`: stop here so consumers walk on `deduped`. Default keeps
+		// recursing so each subtree is structurally complete.
+		if (dedupe) return node;
 	}
 	printed.add(name);
 
 	for (const depName of entry.dependencies) {
 		const depEntry = lockfile.packages[depName];
 		if (!depEntry) continue;
-		node.dependencies.push(buildJsonTree(depName, depEntry, lockfile, printed));
+		node.dependencies.push(buildJsonTree(depName, depEntry, lockfile, printed, false, dedupe));
 	}
 	return node;
 }
@@ -102,18 +121,25 @@ function printTree(
 	isRoot: boolean,
 	isLast: boolean,
 	printed: Set<string>,
+	dedupe: boolean,
 ): void {
 	const connector = isRoot ? "" : isLast ? "└── " : "├── ";
 	const version = entry.version ? `@${entry.version}` : "";
 	const source = entry.source === "local" ? "local" : "";
+	const alreadyPrinted = printed.has(name);
 
-	if (printed.has(name)) {
-		console.log(`${prefix}${connector}${dim(`${name} (${entry.type}, deduped)`)}`);
+	if (alreadyPrinted && !isRoot && dedupe) {
+		console.log(`${prefix}${connector}${dim(`${name} (${entry.type}, ${DEDUPED_LABEL})`)}`);
 		return;
 	}
 
+	// Top-level entries (isRoot) are canonical project declarations and never
+	// carry the (*) marker, even if their name was already printed transitively
+	// in an earlier root's subtree. The marker only signals "this transitive
+	// occurrence has been shown above; nothing new will appear below."
+	const marker = alreadyPrinted && !isRoot ? ` ${dim(DUPLICATE_MARKER)}` : "";
 	console.log(
-		`${prefix}${connector}${pc.cyan(name)}${version ? pc.green(version) : ""} ${dim(`(${entry.type}${source ? `, ${source}` : ""})`)}`,
+		`${prefix}${connector}${pc.cyan(name)}${version ? pc.green(version) : ""} ${dim(`(${entry.type}${source ? `, ${source}` : ""})`)}${marker}`,
 	);
 	printed.add(name);
 
@@ -124,6 +150,15 @@ function printTree(
 		const depEntry = lockfile.packages[depName];
 		if (!depEntry) continue;
 		const childPrefix = isRoot ? "" : prefix + (isLast ? "    " : "│   ");
-		printTree(depName, depEntry, lockfile, childPrefix, false, i === deps.length - 1, printed);
+		printTree(
+			depName,
+			depEntry,
+			lockfile,
+			childPrefix,
+			false,
+			i === deps.length - 1,
+			printed,
+			dedupe,
+		);
 	}
 }

--- a/src/core/lockfile.ts
+++ b/src/core/lockfile.ts
@@ -90,20 +90,76 @@ export function parseLockfile(content: string): Lockfile {
 		throw new Error(`Unsupported lockfile version: ${raw.lockfile_version}`);
 	}
 
+	assertAcyclic(raw);
 	return raw;
 }
 
 /**
- * Read a lockfile from disk.
+ * The resolver rejects cycles via topological sort before writing a lockfile,
+ * so any cycle in `packages` indicates corruption (hand-edit, future
+ * skilltree version with a serialization bug, etc.). Validate once on read so
+ * downstream consumers (deps tree, install --frozen) can trust acyclicity
+ * without re-checking.
+ */
+function assertAcyclic(lockfile: Lockfile): void {
+	const WHITE = 0;
+	const GREY = 1;
+	const BLACK = 2;
+	const color = new Map<string, number>();
+	for (const name of Object.keys(lockfile.packages)) color.set(name, WHITE);
+
+	// Iterative DFS to keep stack depth bounded on deep graphs.
+	for (const start of color.keys()) {
+		if (color.get(start) !== WHITE) continue;
+		// Each frame: [name, indexOfNextChildToVisit]
+		const stack: Array<[string, number]> = [[start, 0]];
+		color.set(start, GREY);
+		while (stack.length > 0) {
+			const top = stack[stack.length - 1];
+			if (!top) break;
+			const [name, idx] = top;
+			const deps = lockfile.packages[name]?.dependencies ?? [];
+			if (idx >= deps.length) {
+				color.set(name, BLACK);
+				stack.pop();
+				continue;
+			}
+			top[1] = idx + 1;
+			const child = deps[idx];
+			if (!child || !lockfile.packages[child]) continue;
+			const c = color.get(child);
+			if (c === GREY) {
+				const cycle = [
+					...stack.map(([n]) => n).slice(stack.findIndex(([n]) => n === child)),
+					child,
+				];
+				throw new Error(
+					`Lockfile is corrupt: dependency cycle detected: ${cycle.join(" → ")}. The resolver rejects cycles, so this lockfile was hand-edited or written by an incompatible tool. Run 'skilltree install' to regenerate.`,
+				);
+			}
+			if (c === WHITE) {
+				color.set(child, GREY);
+				stack.push([child, 0]);
+			}
+		}
+	}
+}
+
+/**
+ * Read a lockfile from disk. Returns `null` only when the file is absent.
+ * Parse errors (corruption, unsupported version, dependency cycle) propagate
+ * so callers don't silently fall through to "no lockfile" remediation.
  */
 export async function readLockfile(dir: string): Promise<Lockfile | null> {
+	const { path } = resolveLockfilePath(dir);
+	let content: string;
 	try {
-		const { path } = resolveLockfilePath(dir);
-		const content = await readFile(path, "utf-8");
-		return parseLockfile(content);
-	} catch {
-		return null;
+		content = await readFile(path, "utf-8");
+	} catch (err: unknown) {
+		if (err instanceof Error && "code" in err && err.code === "ENOENT") return null;
+		throw err;
 	}
+	return parseLockfile(content);
 }
 
 /**
@@ -117,13 +173,15 @@ export async function writeLockfile(dir: string, lockfile: Lockfile): Promise<vo
 // --- Global lockfile ---
 
 export async function readGlobalLockfile(globalDir?: string): Promise<Lockfile | null> {
+	const { path } = resolveGlobalLockfilePath(globalDir);
+	let content: string;
 	try {
-		const { path } = resolveGlobalLockfilePath(globalDir);
-		const content = await readFile(path, "utf-8");
-		return parseLockfile(content);
-	} catch {
-		return null;
+		content = await readFile(path, "utf-8");
+	} catch (err: unknown) {
+		if (err instanceof Error && "code" in err && err.code === "ENOENT") return null;
+		throw err;
 	}
+	return parseLockfile(content);
 }
 
 export async function writeGlobalLockfile(lockfile: Lockfile, globalDir?: string): Promise<void> {

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -217,6 +217,8 @@ Show dependency tree
 Options:
   --json        Output tree as JSON
   -g, --global  Show global dependency tree
+  --dedupe      Stop recursion under already-printed subtrees (terse, cargo-tree
+                default style)
   -h, --help    display help for command
 "
 `;

--- a/tests/commands/deps-tree.test.ts
+++ b/tests/commands/deps-tree.test.ts
@@ -1,11 +1,43 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import { depsTreeCommand } from "../../src/commands/deps.js";
 import { installCommand } from "../../src/commands/install.js";
 import { createLocalSkill, createTestRepo } from "../helpers/git-fixtures.js";
+
+/**
+ * Build the synthetic skill→command→command chain that mirrors the
+ * real-world chain (development-methodology → code-refinement-with-hypothesis
+ * → hypothesis) used to motivate issues #45 and #47. All three entities are
+ * also top-level deps so the duplicate-suppression code paths fire.
+ */
+async function setupDeepChain(dir: string): Promise<void> {
+	await mkdir(join(dir, "commands"), { recursive: true });
+	await writeFile(join(dir, "commands", "hypothesize.md"), "---\nname: hypothesize\n---\nBody\n");
+	await writeFile(
+		join(dir, "commands", "refine.md"),
+		"---\nname: refine\ndependencies:\n  - hypothesize\n---\nBody\n",
+	);
+	await createLocalSkill(join(dir, "skills"), "methodology", ["refine"]);
+	await writeFile(
+		join(dir, "skilltree.yml"),
+		[
+			"dependencies:",
+			"  refine:",
+			"    local: ./commands/refine.md",
+			"    type: command",
+			"  hypothesize:",
+			"    local: ./commands/hypothesize.md",
+			"    type: command",
+			"  methodology:",
+			"    local: ./skills/methodology",
+			"",
+		].join("\n"),
+	);
+	await installCommand(dir, {});
+}
 
 let tempDir: string;
 
@@ -49,7 +81,14 @@ function captureConsole(fn: () => Promise<void>): Promise<string[]> {
 			// This filters out noise from parallel tests bleeding into the capture.
 			return lines
 				.map(stripAnsi)
-				.filter((l) => /\(skill[,)]/.test(l) || /\(agent[,)]/.test(l) || l.includes("deduped)"));
+				.filter(
+					(l) =>
+						/\(skill[,)]/.test(l) ||
+						/\(agent[,)]/.test(l) ||
+						/\(command[,)]/.test(l) ||
+						l.includes("deduped)") ||
+						l.includes("(*)"),
+				);
 		})
 		.finally(() => {
 			console.log = original;
@@ -103,7 +142,7 @@ describe("deps tree rendering", () => {
 		expect(lines[2]).toBe("    └── leaf (skill, local)");
 	});
 
-	test("renders deduped entries correctly", async () => {
+	test("default: diamond shows full topology with (*) marker on transitive duplicates (issue #47)", async () => {
 		const dir = await makeTempDir();
 
 		// Diamond: A→B, A→C, B→D, C→D
@@ -121,12 +160,71 @@ describe("deps tree rendering", () => {
 
 		const lines = await captureConsole(() => depsTreeCommand(dir));
 
-		// shared should appear once fully, rest as deduped
-		// (once under left's subtree, then deduped under right and as root entry)
-		const fullShared = lines.filter((l) => l.includes("shared (skill, local)"));
+		// `shared` appears unmarked under its first transitive site (left's
+		// subtree) AND at top-level (top-level entries are always canonical).
+		// At the second transitive site (right's subtree), `(*)` marks it.
+		const dupShared = lines.filter((l) => l.includes("shared") && l.includes("(*)"));
+		expect(dupShared.length).toBeGreaterThanOrEqual(1);
+
+		// "deduped" wording is gone in the default output — that lives on --dedupe.
+		expect(lines.some((l) => l.includes("deduped)"))).toBe(false);
+	});
+
+	test("default: deep chain duplicated under multiple parents shows full topology (issue #47)", async () => {
+		const dir = await makeTempDir();
+		await setupDeepChain(dir);
+
+		const lines = await captureConsole(() => depsTreeCommand(dir));
+
+		const startIdx = lines.findIndex((l) => l.startsWith("methodology"));
+		expect(startIdx).toBeGreaterThanOrEqual(0);
+		const subtree = lines.slice(startIdx);
+		const subtreeRefine = subtree.filter((l) => l.includes("refine") && l.includes("(*)"));
+		const subtreeHypo = subtree.filter((l) => l.includes("hypothesize") && l.includes("(*)"));
+		expect(subtreeRefine.length).toBe(1);
+		expect(subtreeHypo.length).toBe(1);
+	});
+
+	test("top-level entry is canonical even when already printed as a transitive (issue #47)", async () => {
+		// Iteration order: refine, then hypothesize (which was already printed
+		// as refine's transitive), then methodology. The top-level hypothesize
+		// line must be canonical — it's a direct project dep, not a duplicate.
+		// The marker only belongs on transitive occurrences.
+		const dir = await makeTempDir();
+		await setupDeepChain(dir);
+
+		const lines = await captureConsole(() => depsTreeCommand(dir));
+
+		// The top-level `hypothesize` line (no leading connector — root-level)
+		// must NOT carry the (*) marker.
+		const topLevelHypo = lines.find((l) => l.startsWith("hypothesize") && l.includes("(command"));
+		expect(topLevelHypo).toBeDefined();
+		expect(topLevelHypo).not.toContain("(*)");
+	});
+
+	test("--dedupe preserves the legacy terse view (issue #47)", async () => {
+		const dir = await makeTempDir();
+
+		await createLocalSkill(join(dir, "skills"), "shared");
+		await createLocalSkill(join(dir, "skills"), "left", ["shared"]);
+		await createLocalSkill(join(dir, "skills"), "right", ["shared"]);
+		await createLocalSkill(join(dir, "skills"), "root", ["left", "right"]);
+
+		await writeManifest(
+			dir,
+			"dependencies:\n  root:\n    local: ./skills/root\n  left:\n    local: ./skills/left\n  right:\n    local: ./skills/right\n  shared:\n    local: ./skills/shared\n",
+		);
+
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => depsTreeCommand(dir, { dedupe: true }));
+
+		// With --dedupe, the duplicate carries the legacy "deduped" wording AND
+		// no children are rendered below it.
 		const dedupedShared = lines.filter((l) => l.includes("shared (skill, deduped)"));
-		expect(fullShared.length).toBe(1);
 		expect(dedupedShared.length).toBeGreaterThanOrEqual(1);
+		// Sanity: (*) marker should not appear under --dedupe.
+		expect(lines.some((l) => l.includes("(*)"))).toBe(false);
 	});
 
 	test("renders remote deps with version", async () => {
@@ -213,7 +311,33 @@ describe("deps tree rendering", () => {
 		expect(JSON.parse(lines[0] ?? "")).toEqual([]);
 	});
 
-	test("--json marks deduped entries", async () => {
+	test("--json default: deduped nodes still carry populated `dependencies` (issue #47)", async () => {
+		const dir = await makeTempDir();
+		await setupDeepChain(dir);
+
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+
+		const parsed = JSON.parse(lines[0] ?? "");
+		const methodology = parsed.find((r: { name: string }) => r.name === "methodology");
+		expect(methodology).toBeDefined();
+		const refineUnderMeth = methodology.dependencies.find(
+			(d: { name: string }) => d.name === "refine",
+		);
+		expect(refineUnderMeth).toBeDefined();
+		expect(refineUnderMeth.deduped).toBe(true);
+		expect(refineUnderMeth.dependencies.length).toBe(1);
+		expect(refineUnderMeth.dependencies[0].name).toBe("hypothesize");
+		expect(refineUnderMeth.dependencies[0].deduped).toBe(true);
+	});
+
+	test("--json --dedupe: deduped nodes have empty `dependencies` (legacy view)", async () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "shared");
 		await createLocalSkill(join(dir, "skills"), "left", ["shared"]);
@@ -231,33 +355,66 @@ describe("deps tree rendering", () => {
 		const original = console.log;
 		console.log = (...args: unknown[]) => lines.push(args.join(" "));
 		try {
-			await depsTreeCommand(dir, { json: true });
+			await depsTreeCommand(dir, { json: true, dedupe: true });
 		} finally {
 			console.log = original;
 		}
 
 		const parsed = JSON.parse(lines[0] ?? "");
-		// Find any "shared" appearance below the first one — it should be marked deduped
-		const findShared = (
+		// At least one duplicate occurrence of `shared` should carry
+		// deduped: true AND an empty dependencies array (legacy view).
+		const findDeduped = (
 			node: { name: string; deduped?: boolean; dependencies: unknown[] },
-			seen: { count: number },
-		): boolean => {
-			if (node.name === "shared") {
-				seen.count += 1;
-				if (seen.count > 1 && node.deduped !== true) return false;
+			results: Array<{ deduped: boolean; depsCount: number }>,
+		): void => {
+			if (node.name === "shared" && node.deduped === true) {
+				results.push({ deduped: true, depsCount: node.dependencies.length });
 			}
 			for (const child of node.dependencies as Array<{
 				name: string;
 				deduped?: boolean;
 				dependencies: unknown[];
 			}>) {
-				if (!findShared(child, seen)) return false;
+				findDeduped(child, results);
 			}
-			return true;
 		};
-		const seen = { count: 0 };
-		for (const root of parsed) findShared(root, seen);
-		expect(seen.count).toBeGreaterThanOrEqual(2);
+		const results: Array<{ deduped: boolean; depsCount: number }> = [];
+		for (const root of parsed) findDeduped(root, results);
+		expect(results.length).toBeGreaterThanOrEqual(1);
+		expect(results.every((r) => r.depsCount === 0)).toBe(true);
+	});
+
+	test("a cyclic lockfile is rejected at read time with a clear error (issue #47)", async () => {
+		// The resolver rejects cycles before writing a lockfile, so a cycle
+		// here means corruption (hand-edit, future serialization bug). Surface
+		// it as a load-time error rather than letting deps tree silently render
+		// a partial graph.
+		const dir = await makeTempDir();
+		await writeManifest(dir, "dependencies:\n  a:\n    local: ./skills/a\n");
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			[
+				"lockfile_version: 1",
+				"packages:",
+				"  a:",
+				"    type: skill",
+				"    group: prod",
+				"    source: local",
+				"    path: ./skills/a",
+				"    commit: HEAD",
+				"    dependencies: [b]",
+				"  b:",
+				"    type: skill",
+				"    group: prod",
+				"    source: local",
+				"    path: ./skills/b",
+				"    commit: HEAD",
+				"    dependencies: [a]",
+				"",
+			].join("\n"),
+		);
+
+		await expect(depsTreeCommand(dir)).rejects.toThrow(/cycle detected/);
 	});
 
 	test("renders │ continuation for non-last children with subtrees", async () => {

--- a/tests/core/lockfile.test.ts
+++ b/tests/core/lockfile.test.ts
@@ -127,4 +127,28 @@ describe("parseLockfile", () => {
 			"Unsupported lockfile version",
 		);
 	});
+
+	test("rejects a lockfile with a dependency cycle (issue #47)", () => {
+		// The resolver rejects cycles, so any cycle in a lockfile is corruption.
+		// Validate at read time so all consumers (deps tree, install --frozen)
+		// surface a clear error instead of silently mishandling the bad data.
+		const cyclic = [
+			"lockfile_version: 1",
+			"packages:",
+			"  a: {type: skill, group: prod, source: local, path: ./a, commit: HEAD, dependencies: [b]}",
+			"  b: {type: skill, group: prod, source: local, path: ./b, commit: HEAD, dependencies: [a]}",
+			"",
+		].join("\n");
+		expect(() => parseLockfile(cyclic)).toThrow(/cycle detected.*a → b → a/);
+	});
+
+	test("self-cycle is rejected (issue #47)", () => {
+		const selfCycle = [
+			"lockfile_version: 1",
+			"packages:",
+			"  a: {type: skill, group: prod, source: local, path: ./a, commit: HEAD, dependencies: [a]}",
+			"",
+		].join("\n");
+		expect(() => parseLockfile(selfCycle)).toThrow(/cycle detected.*a → a/);
+	});
 });


### PR DESCRIPTION
Closes #47.

## Summary

Two related fixes shaken out by the user inspecting `skilltree deps tree` output after the issue #45 merge.

**1. `deps tree` now preserves transitive topology by default.**
The old default marked already-printed nodes `(deduped)` and stopped recursing — so reading `development-methodology`'s subtree alone never showed that `hypothesis` was transitively pulled in. Switched to cargo's `(*)` convention: full topology under every occurrence, marker on transitive duplicates only. Top-level entries are *direct project declarations* and never carry the marker even if they were already printed transitively under an earlier root. The legacy "stop on duplicate" view moves behind `--dedupe`.

**2. Cyclic lockfiles are now rejected at read time.**
The resolver already rejects cycles before writing a lockfile (Kahn's), so any cycle in a *parsed* lockfile is corruption (hand-edit, future serialization bug, etc.). Caught the right layer for the validation: `parseLockfile` runs an iterative DFS and throws a clear \`Lockfile is corrupt: dependency cycle detected: A → B → A. ...\` error. `readLockfile` and `readGlobalLockfile` had a catch-all that silently swallowed *all* errors as \"no lockfile found\" — fixed to distinguish `ENOENT` from parse errors.

## Before / After

**Before** (the user's actual output):
\`\`\`
code-refinement-with-hypothesis@0.7.0 (command)
└── hypothesis@0.7.0 (command)
development-methodology@0.7.0 (skill)
└── code-refinement-with-hypothesis (command, deduped)
\`\`\`
From `development-methodology`'s block alone, the reader can't tell that `hypothesis` is transitively pulled in.

**After (default):**
\`\`\`
code-refinement-with-hypothesis@0.7.0 (command)
└── hypothesis@0.7.0 (command)
hypothesis@0.7.0 (command)              ← canonical (top-level rule)
development-methodology@0.7.0 (skill)
└── code-refinement-with-hypothesis@0.7.0 (command) (*)
    └── hypothesis@0.7.0 (command) (*)
\`\`\`

**After (`--dedupe`):** identical to old behavior — terse, stops on duplicate.

## Hypothesis review

Ran `/hypothesis` on the diff (4 hypotheses):
1. Top-level dep also seen as transitive gets `(*)` on its top-level line — **CONFIRMED**, fixed by suppressing the marker for `isRoot=true`.
2. `--dedupe` cycle termination — DISPROVEN.
3. Diamond grandchildren marker — DISPROVEN.
4. Self-cycle / deep cycle / ancestors cleanup — DISPROVEN.

After the cycle-detection-at-parse-time refactor, the entire `ancestors` defensive guard came out (lockfile is now known acyclic by the time renderers see it). Renderers are simpler, single \`printed\` set drives the marker.

## Test plan

- [x] Full suite: 1065 pass, 0 fail.
- [x] Diamond, deep chain (skill → command → command mirroring the motivating case), top-level-also-transitive, `--dedupe` cli + json — all covered.
- [x] `parseLockfile` cycle detection: unit tests for 2-node and self-cycle.
- [x] biome + tsc + pre-commit hooks all green.
- [x] `deps tree --help` snapshot updated for `--dedupe` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)