### PR TITLE
feat(cli): add `remove -D, --dev` + tighten `teach --agent <agent>` (#23)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -125,12 +125,14 @@ export function buildProgram(): Command {
 		.option("--keep-files", "Leave installed files in place")
 		.option("-n, --dry-run", "Preview the removal without changing anything")
 		.option("-g, --global", "Remove from global dependencies")
+		.option("-D, --dev", "Only remove from dev-dependencies (mirrors `add -D`)")
 		.action(async (name: string, opts) => {
 			await removeCommand(name, process.cwd(), {
 				force: opts.force,
 				keepFiles: opts.keepFiles,
 				dryRun: opts.dryRun,
 				global: opts.global,
+				dev: opts.dev,
 			});
 		});
 
@@ -171,7 +173,7 @@ export function buildProgram(): Command {
 	program
 		.command("teach")
 		.description("Install the skilltree skill to all detected coding agents")
-		.option("--agent <name>", "Install to a specific agent only")
+		.option("--agent <agent>", "Install to a specific agent only")
 		.action(async (opts) => {
 			await teachCommand({ agent: opts.agent });
 		});

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -27,6 +27,14 @@ export interface RemoveOptions {
 	global?: boolean;
 	globalDir?: string; // test override
 	dryRun?: boolean;
+	/**
+	 * Scope the removal to `dev-dependencies` only. Without this, `remove`
+	 * searches both groups (the default). With it, a same-named entry in
+	 * `dependencies` is left intact; a name that lives only in `dependencies`
+	 * errors out. Incompatible with `--global` (global manifests have no
+	 * dev-deps).
+	 */
+	dev?: boolean;
 }
 
 export async function removeCommand(
@@ -36,6 +44,14 @@ export async function removeCommand(
 ): Promise<void> {
 	const globalDir = options.globalDir ?? getGlobalDir();
 	const isGlobal = !!options.global;
+	const devOnly = options.dev === true;
+
+	// Mutex: global manifests have no `dev-dependencies`, so `--dev --global`
+	// is meaningless. Reject explicitly rather than silently degrading to a
+	// "name not in manifest" error that would mislead the user about why.
+	if (devOnly && isGlobal) {
+		throw new Error("--dev is not compatible with --global (global manifests have no dev-deps).");
+	}
 
 	const manifest = await loadManifestOrThrow(dir, { global: isGlobal, globalDir });
 	// Validate first — match the install command's invariants so a malformed
@@ -45,7 +61,7 @@ export async function removeCommand(
 	if (!isGlobal) warnLegacyInstallPath(manifest);
 	const lockfile = isGlobal ? await readGlobalLockfile(globalDir) : await readLockfile(dir);
 
-	validateRemoveTarget(name, manifest, lockfile, isGlobal);
+	validateRemoveTarget(name, manifest, lockfile, isGlobal, devOnly);
 
 	if (options.dryRun) {
 		// In a preview we deliberately do NOT prompt for confirmation — there is
@@ -57,7 +73,7 @@ export async function removeCommand(
 	await confirmIfDependents(name, lockfile, options);
 
 	// Remove from manifest
-	removeFromManifest(name, manifest, isGlobal);
+	removeFromManifest(name, manifest, isGlobal, devOnly);
 
 	if (isGlobal) {
 		await writeGlobalManifest(manifest, globalDir);
@@ -147,10 +163,22 @@ function validateRemoveTarget(
 	},
 	lockfile: Lockfile | null,
 	isGlobal: boolean,
+	devOnly: boolean,
 ): void {
 	const inDeps = manifest.dependencies && name in manifest.dependencies;
 	const inDevDeps =
 		!isGlobal && manifest["dev-dependencies"] && name in manifest["dev-dependencies"];
+
+	// Scoped check: --dev cares ONLY about dev-dependencies. A prod-only entry
+	// must error here, not get silently skipped — otherwise the user typing
+	// `remove foo --dev` would see "successfully removed" output while foo is
+	// still in `dependencies`.
+	if (devOnly) {
+		if (!inDevDeps) {
+			throw new Error(`"${name}" is not in dev-dependencies.`);
+		}
+		return;
+	}
 
 	if (!inDeps && !inDevDeps) {
 		const manifestName = isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW;
@@ -188,8 +216,11 @@ function removeFromManifest(
 		"dev-dependencies"?: Record<string, unknown>;
 	},
 	isGlobal: boolean,
+	devOnly: boolean,
 ): void {
-	if (manifest.dependencies && name in manifest.dependencies) {
+	// `--dev` scopes deletion to dev-deps. Without it, both groups are cleared
+	// (legacy behavior: same name in both groups gets fully removed).
+	if (!devOnly && manifest.dependencies && name in manifest.dependencies) {
 		delete manifest.dependencies[name];
 	}
 	if (!isGlobal && manifest["dev-dependencies"] && name in manifest["dev-dependencies"]) {

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -118,6 +118,7 @@ Options:
   --keep-files   Leave installed files in place
   -n, --dry-run  Preview the removal without changing anything
   -g, --global   Remove from global dependencies
+  -D, --dev      Only remove from dev-dependencies (mirrors \`add -D\`)
   -h, --help     display help for command
 "
 `;
@@ -166,8 +167,8 @@ exports[`CLI help snapshots \`teach --help\` is stable 1`] = `
 Install the skilltree skill to all detected coding agents
 
 Options:
-  --agent <name>  Install to a specific agent only
-  -h, --help      display help for command
+  --agent <agent>  Install to a specific agent only
+  -h, --help       display help for command
 "
 `;
 

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -306,6 +306,51 @@ describe("removeCommand", () => {
 		}
 	});
 
+	describe("--dev flag", () => {
+		// `remove --dev` asserts intent: only proceed if the name lives in
+		// `dev-dependencies`. Mirrors `add -D` so scripts can be explicit about
+		// which group they target. The manifest validator forbids the same
+		// name in both groups, so --dev's value is the assertion, not
+		// disambiguation between groups.
+		test("removes a dev-dependency when --dev is set", async () => {
+			const dir = await setup();
+			await addCommand(
+				"dev-skill",
+				{ repo: "github.com/user/repo", path: "skills/dev-skill", dev: true },
+				dir,
+			);
+
+			await removeCommand("dev-skill", dir, { force: true, dev: true });
+
+			const manifest = await readManifest(dir);
+			expect(manifest["dev-dependencies"]?.["dev-skill"]).toBeUndefined();
+		});
+
+		test("errors when --dev is set but name is only in prod dependencies", async () => {
+			const dir = await setup();
+			await addCommand(
+				"prod-only",
+				{ repo: "github.com/user/repo", path: "skills/prod-only" },
+				dir,
+			);
+
+			await expect(removeCommand("prod-only", dir, { force: true, dev: true })).rejects.toThrow(
+				"not in dev-dependencies",
+			);
+
+			// And the prod entry is left untouched
+			const manifest = await readManifest(dir);
+			expect(manifest.dependencies?.["prod-only"]).toBeDefined();
+		});
+
+		test("errors when --dev is combined with --global (global has no dev-deps)", async () => {
+			const dir = await setup();
+			await expect(
+				removeCommand("anything", dir, { force: true, dev: true, global: true }),
+			).rejects.toThrow("--dev is not compatible with --global");
+		});
+	});
+
 	test("orphan cleanup removes installed files of orphans", async () => {
 		const dir = await setup();
 		await addCommand("parent", { repo: "github.com/user/repo", path: "skills/parent" }, dir);


### PR DESCRIPTION
## Summary

Non-breaking flag-parity fixes from #23:

- **`remove -D, --dev`** — mirrors `add -D`. Scopes the operation to `dev-dependencies`; errors when the name lives only in prod (so a script can be explicit about which group it targets). Rejects `--dev --global` since global manifests have no dev-deps.
- **`teach --agent <agent>`** — cosmetic rename of the variable label from `<name>` to `<agent>` so it matches the enum produced by `getKnownAgentNames()` in `AGENT_REGISTRY`.

## Deferred (with rationale in #23 thread)

- **`info --global`** — issue's premise is wrong. `info` reads registries (always user-global at `~/.skilltree/config.yaml`), not the manifest/lockfile. The existing parity test in `tests/cli/flag-parity.test.ts` already excludes `info` from `STATEFUL_COMMANDS` for this reason.
- **`update --frozen`** — requires re-resolving in memory without writing, then diffing against the existing lockfile. That's a real refactor of the install pipeline (`resolveAll` / `buildLockfile`), not flag wiring. Better as its own PR.

## Test Plan

- [x] Added 3 new tests under `removeCommand > --dev flag`: positive case, prod-only rejection, `--dev --global` mutex
- [x] CLI snapshot tests regenerated to cover the new flag + label rename
- [x] Full suite: 1091/1091 passing
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] CI checks pass