### PR TITLE
refactor(manifest): drop parseSources cognitive complexity below 25

### DIFF
--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -70,38 +70,48 @@ export function parseManifest(content: string): Manifest {
 function parseSources(raw: Record<string, unknown>): Record<string, string> {
 	const sources: Record<string, string> = {};
 	for (const [alias, value] of Object.entries(raw)) {
-		if (typeof value === "string") {
-			sources[alias] = value;
-			continue;
-		}
-		if (value && typeof value === "object" && !Array.isArray(value)) {
-			const obj = value as Record<string, unknown>;
-			const hasLocal = "local" in obj;
-			const hasRepo = "repo" in obj;
-			if (hasLocal && hasRepo) {
-				throw new Error(
-					`Invalid manifest: sources.${alias} has both "local" and "repo" — they are mutually exclusive.`,
-				);
-			}
-			if (!hasLocal && !hasRepo) {
-				throw new Error(
-					`Invalid manifest: sources.${alias} must specify either "local" or "repo" (got: ${Object.keys(obj).join(", ") || "empty"}).`,
-				);
-			}
-			const inner = hasLocal ? obj.local : obj.repo;
-			if (typeof inner !== "string") {
-				throw new Error(
-					`Invalid manifest: sources.${alias}.${hasLocal ? "local" : "repo"} must be a string, got ${inner === null ? "null" : typeof inner}.`,
-				);
-			}
-			sources[alias] = inner;
-			continue;
-		}
+		sources[alias] = parseSourceEntry(alias, value);
+	}
+	return sources;
+}
+
+/**
+ * Resolve a single `sources:` entry to its underlying URL/path string.
+ * Accepts either a flat string or a nested `{ local | repo }` mapping.
+ * Throws with the original error wording on any shape violation — the
+ * messages are part of the user-visible contract and several tests pin them.
+ */
+function parseSourceEntry(alias: string, value: unknown): string {
+	if (typeof value === "string") return value;
+
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		throw new Error(
 			`Invalid manifest: sources.${alias} must be a string (a git URL or filesystem path) or a mapping with \`local:\` or \`repo:\`, got ${value === null ? "null" : typeof value}.`,
 		);
 	}
-	return sources;
+
+	const obj = value as Record<string, unknown>;
+	const hasLocal = "local" in obj;
+	const hasRepo = "repo" in obj;
+	if (hasLocal && hasRepo) {
+		throw new Error(
+			`Invalid manifest: sources.${alias} has both "local" and "repo" — they are mutually exclusive.`,
+		);
+	}
+	if (!hasLocal && !hasRepo) {
+		throw new Error(
+			`Invalid manifest: sources.${alias} must specify either "local" or "repo" (got: ${Object.keys(obj).join(", ") || "empty"}).`,
+		);
+	}
+
+	const innerKey = hasLocal ? "local" : "repo";
+	const inner = obj[innerKey];
+	if (typeof inner !== "string") {
+		throw new Error(
+			`Invalid manifest: sources.${alias}.${innerKey} must be a string, got ${inner === null ? "null" : typeof inner}.`,
+		);
+	}
+	return inner;
 }
 
 export function serializeManifest(manifest: Manifest): string {


### PR DESCRIPTION
## Why

`biome check` was reporting `parseSources` in `src/core/manifest.ts` at
cognitive complexity 31 (max 25). It's currently a warning, not a hard
error, so CI still passes — but the function is exactly the kind of place
where the next change is most likely to flip it from "warning" to "error"
without notice.

Closes #53

## What changed

- `src/core/manifest.ts` — extracted `parseSourceEntry(alias, value)` from
  `parseSources`. The new helper handles the flat-string and nested-mapping
  shape checks with a single linear flow; `parseSources` is now a small
  `Object.entries` loop.
- All thrown error messages are preserved **verbatim** — they're pinned by
  tests in `tests/core/manifest-unhappy.test.ts` and form part of the
  user-visible contract.
- No behavior change. Pure structural refactor.

## How tested

- `bun run lint` — was reporting the complexity warning, is now clean.
- `bun test` — full suite still green (1077 tests). The
  `tests/core/manifest*.test.ts` files cover happy + unhappy paths for both
  the flat and nested forms (including `null`, arrays, scalars, both-fields,
  neither-field, and non-string inner values), so the refactor is exercised
  by the existing tests without needing new ones.

## Risk & rollback

Low — single-file structural refactor with no behavior change and no new
public API. Revert with `git revert <sha>` if anything surprising shows up.