### PR TITLE
feat(manifest): accept nested form for sources map

### DIFF
--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -41,7 +41,7 @@ export function parseManifest(content: string): Manifest {
 	}
 
 	if (raw.sources && typeof raw.sources === "object") {
-		manifest.sources = raw.sources as Record<string, string>;
+		manifest.sources = parseSources(raw.sources as Record<string, unknown>);
 	}
 
 	if (raw.dependencies && typeof raw.dependencies === "object") {
@@ -53,6 +53,55 @@ export function parseManifest(content: string): Manifest {
 	}
 
 	return manifest;
+}
+
+/**
+ * Parse the `sources:` map. Accepts two equivalent forms per alias:
+ *
+ *   sources:
+ *     vibes: ~/Projects/vibes              # flat string
+ *     shared:                              # nested mapping (mirrors deps syntax)
+ *       repo: github.com/acme/shared
+ *
+ * Both normalize to a flat `Record<string, string>` internally — the rest of
+ * the resolver only ever sees the URL/path. Nested form must carry exactly
+ * one of `local:` / `repo:`; sources cannot themselves alias another source.
+ */
+function parseSources(raw: Record<string, unknown>): Record<string, string> {
+	const sources: Record<string, string> = {};
+	for (const [alias, value] of Object.entries(raw)) {
+		if (typeof value === "string") {
+			sources[alias] = value;
+			continue;
+		}
+		if (value && typeof value === "object" && !Array.isArray(value)) {
+			const obj = value as Record<string, unknown>;
+			const hasLocal = "local" in obj;
+			const hasRepo = "repo" in obj;
+			if (hasLocal && hasRepo) {
+				throw new Error(
+					`Invalid manifest: sources.${alias} has both "local" and "repo" — they are mutually exclusive.`,
+				);
+			}
+			if (!hasLocal && !hasRepo) {
+				throw new Error(
+					`Invalid manifest: sources.${alias} must specify either "local" or "repo" (got: ${Object.keys(obj).join(", ") || "empty"}).`,
+				);
+			}
+			const inner = hasLocal ? obj.local : obj.repo;
+			if (typeof inner !== "string") {
+				throw new Error(
+					`Invalid manifest: sources.${alias}.${hasLocal ? "local" : "repo"} must be a string, got ${inner === null ? "null" : typeof inner}.`,
+				);
+			}
+			sources[alias] = inner;
+			continue;
+		}
+		throw new Error(
+			`Invalid manifest: sources.${alias} must be a string (a git URL or filesystem path) or a mapping with \`local:\` or \`repo:\`, got ${value === null ? "null" : typeof value}.`,
+		);
+	}
+	return sources;
 }
 
 export function serializeManifest(manifest: Manifest): string {

--- a/tests/core/manifest-unhappy.test.ts
+++ b/tests/core/manifest-unhappy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { validateGlobalManifest, validateManifest } from "../../src/core/manifest.js";
+import {
+	parseManifest,
+	validateGlobalManifest,
+	validateManifest,
+} from "../../src/core/manifest.js";
 import type { Dependency, Manifest } from "../../src/types.js";
 
 describe("global manifest validation", () => {
@@ -93,5 +97,99 @@ describe("manifest missing fields", () => {
 		};
 		const errors = validateManifest(manifest);
 		expect(errors).toEqual([]);
+	});
+});
+
+describe("sources map shape", () => {
+	test("accepts plain-string source values", () => {
+		const yaml = `
+sources:
+  vibes: ~/Projects/vibes
+  shared: github.com/acme/shared
+`;
+		const manifest = parseManifest(yaml);
+		expect(manifest.sources?.vibes).toBe("~/Projects/vibes");
+		expect(manifest.sources?.shared).toBe("github.com/acme/shared");
+	});
+
+	test("accepts nested local source value", () => {
+		const yaml = `
+sources:
+  vibes:
+    local: ~/Projects/vibes
+`;
+		const manifest = parseManifest(yaml);
+		expect(manifest.sources?.vibes).toBe("~/Projects/vibes");
+	});
+
+	test("accepts nested repo source value", () => {
+		const yaml = `
+sources:
+  shared:
+    repo: github.com/acme/shared
+`;
+		const manifest = parseManifest(yaml);
+		expect(manifest.sources?.shared).toBe("github.com/acme/shared");
+	});
+
+	test("accepts a mix of flat and nested source values", () => {
+		const yaml = `
+sources:
+  vibes:
+    local: ~/Projects/vibes
+  shared: github.com/acme/shared
+  pinned:
+    repo: github.com/acme/pinned
+`;
+		const manifest = parseManifest(yaml);
+		expect(manifest.sources?.vibes).toBe("~/Projects/vibes");
+		expect(manifest.sources?.shared).toBe("github.com/acme/shared");
+		expect(manifest.sources?.pinned).toBe("github.com/acme/pinned");
+	});
+
+	test("rejects nested form with both local and repo", () => {
+		const yaml = `
+sources:
+  bad:
+    local: ~/foo
+    repo: github.com/x/y
+`;
+		expect(() => parseManifest(yaml)).toThrow(/sources\.bad/);
+		expect(() => parseManifest(yaml)).toThrow(/mutually exclusive/);
+	});
+
+	test("rejects empty nested form", () => {
+		const yaml = `
+sources:
+  bad: {}
+`;
+		expect(() => parseManifest(yaml)).toThrow(/sources\.bad/);
+		expect(() => parseManifest(yaml)).toThrow(/local.*repo/);
+	});
+
+	test("rejects nested form with unknown key", () => {
+		const yaml = `
+sources:
+  bad:
+    source: other
+`;
+		expect(() => parseManifest(yaml)).toThrow(/sources\.bad/);
+	});
+
+	test("rejects non-string scalar source value", () => {
+		const yaml = `
+sources:
+  weird: 42
+`;
+		expect(() => parseManifest(yaml)).toThrow(/sources\.weird/);
+	});
+
+	test("rejects nested form with non-string inner value", () => {
+		const yaml = `
+sources:
+  bad:
+    local: 42
+`;
+		expect(() => parseManifest(yaml)).toThrow(/sources\.bad/);
 	});
 });


### PR DESCRIPTION
## Summary

- The `sources:` map now accepts both flat-string values and nested `{ local: ... }` / `{ repo: ... }` mappings, so authors can mirror the `dependencies:` syntax without surprise.
- Replaces a cryptic internal crash (`value.startsWith is not a function`) with clear `sources.<alias>` validation errors when the nested form is malformed (empty, both keys, non-string inner, unknown key).
- Pure parser change; downstream resolution and lockfile shape are unchanged because both forms normalize to the existing `Record<string, string>`.

## Why

Reported in the field: a global manifest mirrored the dep syntax —

```yaml
sources:
  vibes:
    local: ~/Projects/vibes
```

— and `skilltree install --global` died with `value.startsWith is not a function` from inside `isLocalSource`. The author's intuition was reasonable (deps use nested mappings everywhere else), the crash was not.

Both forms are equivalent now:

```yaml
sources:
  vibes: ~/Projects/vibes              # flat (still works)
  shared:                              # nested (new)
    local: ~/Projects/shared
  remote:
    repo: github.com/acme/remote
```

## Test plan

- [x] `bun test tests/core/manifest-unhappy.test.ts` — 17/17 pass (9 new cases covering both forms and every rejection path)
- [x] `bun test` — full suite 1074/1074 pass
- [x] End-to-end: `bun run dev -- install --global` against a real `~/.skilltree/global.yml` using the nested form — installs cleanly, sibling resolution still finds transitive bare-name deps inside the local source repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)