### PR TITLE
fix(scan): ignore Claude Code built-in slash commands

### DIFF
--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -43,6 +43,52 @@ const PATTERNS = [
 const MIN_NAME_LENGTH = 2;
 
 /**
+ * Claude Code's built-in slash commands. They ship with the harness, are not
+ * packaged as registry skills/commands, and cannot be declared in
+ * `dependencies:` — so the regex scan must drop them from the "undeclared"
+ * set rather than ask the author to declare them. Issue #43.
+ *
+ * Match is exact (no prefix matching), so registry commands like `loop-runner`
+ * are still detected normally.
+ */
+export const BUILTIN_HARNESS_COMMANDS = new Set([
+	// Scheduling & loops
+	"loop",
+	"schedule",
+	// Code workflows
+	"simplify",
+	"review",
+	"security-review",
+	// Model / mode toggles
+	"fast",
+	"model",
+	// Harness control
+	"help",
+	"clear",
+	"config",
+	"init",
+	"compact",
+	"resume",
+	"upgrade",
+	"exit",
+	// Config UIs
+	"agents",
+	"mcp",
+	"hooks",
+	"permissions",
+	// Diagnostics / account
+	"ide",
+	"cost",
+	"release-notes",
+	"login",
+	"logout",
+	"memory",
+	"status",
+	"bug",
+	"doctor",
+]);
+
+/**
  * Common English words that appear before "skill" in prose but are not skill
  * names (e.g., "a companion skill", "the expected skill"). Matched only for
  * single-token captures — hyphenated names like "python-coding" are never
@@ -111,6 +157,21 @@ export interface ScanResult {
 }
 
 /**
+ * Whether a regex-captured token survives the post-match filters and counts as
+ * a real entity reference. Drops sub-minimum-length tokens, self-references,
+ * single-word English stopwords ("companion skill"), and Claude Code's
+ * built-in slash commands (issue #43). Hyphenated tokens bypass the stopword
+ * check since real skill IDs are conventionally hyphenated.
+ */
+function isCandidateRef(depName: string, selfName: string): boolean {
+	if (depName.length < MIN_NAME_LENGTH) return false;
+	if (depName === selfName) return false;
+	if (!depName.includes("-") && STOPWORDS.has(depName.toLowerCase())) return false;
+	if (BUILTIN_HARNESS_COMMANDS.has(depName)) return false;
+	return true;
+}
+
+/**
  * Scan a single SKILL.md, agent .md, or command .md file for undeclared
  * dependencies.
  */
@@ -144,11 +205,7 @@ export async function scanFile(filePath: string): Promise<ScanResult | null> {
 			const match = pattern.exec(body);
 			if (match === null) break;
 			const depName = match[1];
-			if (depName && depName.length >= MIN_NAME_LENGTH) {
-				// Filter self-references and common English stopwords (false positives
-				// like "a companion skill"). Hyphenated names bypass the stopword check.
-				if (depName === name) continue;
-				if (!depName.includes("-") && STOPWORDS.has(depName.toLowerCase())) continue;
+			if (depName && isCandidateRef(depName, name)) {
 				detected.add(depName);
 			}
 		}

--- a/tests/core/scanner.test.ts
+++ b/tests/core/scanner.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyToFrontmatter, scanFile } from "../../src/core/scanner.js";
+import { applyToFrontmatter, BUILTIN_HARNESS_COMMANDS, scanFile } from "../../src/core/scanner.js";
 
 let tempDir: string;
 
@@ -386,12 +386,12 @@ describe("scanFile — slash-command references", () => {
 		const filePath = await writeCommand(
 			dir,
 			"code-refinement-with-hypothesis",
-			"Use /loop 1m /hypothesis to run iteratively.",
+			"Use /task-builder /hypothesis to run iteratively.",
 		);
 
 		const result = await scanFile(filePath);
 		expect(result?.detected).toContain("hypothesis");
-		expect(result?.detected).toContain("loop");
+		expect(result?.detected).toContain("task-builder");
 		expect(result?.undeclared).toContain("hypothesis");
 	});
 
@@ -439,6 +439,69 @@ describe("scanFile — slash-command references", () => {
 
 		const result = await scanFile(filePath);
 		expect(result?.detected).toContain("hypothesis");
+	});
+
+	test("ignores Claude Code built-in slash commands (issue #43)", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(
+			dir,
+			"my-cmd",
+			"Run `/loop` and `/simplify`, then `/help`. Also see /clear and /compact.",
+		);
+
+		const result = await scanFile(filePath);
+		// None of the built-in harness commands should leak into detected/undeclared
+		for (const builtin of ["loop", "simplify", "help", "clear", "compact"]) {
+			expect(result?.detected).not.toContain(builtin);
+			expect(result?.undeclared).not.toContain(builtin);
+		}
+	});
+
+	test("does not ignore registry commands that share a prefix with builtins", async () => {
+		// "loop" is a builtin, but "loop-runner" is a hypothetical registry command
+		// — only exact matches should be filtered.
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(dir, "my-cmd", "Use /loop-runner each round.");
+
+		const result = await scanFile(filePath);
+		expect(result?.detected).toContain("loop-runner");
+		expect(result?.undeclared).toContain("loop-runner");
+	});
+
+	test("BUILTIN_HARNESS_COMMANDS includes the commands enumerated in issue #43", () => {
+		// Sanity-check the seed list. Update as Anthropic adds new built-ins.
+		for (const name of [
+			"loop",
+			"schedule",
+			"simplify",
+			"fast",
+			"help",
+			"clear",
+			"config",
+			"init",
+			"review",
+			"agents",
+			"mcp",
+			"hooks",
+			"permissions",
+			"security-review",
+			"ide",
+			"cost",
+			"release-notes",
+			"login",
+			"logout",
+			"model",
+			"memory",
+			"status",
+			"compact",
+			"resume",
+			"upgrade",
+			"exit",
+			"bug",
+			"doctor",
+		]) {
+			expect(BUILTIN_HARNESS_COMMANDS.has(name)).toBe(true);
+		}
 	});
 
 	test("filters self-reference by filename when no name: in frontmatter", async () => {


### PR DESCRIPTION
## Why

`skilltree scan` flagged references to Claude Code's built-in slash commands (`/loop`, `/simplify`, `/help`, ...) as undeclared dependencies. They're harness-provided, not packaged as registry skills, so they cannot be declared in `dependencies:`. The result: pre-commit blocks legitimate docs that referenced them, and the only workaround was `--no-verify`.

Closes #43

## What changed

- `src/core/scanner.ts`: introduced `BUILTIN_HARNESS_COMMANDS` (a Set with the built-ins enumerated in #43) and added an exact-match filter in the post-regex pass.
- Extracted the per-match filters (length, self-reference, stopword, built-in) into a small `isCandidateRef` helper so the rules live in one place. This also keeps `scanFile`'s cognitive complexity under the lint threshold after the new check landed.
- `tests/core/scanner.test.ts`: added cases for the new filter, a regression test confirming registry commands that *share a prefix* with a built-in (e.g. `loop-runner`) are still detected, and a parametrized sanity check on the seed list. Updated one prior test that used `/loop` as a placeholder to use `/task-builder` instead.

The match is intentionally exact (no prefix matching). LLM scan already handled this correctly; only the regex stage needed the ignore set.

## How tested

- `bun test tests/core/scanner.test.ts` — 40 pass.
- `bun test` — full suite, 1077 pass, 0 fail.
- Smoke: ran `bun run dev -- scan` against a synthetic command file with `/loop`, `/simplify`, `/security-review` — output is `All entity references are declared in frontmatter.` (previously: those tokens were reported undeclared).

## Risk & rollback

Low. The change only narrows what regex scan reports — no new files, no schema changes, no install path touched. Revert is `git revert <sha>`.