### PR TITLE
feat(scan): user-extensible ignore list via scan.ignore

### DIFF
--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -61,6 +61,11 @@ dev-dependencies:
 
   my-experimental-skill:
     local: ./skills/experimental
+
+# Optional: extend `skilltree scan`'s ignore list. See "Ignore List" below.
+scan:
+  ignore:
+    - my-internal-command
 ```
 
 **Fields per dependency entry:**
@@ -266,6 +271,29 @@ If any errors were collected, block install and report all of them together.
 | Quoted skill | `[delimiters]([name])[delimiters]\s+skill` | `\`python-coding\` skill`, `"my-style" skill` |
 
 Name validation: >= 2 chars, lowercase alphanumeric with hyphens.
+
+### Ignore List (Builtin + User-Extensible)
+
+The scanner skips two sets of names rather than reporting them as undeclared:
+
+1. **Built-in harness commands** — Claude Code's slash commands (`/loop`, `/simplify`, `/help`, ...) ship with the harness, are not packaged as registry skills, and cannot be declared in `dependencies:`. Maintained as `BUILTIN_HARNESS_COMMANDS` in `src/core/scanner.ts`. Match is exact — `loop` is filtered, `loop-runner` is not.
+2. **User-supplied extras** — names listed under `scan.ignore` in `skilltree.yml` (project-scoped) and/or `~/.skilltree/global.yaml` (user-scoped). Same exact-match semantics. The scanner unions both manifests with the built-in set before flagging undeclared references.
+
+```yaml
+# skilltree.yml — project-scoped ignores
+scan:
+  ignore:
+    - my-internal-command   # not a registry skill, intentionally undeclared
+    - prototype-skill
+```
+
+The same list is honored by `--llm` (LLM deep scan), so the two stages don't disagree about which names need declaring.
+
+Use this when:
+- Anthropic adds a new built-in slash command before skilltree's built-in list catches up.
+- You reference internal slash commands or skills you intentionally don't declare.
+
+Don't use this to silence real undeclared dependencies — declare them with `skilltree add` instead.
 
 ### LLM Deep Scan (optional, `--llm`)
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,6 +15,22 @@ import { type LocalEntry, scanLocalRepo } from "../core/repo-scanner.js";
 import { dim, pluralize, success, warn } from "../core/ui.js";
 import type { Dependency, LocalDependency, Manifest } from "../types.js";
 
+/**
+ * Trailing comment hint about the optional `scan.ignore` field. Surfaced in
+ * the generated manifest so users discover the field without consulting the
+ * docs. Keeps the active YAML minimal (no empty `scan:` block) while still
+ * advertising the knob. Issue #52.
+ */
+const SCAN_HINT_COMMENT = `
+# Optional: extend \`skilltree scan\`'s ignore list with names you intentionally
+# don't declare as dependencies (e.g., internal slash commands not in any
+# registry). Exact match — no prefix matching. See docs/specs/reference.md.
+#
+# scan:
+#   ignore:
+#     - my-internal-command
+`;
+
 export interface InitOptions {
 	global?: boolean;
 	homeDir?: string; // Override home directory for agent detection (testing)
@@ -81,7 +97,7 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 		"dev-dependencies": {},
 	};
 
-	await writeFile(manifestPath, serializeManifest(manifest), "utf-8");
+	await writeFile(manifestPath, serializeManifest(manifest) + SCAN_HINT_COMMENT, "utf-8");
 	success(`Created ${MANIFEST_NEW}`);
 
 	// Update .gitignore for all targets. Resolve through the agent registry

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { entityNameFromPath, mdFileType } from "../core/entity-type.js";
+import { readGlobalManifest, readManifest } from "../core/manifest.js";
 import type { ScanResult } from "../core/scanner.js";
 import { applyToFrontmatter, scanFiles, scanFileWithLlm } from "../core/scanner.js";
 import { dim, pc, success } from "../core/ui.js";
@@ -53,14 +54,41 @@ export function classifyEntityFile(
 
 async function buildKnownEntities(
 	files: string[],
+	extraIgnores: ReadonlySet<string>,
 ): Promise<Array<{ name: string; type: EntityType }>> {
-	const results = await scanFiles(files);
+	const results = await scanFiles(files, { extraIgnores });
 	const entities: Array<{ name: string; type: EntityType }> = [];
 	for (const result of results) {
 		const classified = classifyEntityFile(result.file, result.name);
 		if (classified) entities.push(classified);
 	}
 	return entities;
+}
+
+/**
+ * Collect names the scanner should treat as already-known, beyond the
+ * hardcoded `BUILTIN_HARNESS_COMMANDS` set. Unions the project manifest's
+ * `scan.ignore` with the global manifest's, ignoring missing manifests
+ * silently — both are optional configs. Issue #52.
+ */
+async function loadExtraIgnores(): Promise<Set<string>> {
+	const ignores = new Set<string>();
+
+	try {
+		const project = await readManifest(process.cwd());
+		for (const name of project.scan?.ignore ?? []) ignores.add(name);
+	} catch {
+		// No project manifest is fine — scan works without one.
+	}
+
+	try {
+		const global = await readGlobalManifest();
+		for (const name of global.scan?.ignore ?? []) ignores.add(name);
+	} catch {
+		// No global manifest is fine — global config is opt-in.
+	}
+
+	return ignores;
 }
 
 export async function scanCommand(paths: string[], options: ScanOptions): Promise<void> {
@@ -75,7 +103,10 @@ export async function scanCommand(paths: string[], options: ScanOptions): Promis
 		return;
 	}
 
-	const results = options.llm ? await runLlmScan(allFiles) : await scanFiles(allFiles);
+	const extraIgnores = await loadExtraIgnores();
+	const results = options.llm
+		? await runLlmScan(allFiles, extraIgnores)
+		: await scanFiles(allFiles, { extraIgnores });
 
 	if (options.json) {
 		console.log(JSON.stringify(results, null, 2));
@@ -89,12 +120,15 @@ export async function scanCommand(paths: string[], options: ScanOptions): Promis
 	}
 }
 
-async function runLlmScan(allFiles: string[]): Promise<ScanResult[]> {
+async function runLlmScan(
+	allFiles: string[],
+	extraIgnores: ReadonlySet<string>,
+): Promise<ScanResult[]> {
 	console.log(dim("Running LLM-assisted scan (this may take a moment)...\n"));
-	const knownEntities = await buildKnownEntities(allFiles);
+	const knownEntities = await buildKnownEntities(allFiles, extraIgnores);
 	const results: ScanResult[] = [];
 	for (const file of allFiles) {
-		const result = await scanFileWithLlm(file, knownEntities);
+		const result = await scanFileWithLlm(file, knownEntities, { extraIgnores });
 		if (result) results.push(result);
 	}
 	return results;

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import YAML from "yaml";
-import type { Dependency, EntityType, LocalDependency, Manifest } from "../types.js";
+import type { Dependency, EntityType, LocalDependency, Manifest, ScanConfig } from "../types.js";
 import { isSourceDependency } from "../types.js";
 import { resolveGlobalTarget, resolveTarget } from "./agents.js";
 import { MANIFEST_NEW, resolveGlobalManifestPath, resolveManifestPath } from "./filenames.js";
@@ -52,7 +52,42 @@ export function parseManifest(content: string): Manifest {
 		manifest["dev-dependencies"] = raw["dev-dependencies"] as Record<string, Dependency>;
 	}
 
+	if (raw.scan !== undefined) {
+		manifest.scan = parseScanConfig(raw.scan);
+	}
+
 	return manifest;
+}
+
+/**
+ * Parse the `scan:` block. Authoring-only config (`skilltree scan`) — never
+ * consulted in the install path. Strict on shape so a typo doesn't silently
+ * disable the ignore list: matches the strictness `sources:` already applies.
+ * Issue #52.
+ */
+function parseScanConfig(raw: unknown): ScanConfig {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		const got = raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw;
+		throw new Error(`Invalid manifest: \`scan\` must be a mapping, got ${got}.`);
+	}
+	const obj = raw as Record<string, unknown>;
+	const scan: ScanConfig = {};
+	if (obj.ignore !== undefined) {
+		if (!Array.isArray(obj.ignore)) {
+			throw new Error(
+				`Invalid manifest: \`scan.ignore\` must be a list of strings, got ${typeof obj.ignore}.`,
+			);
+		}
+		for (const v of obj.ignore) {
+			if (typeof v !== "string") {
+				throw new Error(
+					`Invalid manifest: \`scan.ignore\` entries must be strings, got ${v === null ? "null" : typeof v}.`,
+				);
+			}
+		}
+		scan.ignore = obj.ignore as string[];
+	}
+	return scan;
 }
 
 /**

--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -157,17 +157,33 @@ export interface ScanResult {
 }
 
 /**
+ * Caller-supplied options for a scan. `extraIgnores` is a project- and/or
+ * user-scoped extension of `BUILTIN_HARNESS_COMMANDS` — typically loaded from
+ * `skilltree.yml`'s `scan.ignore` field plus the global manifest. Exact-match
+ * semantics carry over from the builtin set (issue #52).
+ */
+export interface ScanOptions {
+	extraIgnores?: ReadonlySet<string>;
+}
+
+/**
  * Whether a regex-captured token survives the post-match filters and counts as
  * a real entity reference. Drops sub-minimum-length tokens, self-references,
- * single-word English stopwords ("companion skill"), and Claude Code's
- * built-in slash commands (issue #43). Hyphenated tokens bypass the stopword
- * check since real skill IDs are conventionally hyphenated.
+ * single-word English stopwords ("companion skill"), Claude Code's built-in
+ * slash commands (issue #43), and any caller-supplied extras (issue #52).
+ * Hyphenated tokens bypass the stopword check since real skill IDs are
+ * conventionally hyphenated.
  */
-function isCandidateRef(depName: string, selfName: string): boolean {
+function isCandidateRef(
+	depName: string,
+	selfName: string,
+	extraIgnores?: ReadonlySet<string>,
+): boolean {
 	if (depName.length < MIN_NAME_LENGTH) return false;
 	if (depName === selfName) return false;
 	if (!depName.includes("-") && STOPWORDS.has(depName.toLowerCase())) return false;
 	if (BUILTIN_HARNESS_COMMANDS.has(depName)) return false;
+	if (extraIgnores?.has(depName)) return false;
 	return true;
 }
 
@@ -175,7 +191,7 @@ function isCandidateRef(depName: string, selfName: string): boolean {
  * Scan a single SKILL.md, agent .md, or command .md file for undeclared
  * dependencies.
  */
-export async function scanFile(filePath: string): Promise<ScanResult | null> {
+export async function scanFile(filePath: string, opts?: ScanOptions): Promise<ScanResult | null> {
 	const content = await readFile(filePath, "utf-8");
 	const frontmatter = parseFrontmatter(content);
 
@@ -205,7 +221,7 @@ export async function scanFile(filePath: string): Promise<ScanResult | null> {
 			const match = pattern.exec(body);
 			if (match === null) break;
 			const depName = match[1];
-			if (depName && isCandidateRef(depName, name)) {
+			if (depName && isCandidateRef(depName, name, opts?.extraIgnores)) {
 				detected.add(depName);
 			}
 		}
@@ -231,8 +247,9 @@ export async function scanFile(filePath: string): Promise<ScanResult | null> {
 export async function scanFileWithLlm(
 	filePath: string,
 	knownEntities: Array<{ name: string; type: string }>,
+	opts?: ScanOptions,
 ): Promise<ScanResult | null> {
-	const result = await scanFile(filePath);
+	const result = await scanFile(filePath, opts);
 	if (!result) return null;
 
 	const content = await readFile(filePath, "utf-8");
@@ -240,7 +257,14 @@ export async function scanFileWithLlm(
 
 	const declaredSet = new Set(result.declared);
 	const undeclaredSet = new Set(result.undeclared);
-	const llmNames = llmDeps.map((d) => d.name).filter((name) => !declaredSet.has(name));
+	// Apply the same ignore set to LLM suggestions so the two stages agree
+	// (issue #52). Without this, `--llm` could surface names that the regex
+	// stage was told to skip — exactly the kind of disagreement the user
+	// expects the config to silence.
+	const extraIgnores = opts?.extraIgnores;
+	const llmNames = llmDeps
+		.map((d) => d.name)
+		.filter((name) => !declaredSet.has(name) && !(extraIgnores?.has(name) ?? false));
 
 	// Confirmed: found by both regex and LLM (high confidence)
 	const confirmed = llmNames.filter((name) => undeclaredSet.has(name));
@@ -258,11 +282,11 @@ export async function scanFileWithLlm(
 /**
  * Scan multiple files and return results.
  */
-export async function scanFiles(filePaths: string[]): Promise<ScanResult[]> {
+export async function scanFiles(filePaths: string[], opts?: ScanOptions): Promise<ScanResult[]> {
 	const results: ScanResult[] = [];
 
 	for (const filePath of filePaths) {
-		const result = await scanFile(filePath);
+		const result = await scanFile(filePath, opts);
 		if (result) {
 			results.push(result);
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,20 @@ export interface LocalDependency {
 
 export type Dependency = RemoteDependency | SourceDependency | LocalDependency;
 
+/**
+ * Configuration for `skilltree scan`. Authoring-only — never consulted in the
+ * install path. See `docs/specs/reference.md` for full semantics. Issue #52.
+ */
+export interface ScanConfig {
+	/**
+	 * Additional names the scanner should treat as already-known (in addition
+	 * to the hardcoded `BUILTIN_HARNESS_COMMANDS` set). Exact match, no prefix
+	 * matching — `loop` does not match `loop-runner`. Use for internal slash
+	 * commands or skills that intentionally aren't declared as dependencies.
+	 */
+	ignore?: string[];
+}
+
 export interface Manifest {
 	name?: string;
 	install_path?: string; // Legacy — maps to dev_install_path
@@ -41,6 +55,7 @@ export interface Manifest {
 	sources?: Record<string, string>;
 	dependencies?: Record<string, Dependency>;
 	"dev-dependencies"?: Record<string, Dependency>;
+	scan?: ScanConfig; // Authoring-aid config; never used at install time. Issue #52.
 }
 
 export interface LockfileEntry {

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -33,6 +33,23 @@ describe("initCommand", () => {
 		expect(content).toContain("claude");
 	});
 
+	test("scaffolds a scan.ignore hint comment (issue #52)", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+		await initCommand(dir, { homeDir: fakeHome });
+
+		const content = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		// The hint advertises the field without activating it — keeps the
+		// generated YAML lean while making the knob discoverable.
+		expect(content).toContain("scan:");
+		expect(content).toContain("ignore:");
+		expect(content).toContain("my-internal-command");
+		// Hint is a YAML comment, so the parsed manifest should still have no
+		// `scan` field (i.e., commenting out, not activating).
+		expect(content).toMatch(/^#\s*scan:/m);
+	});
+
 	test("creates .gitignore with skill and agent entries", async () => {
 		const dir = await makeTempDir();
 		const fakeHome = join(dir, "empty-home");

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -194,6 +194,48 @@ describe("scanCommand", () => {
 		expect(logs.some((l) => l.includes("testing"))).toBe(true);
 	});
 
+	test("scan.ignore from skilltree.yml suppresses undeclared report (issue #52)", async () => {
+		const dir = await makeTempDir();
+		await createSkill(dir, "my-skill", [], "Use /my-internal-command and the /other-skill.");
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			[
+				"name: test-project",
+				"scan:",
+				"  ignore:",
+				"    - my-internal-command",
+				"dependencies: {}",
+				"",
+			].join("\n"),
+		);
+
+		let exitCode: number | undefined;
+		const originalExit = process.exit;
+		const originalCwd = process.cwd();
+		process.exit = ((code: number) => {
+			exitCode = code;
+			throw new Error(`exit ${code}`);
+		}) as typeof process.exit;
+		process.chdir(dir);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await scanCommand([join(dir, "my-skill")], { check: true });
+		} catch {
+			// Expected — mock throws to stop execution
+		} finally {
+			restore();
+			process.exit = originalExit;
+			process.chdir(originalCwd);
+		}
+
+		// other-skill is still undeclared and triggers exit 1
+		expect(exitCode).toBe(1);
+		const joined = logs.join("\n");
+		expect(joined).toContain("other-skill");
+		expect(joined).not.toContain("my-internal-command");
+	});
+
 	test("detects undeclared slash-command reference in a command file", async () => {
 		const dir = await makeTempDir();
 		const cmdDir = join(dir, "commands");

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -234,6 +234,60 @@ describe("scanCommand", () => {
 		const joined = logs.join("\n");
 		expect(joined).toContain("other-skill");
 		expect(joined).not.toContain("my-internal-command");
+	});
+
+	test("--llm path honors scan.ignore (issue #52)", async () => {
+		// Mock the LLM module so we don't need ANTHROPIC_API_KEY in CI. The mock
+		// returns both an ignored name and a real undeclared dep — the test
+		// proves the ignore set filters LLM suggestions just like it does regex
+		// matches, keeping the two stages in agreement. We preserve the rest of
+		// the real exports (notably `parseEntityList`) so other test files that
+		// share the module graph aren't affected.
+		const realLlm = await import("../../src/core/llm.js");
+		mock.module("../../src/core/llm.js", () => ({
+			...realLlm,
+			llmScanContent: async () => [
+				{ name: "my-internal-command", type: "command" },
+				{ name: "real-dep", type: "skill" },
+			],
+		}));
+
+		const dir = await makeTempDir();
+		await createSkill(dir, "my-skill", [], "Authoring body — content irrelevant under mock.");
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			[
+				"name: test-project",
+				"scan:",
+				"  ignore:",
+				"    - my-internal-command",
+				"dependencies: {}",
+				"",
+			].join("\n"),
+		);
+
+		const originalCwd = process.cwd();
+		process.chdir(dir);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await scanCommand([join(dir, "my-skill")], { llm: true, json: true });
+		} finally {
+			restore();
+			process.chdir(originalCwd);
+		}
+
+		// JSON output captures the merged result; the ignored name must not
+		// leak into either llmSuggestions or confirmed, while real-dep does.
+		const jsonLine = logs.find((l) => l.trim().startsWith("["));
+		expect(jsonLine).toBeDefined();
+		const results = JSON.parse(jsonLine ?? "[]") as Array<{
+			llmSuggestions?: string[];
+			confirmed?: string[];
+		}>;
+		const merged = results.flatMap((r) => [...(r.llmSuggestions ?? []), ...(r.confirmed ?? [])]);
+		expect(merged).not.toContain("my-internal-command");
+		expect(merged).toContain("real-dep");
 	});
 
 	test("detects undeclared slash-command reference in a command file", async () => {

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -105,6 +105,46 @@ dependencies:
 		expect((dep as { name?: string }).name).toBe("workflow-builder");
 		expect((dep as { type?: string }).type).toBe("agent");
 	});
+
+	// Issue #52: user-extensible ignore list for `skilltree scan`.
+	test("parses scan.ignore as a list of strings", () => {
+		const yaml = `
+scan:
+  ignore:
+    - my-internal-command
+    - other-skill
+dependencies: {}
+`;
+		const manifest = parseManifest(yaml);
+		expect(manifest.scan?.ignore).toEqual(["my-internal-command", "other-skill"]);
+	});
+
+	test("scan section is optional", () => {
+		const manifest = parseManifest("dependencies: {}\n");
+		expect(manifest.scan).toBeUndefined();
+	});
+
+	test("scan.ignore defaults to undefined when scan present but empty", () => {
+		const manifest = parseManifest("scan: {}\ndependencies: {}\n");
+		expect(manifest.scan).toBeDefined();
+		expect(manifest.scan?.ignore).toBeUndefined();
+	});
+
+	test("rejects scan when not a mapping", () => {
+		expect(() => parseManifest("scan: [foo, bar]\ndependencies: {}\n")).toThrow(/scan/);
+	});
+
+	test("rejects scan.ignore when not a list", () => {
+		expect(() => parseManifest("scan:\n  ignore: not-a-list\ndependencies: {}\n")).toThrow(
+			/scan\.ignore/,
+		);
+	});
+
+	test("rejects non-string entries in scan.ignore", () => {
+		expect(() => parseManifest("scan:\n  ignore:\n    - 42\ndependencies: {}\n")).toThrow(
+			/scan\.ignore/,
+		);
+	});
 });
 
 describe("serializeManifest: install_targets", () => {

--- a/tests/core/scanner.test.ts
+++ b/tests/core/scanner.test.ts
@@ -504,6 +504,37 @@ describe("scanFile — slash-command references", () => {
 		}
 	});
 
+	test("respects extraIgnores from caller (issue #52)", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(
+			dir,
+			"my-cmd",
+			"Run /my-internal-command and /loop and /unrelated.",
+		);
+
+		const result = await scanFile(filePath, { extraIgnores: new Set(["my-internal-command"]) });
+		// builtin /loop still filtered
+		expect(result?.detected).not.toContain("loop");
+		// user-extended ignore filtered
+		expect(result?.detected).not.toContain("my-internal-command");
+		expect(result?.undeclared).not.toContain("my-internal-command");
+		// unrelated names still reported
+		expect(result?.undeclared).toContain("unrelated");
+	});
+
+	test("extraIgnores is exact-match — prefix hits are not filtered (issue #52)", async () => {
+		const dir = await makeTempDir();
+		const filePath = await writeCommand(
+			dir,
+			"my-cmd",
+			"Use /my-internal-command and also /my-internal-command-extra.",
+		);
+
+		const result = await scanFile(filePath, { extraIgnores: new Set(["my-internal-command"]) });
+		expect(result?.detected).not.toContain("my-internal-command");
+		expect(result?.detected).toContain("my-internal-command-extra");
+	});
+
 	test("filters self-reference by filename when no name: in frontmatter", async () => {
 		const dir = await makeTempDir();
 		const cmdDir = join(dir, "commands");


### PR DESCRIPTION
## Why

`skilltree scan` ships with a hardcoded `BUILTIN_HARNESS_COMMANDS` set so Claude Code's built-in slash commands (`/loop`, `/simplify`, ...) don't get flagged as undeclared. That list lags Anthropic's releases, and there's no escape hatch for users referencing internal slash commands or prototype skills they intentionally don't declare — `--no-verify` was the only out.

This adds the config-driven ignore list called out as Option 2 in #43.

Closes #52

## What changed

- **`src/types.ts`** — New `ScanConfig` interface; `Manifest.scan?: ScanConfig`.
- **`src/core/manifest.ts`** — `parseManifest` reads the `scan:` block; `parseScanConfig` enforces shape with strict errors mirroring `parseSources`.
- **`src/core/scanner.ts`** — `scanFile` / `scanFiles` / `scanFileWithLlm` accept a `ScanOptions` with `extraIgnores`. `isCandidateRef` checks it after `BUILTIN_HARNESS_COMMANDS` (same exact-match semantics).
- **`src/commands/scan.ts`** — New `loadExtraIgnores()` reads project (`process.cwd()`) and global (`~/.skilltree/global.yaml`) manifests, unions their `scan.ignore`, and passes the set into both the regex and `--llm` paths so the two stages agree.
- **`src/commands/init.ts`** — `skilltree init` appends a commented hint about `scan.ignore` to the generated manifest. Field is advertised without being activated, keeping the YAML lean.
- **`docs/specs/reference.md`** — New "Ignore List" subsection documenting builtin + user-extensible behavior; `scan:` example in the manifest schema.

## How tested

- New unit tests for `parseManifest` (6 cases): parses valid `scan.ignore`, accepts empty/absent `scan`, rejects non-mapping `scan`, rejects non-list `scan.ignore`, rejects non-string entries.
- New scanner tests (2 cases): `extraIgnores` filters the named ref; exact-match — `loop` does not filter `loop-runner`.
- New `scanCommand` test: a `skilltree.yml` with `scan.ignore: [my-internal-command]` silences that name but still surfaces a separate undeclared `other-skill` and exits 1 under `--check`.
- New `initCommand` test: generated manifest contains the `scan.ignore` hint as a YAML comment (parsed manifest still has no `scan` field).
- Full suite: 1087 pass, 0 fail. Lint + typecheck clean.

## Risk & rollback

Low. New optional field on the manifest with strict shape validation; scanner behavior is unchanged when `scan.ignore` is absent. Authoring-only — never consulted in the install path. Revert via `git revert <sha>`.