### PR TITLE
fix(registry): bare clones mirror branches and prune revoked tags (#55)

### DIFF
--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -141,6 +141,41 @@ export function toGitCloneUrl(repo: string): string {
 }
 
 /**
+ * The fetch refspec we install on every bare cache. `git clone --bare` deliberately
+ * leaves `remote.origin.fetch` unset (see `git-clone(1)`: "neither remote-tracking
+ * branches nor the related configuration variables are created"), so a subsequent
+ * `git fetch --tags` resolves the remote's HEAD into FETCH_HEAD only and never
+ * updates `refs/heads/*` — new commits on the default branch are silently missed
+ * (issue #55).
+ *
+ * Installing this refspec — both on fresh clones and on pre-existing caches —
+ * gives us mirror-style branch updates without the broader `--mirror` semantics
+ * (PR refs, replace refs, etc.).
+ */
+const BARE_FETCH_REFSPEC = "+refs/heads/*:refs/heads/*";
+
+/**
+ * Backfill the branch-mirroring fetch refspec into a bare cache, replacing
+ * any pre-existing value(s). Use `--replace-all` rather than a plain
+ * `git config name value`: plain set fails with exit 5 ("cannot overwrite
+ * multiple values with a single value") when the cache already has more
+ * than one `remote.origin.fetch` entry — which can happen with caches
+ * produced by `git clone --mirror` or hand-edited configs. That failure
+ * would break the very `registry update` path this fix exists to rescue.
+ *
+ * Net behavior: after this call, the cache has exactly one fetch refspec,
+ * `BARE_FETCH_REFSPEC`. We intentionally overwrite broader refspecs too
+ * (e.g. mirror's `+refs/*:refs/*`); skilltree exclusively manages the
+ * cache directory, so narrowing to heads-only is the canonical state.
+ *
+ * Idempotent: rewriting the same value is a no-op on disk semantics and
+ * cheap enough to run on every fetch. See issue #55.
+ */
+async function ensureBareFetchRefspec(git: ReturnType<typeof simpleGit>): Promise<void> {
+	await git.raw(["config", "--replace-all", "remote.origin.fetch", BARE_FETCH_REFSPEC]);
+}
+
+/**
  * Clone a bare repo if it doesn't exist, or fetch if it does.
  * If the directory exists but is not a valid bare repo (e.g., empty dir
  * from a failed previous clone), it is removed and re-cloned. If the
@@ -164,7 +199,36 @@ export async function cloneOrFetchBare(repoUrl: string, targetDir: string): Prom
 					if (await isOriginUrlDrifted(git, repoUrl)) {
 						await rm(targetDir, { recursive: true, force: true });
 					} else {
-						await git.fetch(["--tags", "--prune"]);
+						// Backfill the refspec on caches produced by older
+						// skilltree builds before fetching — see issue #55.
+						await ensureBareFetchRefspec(git);
+						// Two-fetch dance to keep branch-vs-tag pruning
+						// asymmetric — both are required, and `--prune` /
+						// `--prune-tags` flags on a single invocation cannot
+						// express the split:
+						//
+						// 1) Branches (no prune): with our configured refspec
+						//    `+refs/heads/*:refs/heads/*`, a `--prune` would
+						//    delete local `refs/heads/<branch>` whenever the
+						//    upstream removed or renamed the branch. Tagless
+						//    dep resolution reads
+						//    `getCommitSha(cache, getDefaultBranch(cache))`
+						//    — pruning the cached default branch under a
+						//    rename would turn that into a hard error
+						//    instead of returning the last-known commit.
+						// 2) Tags (prune): a maintainer revoking a tag (e.g.
+						//    pointing at a leaked-credential or malicious
+						//    commit) MUST propagate to consumers. Without
+						//    pruning, `resolveOneRepo` in `src/core/graph.ts`
+						//    keeps resolving the dead tag against the cached
+						//    commit forever.
+						//
+						// The explicit `+refs/tags/*:refs/tags/*` on the
+						// second call overrides the configured branch
+						// refspec for that invocation, so `--prune` is
+						// scoped to tags only.
+						await git.fetch(["--tags"]);
+						await git.fetch(["--prune", "origin", "+refs/tags/*:refs/tags/*"]);
 						return;
 					}
 				}
@@ -179,7 +243,16 @@ export async function cloneOrFetchBare(repoUrl: string, targetDir: string): Prom
 	}
 	await mkdir(targetDir, { recursive: true });
 	const gitUrl = toGitCloneUrl(repoUrl);
-	await simpleGit().clone(gitUrl, targetDir, ["--bare"]);
+	// `-o origin` locks the remote name regardless of the user's
+	// `clone.defaultRemoteName` git config — otherwise users who've set
+	// that globally (e.g. to "upstream") would get a cache whose remote
+	// has a non-`origin` name, breaking `ensureBareFetchRefspec` (which
+	// writes `remote.origin.fetch`), the drift check (which reads
+	// `remote.origin.url`), and the tag-pruning fetch below (which
+	// references `origin` explicitly).
+	await simpleGit().clone(gitUrl, targetDir, ["--bare", "-o", "origin"]);
+	// Fresh clones need the refspec too — `git clone --bare` doesn't set one.
+	await ensureBareFetchRefspec(simpleGit(targetDir));
 }
 
 /**

--- a/tests/core/git.test.ts
+++ b/tests/core/git.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import {
+	cloneOrFetchBare,
 	ensureCached,
 	getCommitSha,
 	getDefaultBranch,
@@ -175,5 +176,215 @@ describe("git operations with local bare repo", () => {
 
 		const branch = await getDefaultBranch(bareDir);
 		expect(["main", "master"]).toContain(branch);
+	});
+});
+
+describe("cloneOrFetchBare", () => {
+	// Regression: issue #55 — bare clones produced by `git clone --bare` have no
+	// remote.origin.fetch refspec. A subsequent `git fetch --tags --prune`
+	// updates tags but leaves refs/heads/* frozen at clone time, so new commits
+	// on the default branch are silently missed.
+	test("picks up new commits on the default branch on re-fetch (issue #55)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "src-repo", [{ path: "skills/a", name: "a" }]);
+		const bareDir = join(dir, "bare-cache");
+
+		// First call: clones from scratch.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+		const branch = await getDefaultBranch(bareDir);
+		const initialSha = await getCommitSha(bareDir, branch);
+
+		// Advance the source by one commit on the default branch.
+		const srcGit = simpleGit(repoDir);
+		await writeFile(join(repoDir, "newfile.txt"), "x");
+		await srcGit.add(".");
+		await srcGit.commit("second");
+		const newSrcSha = (await srcGit.revparse(["HEAD"])).trim();
+		expect(newSrcSha).not.toBe(initialSha);
+
+		// Second call: must fetch the new commit into the bare clone's
+		// refs/heads/<branch>, not just resolve it into FETCH_HEAD.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+		const updatedSha = await getCommitSha(bareDir, branch);
+
+		expect(updatedSha).toBe(newSrcSha);
+	});
+
+	// Existing users (pre-fix) have stale caches with no refspec configured.
+	// The fix has to be self-healing: when cloneOrFetchBare runs against such a
+	// cache, it must backfill the refspec AND pull in the commits the cache
+	// missed while the bug was live. Re-cloning would be slow for large repos
+	// and would discard reflog/objects unnecessarily.
+	test("self-heals a pre-existing bare clone that has no fetch refspec (issue #55)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "src-repo", [{ path: "skills/a", name: "a" }]);
+		const bareDir = join(dir, "bare-cache");
+
+		// Simulate a cache produced by the old (buggy) code: a plain
+		// `git clone --bare` with no refspec configured.
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+		const bareGit = simpleGit(bareDir);
+		// Sanity check: refspec is unset, mirroring the on-disk state of
+		// every cache produced by skilltree <= 0.25.1.
+		let refspec = "";
+		try {
+			refspec = (await bareGit.raw(["config", "--get", "remote.origin.fetch"])).trim();
+		} catch {
+			// `git config --get` exits 1 when the key is missing.
+		}
+		expect(refspec).toBe("");
+
+		const branch = await getDefaultBranch(bareDir);
+		const initialSha = await getCommitSha(bareDir, branch);
+
+		// Advance the source.
+		const srcGit = simpleGit(repoDir);
+		await writeFile(join(repoDir, "newfile.txt"), "x");
+		await srcGit.add(".");
+		await srcGit.commit("second");
+		const newSrcSha = (await srcGit.revparse(["HEAD"])).trim();
+		expect(newSrcSha).not.toBe(initialSha);
+
+		// cloneOrFetchBare should heal the stale cache: install the refspec
+		// and fetch the missed commit on the same invocation.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+
+		const healedRefspec = (await bareGit.raw(["config", "--get", "remote.origin.fetch"])).trim();
+		expect(healedRefspec).toBe("+refs/heads/*:refs/heads/*");
+
+		const updatedSha = await getCommitSha(bareDir, branch);
+		expect(updatedSha).toBe(newSrcSha);
+	});
+
+	// Regression for round-1 hypothesis H1: a cache that already has *multiple*
+	// remote.origin.fetch entries (e.g. produced by `git clone --mirror`, or
+	// hand-edited by a user) would make a plain `git config <name> <value>`
+	// exit 5 with "cannot overwrite multiple values with a single value",
+	// breaking the self-healing path. ensureBareFetchRefspec must collapse all
+	// existing values to the single canonical one.
+	test("self-heals a cache that has MULTIPLE pre-existing fetch refspecs (H1)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "src-repo", [{ path: "skills/a", name: "a" }]);
+		const bareDir = join(dir, "bare-cache");
+
+		// Simulate a cache produced by an older `--mirror` setup or a manual
+		// `git config --add`: two distinct fetch refspecs configured.
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+		const bareGit = simpleGit(bareDir);
+		await bareGit.raw(["config", "--add", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"]);
+		await bareGit.raw(["config", "--add", "remote.origin.fetch", "+refs/tags/*:refs/tags/*"]);
+
+		// Sanity: two values present.
+		const before = (await bareGit.raw(["config", "--get-all", "remote.origin.fetch"])).trim();
+		expect(before.split("\n").length).toBe(2);
+
+		// Must not throw — the fix uses --replace-all.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+
+		// After healing, exactly one canonical refspec remains.
+		const after = (await bareGit.raw(["config", "--get-all", "remote.origin.fetch"])).trim();
+		expect(after).toBe("+refs/heads/*:refs/heads/*");
+	});
+
+	// Regression for round-1 hypothesis H2: with the new refspec installed,
+	// `git fetch --prune` would delete local refs/heads/<branch> whenever the
+	// upstream removed/renamed the branch. Tagless dep resolution in
+	// src/core/graph.ts reads getCommitSha(cache, getDefaultBranch(cache)),
+	// so pruning the cached default branch under an upstream rename turns
+	// that into a hard failure instead of resolving to the last-known commit.
+	// cloneOrFetchBare must NOT prune.
+	test("preserves locally-cached branches that upstream has deleted (H2)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "src-repo", [{ path: "skills/a", name: "a" }]);
+		const bareDir = join(dir, "bare-cache");
+
+		// First, clone the cache while a side branch exists upstream.
+		const srcGit = simpleGit(repoDir);
+		await srcGit.checkoutLocalBranch("side-branch");
+		await writeFile(join(repoDir, "side.txt"), "x");
+		await srcGit.add(".");
+		await srcGit.commit("side commit");
+		const defaultBranch = (await srcGit.raw(["symbolic-ref", "--short", "HEAD"])).trim();
+		// Return upstream to its default branch.
+		await srcGit.checkout(defaultBranch === "side-branch" ? "main" : defaultBranch);
+
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+
+		// Cache has side-branch right after the initial clone.
+		const sideShaInitial = await getCommitSha(bareDir, "side-branch");
+		expect(sideShaInitial).toMatch(/^[a-f0-9]{40}$/);
+
+		// Upstream deletes side-branch.
+		await srcGit.deleteLocalBranch("side-branch", true);
+
+		// Re-fetch. With --prune, side-branch would be deleted locally.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+
+		// The cached branch must still resolve — this is the data point
+		// tagless resolution in src/core/graph.ts depends on for repos
+		// whose default branch has been renamed upstream.
+		const sideShaAfter = await getCommitSha(bareDir, "side-branch");
+		expect(sideShaAfter).toBe(sideShaInitial);
+	});
+
+	// Regression for round-2 hypothesis H2: dropping `--prune` outright would
+	// be wrong in the other direction — upstream-revoked tags must propagate to
+	// the cache so `resolveOneRepo` in src/core/graph.ts doesn't keep resolving
+	// a revoked tag (e.g. a maintainer's emergency tag deletion pointing at a
+	// vulnerable commit). The fix uses `--prune-tags` which prunes tags but
+	// leaves branches alone.
+	test("prunes upstream-revoked tags from the cache (round-2 H2)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"src-repo",
+			[{ path: "skills/a", name: "a" }],
+			"v1.0.0",
+		);
+		const bareDir = join(dir, "bare-cache");
+
+		// Initial clone — cache mirrors upstream's tags.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+		expect(await listTags(bareDir)).toContain("v1.0.0");
+
+		// Upstream revokes v1.0.0 (e.g. emergency tag deletion).
+		const srcGit = simpleGit(repoDir);
+		await srcGit.raw(["tag", "-d", "v1.0.0"]);
+
+		// Re-fetch. The revoked tag must NOT linger in the cache.
+		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+		expect(await listTags(bareDir)).not.toContain("v1.0.0");
+	});
+
+	// Regression for round-3 hypothesis H3: when a user has set
+	// `clone.defaultRemoteName=upstream` (or any non-default value) in their
+	// global gitconfig, `git clone --bare` honors that and names the remote
+	// `upstream` instead of `origin`. Without `-o origin`, every other call
+	// in cloneOrFetchBare that hardcodes `origin` (ensureBareFetchRefspec
+	// writing `remote.origin.fetch`, drift check reading `remote.origin.url`,
+	// tag-prune fetch referencing `origin` explicitly) breaks.
+	test("honors -o origin regardless of clone.defaultRemoteName (round-3 H3)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "src-repo", [{ path: "skills/a", name: "a" }]);
+		const bareDir = join(dir, "bare-cache");
+
+		// Inject `clone.defaultRemoteName=upstream` into a scratch global
+		// gitconfig and point this process at it. cloneOrFetchBare spawns
+		// `git` via simple-git, which inherits this env — so the spawn sees
+		// the hostile config. If the fix is in place (`-o origin` on the
+		// clone), the cache's remote name MUST still be `origin`.
+		const hostileConfig = join(dir, "hostile-gitconfig");
+		await writeFile(hostileConfig, "[clone]\n  defaultRemoteName = upstream\n");
+		const savedEnv = process.env.GIT_CONFIG_GLOBAL;
+		process.env.GIT_CONFIG_GLOBAL = hostileConfig;
+		try {
+			await cloneOrFetchBare(`file://${repoDir}`, bareDir);
+		} finally {
+			if (savedEnv === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+			else process.env.GIT_CONFIG_GLOBAL = savedEnv;
+		}
+
+		const remotes = (await simpleGit(bareDir).raw(["remote"])).trim();
+		expect(remotes).toBe("origin");
 	});
 });

--- a/tests/core/git.test.ts
+++ b/tests/core/git.test.ts
@@ -300,13 +300,16 @@ describe("cloneOrFetchBare", () => {
 
 		// First, clone the cache while a side branch exists upstream.
 		const srcGit = simpleGit(repoDir);
+		// Capture the default branch BEFORE creating side-branch — must work
+		// regardless of `init.defaultBranch` (CI runners often default to
+		// `master` while modern local installs default to `main`).
+		const defaultBranch = (await srcGit.raw(["symbolic-ref", "--short", "HEAD"])).trim();
 		await srcGit.checkoutLocalBranch("side-branch");
 		await writeFile(join(repoDir, "side.txt"), "x");
 		await srcGit.add(".");
 		await srcGit.commit("side commit");
-		const defaultBranch = (await srcGit.raw(["symbolic-ref", "--short", "HEAD"])).trim();
 		// Return upstream to its default branch.
-		await srcGit.checkout(defaultBranch === "side-branch" ? "main" : defaultBranch);
+		await srcGit.checkout(defaultBranch);
 
 		await cloneOrFetchBare(`file://${repoDir}`, bareDir);
 


### PR DESCRIPTION
## Summary

Fixes #55. `skilltree registry update` silently missed commits pushed to a registry repo's default branch after the initial `registry add` because `git clone --bare` deliberately omits `remote.origin.fetch`, leaving the subsequent `git fetch --tags --prune` to resolve only `FETCH_HEAD` and never update `refs/heads/*`.

The fix in `src/core/git.ts` installs the missing refspec on every cache (fresh + backfill for existing) and reshapes the fetch flow so that:

- **Branches mirror correctly** — `+refs/heads/*:refs/heads/*` makes the bare cache pick up new commits and new branches.
- **Branches survive upstream deletes** — no `--prune` on the branch fetch, because tagless dep resolution reads `getCommitSha(cache, getDefaultBranch(cache))` and would hard-fail if upstream renamed the default branch and we pruned the local copy.
- **Revoked tags propagate** — a separate `git fetch --prune origin "+refs/tags/*:refs/tags/*"` prunes upstream-deleted tags only, so a maintainer revoking a security-tagged release can't keep being resolved against the cached commit. The explicit refspec scopes `--prune` to tags; verified empirically that no single-fetch invocation can express this asymmetry safely.
- **Multi-value configs heal** — `git config --replace-all` so caches with multiple existing `remote.origin.fetch` entries (mirror clones, hand edits) don't error with "cannot overwrite multiple values".
- **`clone.defaultRemoteName` users don't break** — `-o origin` on the clone locks the remote name regardless of the user's global gitconfig.

Existing users heal automatically on their next `registry update`: the refspec backfill happens before the fetch, so the same invocation that installs the fix also catches up on missed commits/tags. No re-clone unless a cache predates `-o origin` and was created under a non-default remote name.

The diff was refined through four rounds of hypothesis-driven review (TDD style). Each round verified four concrete failure modes with independent agents; every CONFIRMED hypothesis became a test + fix pair.

## Test plan

- [x] `bun test tests/core/git.test.ts` — 19 tests, including 6 regression tests for issue #55 + each round-N CONFIRMED hypothesis
- [x] `bun test` — full suite, 1083 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only the pre-existing `parseSources` complexity warning, unrelated)
- [x] Manually reproduced the original bug (HEAD-only fetch leaves `refs/heads/main` stale) and confirmed the fix makes the new-commits-on-branch test fail without it and pass with it.
- [x] Verified each regression test catches its regression by reverting the corresponding fix and watching the test fail.
- [x] Verified Bun isolates `process.env` across test files so the `GIT_CONFIG_GLOBAL` mutation in the H3 test can't leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)