### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ demo/*.mp4
 .claude/agents/
 .claude/commands/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 test
 package-lock.json
 .playwright-cli/


### PR DESCRIPTION
Adds the scheduled-tasks lock file to .gitignore so it doesn't show up as an untracked artifact in working trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
