### PR TITLE
Carbon: publication-surface — publish: false, exclude, fallback chain, check lint (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,33 @@ skilltree add my-style --local ./skills/my-style
 skilltree install    # symlinks .claude/skills/my-style → ./skills/my-style
 ```
 
+### Publication Surface — `publish:` and `exclude:`
+
+When your repo is also a registry (other people install skills from it), `skilltree.yml` doubles as your **publication surface**: it tells the world which entities you offer and what's part of each one.
+
+```yaml
+dependencies:
+  python-coding:
+    local: ./skills/python-coding
+    type: skill
+    exclude:                       # trim noise from what consumers receive
+      - "experiments/"
+      - "*.scratch.md"
+
+  experimental-refactor:
+    local: ./skills/experimental-refactor
+    type: skill
+    publish: false                 # WIP — installs locally but hidden from consumers
+```
+
+- **`publish: false`** marks a local entity as not-ready-to-share. It still installs into your own `.claude/` (so you can dogfood it), but registry search, `vendor`, and any downstream `skilltree install` that would otherwise resolve it through your manifest skip it. The flag is only valid on local entries.
+- **`exclude:`** trims files from the entity when consumers install or vendor it. Gitignore-style globs, relative to the entity root.
+- **`.skilltreeignore`** (repo root): gitignore-style patterns that apply to every published entity. Useful for cross-cutting noise (`.DS_Store`, `*.log`).
+
+Run `skilltree check` to catch the asymmetric-publish footgun: a published entity that transitively depends on a `publish: false` same-repo entity will install fine for you but fail for consumers. The check reports the chain so the fix is obvious.
+
+This is **authoring intent, not access control** — anyone with git access to your repo can read every file regardless of these flags. They're about what your repo *offers*, not what it *protects*.
+
 ### Global Dependencies
 
 Skills you want available in every project without adding them to each `skilltree.yml`.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,6 +14,31 @@
 
 - [x] **Migration guide** — Documented in commands.md under `targets migrate`. → Fixed.
 
+## Carbon follow-ups (issue #63 / publication surface)
+
+- [ ] **Vendor + dev-dependencies — strict-spec interpretation.** Spec
+  PS20 says "vendor applies the visibility predicate." Strict reading
+  would also drop `dev-dependencies` from vendored output (the predicate
+  excludes them by definition). Phase 3 preserved today's behavior
+  (vendor copies both groups) and only filtered `publish: false`. Need
+  sir's call on whether to tighten. Probably needs a design pass first
+  to confirm vendor's audience (own-repo freeze vs distribution to
+  outside consumers).
+
+- [ ] **Consolidate `describeType(value)` helper.** The same
+  null/array/typeof pattern appears at `manifest.ts:70`, `parseSourceEntry:124`,
+  and the new `describeType` introduced in Carbon Phase 1. Reasonable
+  cleanup — extract to a shared internal helper in `core/types-utils.ts`
+  or similar.
+
+- [ ] **`!negation` patterns in `IgnoreMatcher`.** Phase 3 deliberately
+  skipped negation to keep the matcher minimal. Add if a real `exclude:`
+  or `.skilltreeignore` use case surfaces that needs to opt-back-in.
+
+- [ ] **Soft warning on `publish: false` in dev-dependencies.** Allowed
+  today (redundant — dev-deps are already hidden), but a `skilltree check`
+  hint might prevent confusion.
+
 ## Deferred from issue #23 (CLI flag consistency)
 
 The non-breaking subset of issue #23 shipped in PRs PM1–PM4. The items

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -14,6 +14,8 @@ Project Naming Theme: Elements
 
 - **Boron** (04/21/2026): Origin-manifest resolution for direct deps — `path:` optional when origin declares the name, redundancy/override warnings, `force_path` opt-out, `skilltree add --path` optional
 
+- **Carbon** (05/14/2026): Publication surface — `skilltree.yml` as registry-index fallback, `publish: false` for WIP local entities, `exclude:` + `.skilltreeignore` for file-level trim, unified visibility predicate across indexing/vendor/origin-manifest lookup, `check` lint for asymmetric publish state (resolves #63)
+
 ## Completed Projects
 
 (none)

--- a/docs/planning/carbon/PLAN.md
+++ b/docs/planning/carbon/PLAN.md
@@ -1,0 +1,108 @@
+# Carbon — Publication Surface
+
+Project-Type: production
+Sub-Project: Carbon (started 05/14/2026)
+
+Spec: [docs/specs/publication_surface.md](../../specs/publication_surface.md) (v1.0)
+
+Resolves issue #63 (closes on merge of final phase). Builds on Lithium (registries / `skilltree-index.yml`) and Boron (origin-manifest resolution).
+
+## Project shape
+
+One cohesive feature with five layered phases. Phase 1 lays the foundation (types + validation + the visibility predicate helper) without wiring it up yet — every subsequent phase plugs into that predicate at a specific consumer-facing path.
+
+```
+Phase 1: foundation
+  types + validateManifest + visibility predicate helper
+       │
+       ├──→ Phase 2: registry-scanner fallback + index filtering
+       │
+       ├──→ Phase 3: installer + vendor exclude / .skilltreeignore
+       │
+       ├──→ Phase 4: graph extension for downstream visibility
+       │
+       └──→ Phase 5: check lint for asymmetric publish state
+```
+
+After Phase 1 ships, Phases 2–5 are mostly independent and could be parallelized in principle, but we ship them sequentially for clean per-phase commits and reviewable diffs.
+
+## Phase 1: Foundation — types, validation, visibility predicate
+<!-- Spec: publication_surface.md PS1–PS5, PS27–PS28 -->
+
+Lay the foundation: schema fields, validation, and one helper that every subsequent phase calls. No use sites are wired up yet — Phase 1 produces dead code that gets activated in Phases 2–5.
+
+### Tasks
+- [ ] Add `publish?: boolean` and `exclude?: string[]` to the `Dependency` type in `src/types.ts` (and any mirrored types for local/remote variants). (PS3, PS6)
+- [ ] `parseManifest` / `serializeManifest` in `src/core/manifest.ts`: round-trip the two new fields. Preserve omission when the user didn't set them.
+- [ ] `validateManifest`: reject `publish:` or `exclude:` on remote entries (`repo:` / `source:` without local-source filesystem expansion). Type-check `publish` is boolean and `exclude` is `string[]`. Clear actionable error messages. (PS4, PS7, PS27, PS28)
+- [ ] New file `src/core/visibility.ts` with `isPubliclyVisible(entry: Dependency, group: "dependencies" | "dev-dependencies"): boolean`. Single source of truth. (PS1, PS2)
+- [ ] Tests (`tests/core/manifest-publish-exclude.test.ts`): round-trip; reject on remote entries; type errors. Parametrized.
+- [ ] Tests (`tests/core/visibility.test.ts`): predicate table covering all four combinations (group × publish flag) plus default (publish omitted).
+- [ ] No use sites changed yet — Phase 1 is foundation only.
+
+## Phase 2: Registry-scanner fallback + index filtering
+<!-- Spec: publication_surface.md PS12–PS14 -->
+
+Wire the visibility predicate into registry indexing and add the `skilltree.yml`-as-index fallback tier.
+
+### Tasks
+- [ ] `src/core/registry-scanner.ts`: insert tier 2 (manifest-derived) between curated `skilltree-index.yml` and the dynamic `git ls-tree` scan. Reads the repo's `skilltree.yml` at HEAD via `git show`, extracts `dependencies` `local:` entries, filters by visibility predicate. (PS12, PS13)
+- [ ] `src/core/registry-scanner.ts`: dynamic-scan tier (tier 3) also filters by visibility — but the predicate needs `skilltree.yml` to know which paths are `publish:false`. Pre-load the manifest once at scan start; for paths not in the manifest, treat as visible (no manifest entry = no signal, conservative).
+- [ ] `src/commands/registry.ts` (or wherever `registry index` lives): when generating `skilltree-index.yml`, skip entries with `publish: false`. (PS14)
+- [ ] Tests (`tests/core/registry-scanner-fallback.test.ts`): three-tier fallback ordering; manifest tier surfaces only visible entries; dynamic tier filters by manifest where available.
+- [ ] Tests (`tests/commands/registry-index-publish.test.ts`): `registry index` generation skips `publish:false`.
+- [ ] Update `docs/specs/registries.md` to document the fallback chain. (PS29)
+
+## Phase 3: Installer + vendor — exclude and .skilltreeignore
+<!-- Spec: publication_surface.md PS6–PS11, PS17, PS20–PS22 -->
+
+File-level trim. Introduces a glob-based ignore engine and wires it into both installer and vendor copy paths.
+
+### Tasks
+- [ ] New file `src/core/ignore.ts`: thin wrapper around a gitignore-style matcher. Accepts a list of patterns + a base path; returns a `shouldExclude(file: string): boolean` function. Composable across the two scopes. (PS9, PS11)
+- [ ] `src/core/manifest.ts` (or new helper): load `.skilltreeignore` from repo root if present; expose to installer/vendor.
+- [ ] `src/core/installer.ts`: when copying a local entity, build the combined matcher (entity-relative `exclude:` + repo-relative `.skilltreeignore`) and skip excluded files. (PS17)
+- [ ] `src/commands/vendor.ts`: apply visibility predicate to entity selection (skip `publish:false`); apply combined matcher when copying. (PS20, PS21)
+- [ ] Tests (`tests/core/ignore.test.ts`): parametrized — leading slash, trailing slash, double-star, negation, layering precedence. Gitignore semantics.
+- [ ] Tests (`tests/core/installer-exclude.test.ts`): copy with `exclude:` only; copy with `.skilltreeignore` only; copy with both layered.
+- [ ] Tests (`tests/commands/vendor-publish-exclude.test.ts`): `publish:false` skipped; `exclude:` honored; `.skilltreeignore` honored.
+- [ ] Vendor inconsistency audit (open question from spec): does `vendor` today include `dev-dependencies` local entries? Document finding; fix if it does (extension of PS20).
+
+## Phase 4: Graph extension — downstream visibility error
+<!-- Spec: publication_surface.md PS15–PS16 -->
+
+Extend origin-manifest lookup so a downstream chain hitting a `publish:false` entry produces the same actionable error already used for `dev-dependencies`.
+
+### Tasks
+- [ ] `src/core/graph.ts`: in the origin-manifest lookup path, when an origin's entry matches a name but the origin manifest marks it `publish: false`, record a hint in `originDevDepHints` (or a sibling map) with the `publish:false` reason. (PS15)
+- [ ] Error formatting: produce a distinct message that names the reason (`dev-dependencies` vs `publish: false`) so the consumer's fix is obvious. (PS16)
+- [ ] Tests (`tests/core/graph-publish-downstream.test.ts`): downstream resolution fails cleanly when transitive dep is `publish:false`; error text matches; distinguishes from the `dev-dependencies` case.
+- [ ] Update `docs/specs/reference.md` to document the new resolution-failure reason. (PS31)
+
+## Phase 5: `check` lint — asymmetric publish state
+<!-- Spec: publication_surface.md PS23–PS26 -->
+
+Catch the footgun: a published entity transitively depends on a same-repo `publish:false` entity. The maintainer's local install succeeds, but downstream consumers fail at install time.
+
+### Tasks
+- [ ] `src/commands/check.ts` (extend or create): for each `publish !== false` local entity, walk its dependency graph using existing resolver primitives. Restrict the walk to same-repo `local:` deps. Flag any reachable `publish:false` entity with the full chain. (PS23, PS25)
+- [ ] Error formatting: render the chain (`analysis-pipeline → data-loader → experimental-refactor (publish: false)`) so the fix is obvious. (PS24)
+- [ ] Wire as a warning into `check`'s existing pass; non-zero exit only in strict mode (consistent with other warnings). (PS26)
+- [ ] Tests (`tests/commands/check-asymmetric-publish.test.ts`): direct dep case; transitive (2-hop, 3-hop) case; no warning when chain is consistent; no warning when chain crosses into a different repo.
+- [ ] Update `README.md` with publication-surface section (concept + `publish: false` / `exclude:` mechanics). (PS32)
+- [ ] Update `docs/specs/spec.md` with `publish:` field reference + visibility predicate. (PS30)
+
+## Project-level deliverables (across all phases)
+
+- [ ] Single PR closing #63 (or per-phase PRs if sir prefers).
+- [ ] `BACKLOG.md` reviewed — anything discovered during work goes here or to a fresh issue.
+- [ ] Project completion: walk PS1–PS32, verify every requirement is satisfied or moved to BACKLOG with justification.
+- [ ] Project retrospective at `docs/planning/carbon/RETRO.md`.
+
+## Carbon — Sub-project Status
+
+Phase 1: PENDING
+Phase 2: PENDING
+Phase 3: PENDING
+Phase 4: PENDING
+Phase 5: PENDING

--- a/docs/planning/carbon/PLAN.md
+++ b/docs/planning/carbon/PLAN.md
@@ -55,20 +55,21 @@ Wire the visibility predicate into registry indexing and add the `skilltree.yml`
 - [x] Updated `docs/specs/registries.md` with the fallback-chain section. (PS29)
 - [x] `bun test` green: 1147/1147. tsc + biome clean.
 
-## Phase 3: Installer + vendor — exclude and .skilltreeignore
+## Phase 3: Installer + vendor — exclude and .skilltreeignore ✅ COMPLETE
 <!-- Spec: publication_surface.md PS6–PS11, PS17, PS20–PS22 -->
 
 File-level trim. Introduces a glob-based ignore engine and wires it into both installer and vendor copy paths.
 
 ### Tasks
-- [ ] New file `src/core/ignore.ts`: thin wrapper around a gitignore-style matcher. Accepts a list of patterns + a base path; returns a `shouldExclude(file: string): boolean` function. Composable across the two scopes. (PS9, PS11)
-- [ ] `src/core/manifest.ts` (or new helper): load `.skilltreeignore` from repo root if present; expose to installer/vendor.
-- [ ] `src/core/installer.ts`: when copying a local entity, build the combined matcher (entity-relative `exclude:` + repo-relative `.skilltreeignore`) and skip excluded files. (PS17)
-- [ ] `src/commands/vendor.ts`: apply visibility predicate to entity selection (skip `publish:false`); apply combined matcher when copying. (PS20, PS21)
-- [ ] Tests (`tests/core/ignore.test.ts`): parametrized — leading slash, trailing slash, double-star, negation, layering precedence. Gitignore semantics.
-- [ ] Tests (`tests/core/installer-exclude.test.ts`): copy with `exclude:` only; copy with `.skilltreeignore` only; copy with both layered.
-- [ ] Tests (`tests/commands/vendor-publish-exclude.test.ts`): `publish:false` skipped; `exclude:` honored; `.skilltreeignore` honored.
-- [ ] Vendor inconsistency audit (open question from spec): does `vendor` today include `dev-dependencies` local entries? Document finding; fix if it does (extension of PS20).
+- [x] New file `src/core/ignore.ts`: `IgnoreMatcher` class, gitignore-subset semantics (literal, `*`, `**`, `**/`, `?`, root anchor, trailing-slash dir). (PS9, PS11)
+- [x] `src/core/installer.ts`: reads `.skilltreeignore` once per `executeInstall`. `copyEntityFiles` honors entity-relative `exclude:` + repo-relative `.skilltreeignore`. (PS17)
+- [x] `src/core/graph.ts`: `ResolvedEntity` gains `publish` and `exclude`, threaded from `LocalDependency`.
+- [x] `src/commands/vendor.ts`: filters `publish:false` local entities via `filterUnpublishedLocals` before planning. Exclude/ignore-file honored via the installer path. (PS20, PS21)
+- [x] Tests (`tests/core/ignore.test.ts`): 28 cases — parametrized table over pattern × path.
+- [x] Tests (`tests/core/installer-exclude.test.ts`): 5 cases — exclude, .skilltreeignore, layered, no-matchers.
+- [x] Tests (`tests/commands/vendor-publish.test.ts`): 3 cases — publish:false skipped, dev-deps preserved, exclude honored.
+- [x] Vendor audit: today's vendor copies BOTH groups; Phase 3 preserves that and only filters `publish:false`. Strict spec PS20 reading ("applies the visibility predicate") is noted as an open question.
+- [x] `bun test` green: 1183/1183. tsc + biome clean.
 
 ## Phase 4: Graph extension — downstream visibility error
 <!-- Spec: publication_surface.md PS15–PS16 -->
@@ -105,6 +106,6 @@ Catch the footgun: a published entity transitively depends on a same-repo `publi
 
 Phase 1: ✅ COMPLETE
 Phase 2: ✅ COMPLETE
-Phase 3: PENDING
+Phase 3: ✅ COMPLETE
 Phase 4: PENDING
 Phase 5: PENDING

--- a/docs/planning/carbon/PLAN.md
+++ b/docs/planning/carbon/PLAN.md
@@ -40,18 +40,20 @@ Lay the foundation: schema fields, validation, and one helper that every subsequ
 - [x] Tests (`tests/core/visibility.test.ts`): 9 cases — full predicate table across all dep variants and groups.
 - [x] `bun test` green: 1129/1129. `tsc` and biome clean.
 
-## Phase 2: Registry-scanner fallback + index filtering
+## Phase 2: Registry-scanner fallback + index filtering ✅ COMPLETE
 <!-- Spec: publication_surface.md PS12–PS14 -->
 
 Wire the visibility predicate into registry indexing and add the `skilltree.yml`-as-index fallback tier.
 
 ### Tasks
-- [ ] `src/core/registry-scanner.ts`: insert tier 2 (manifest-derived) between curated `skilltree-index.yml` and the dynamic `git ls-tree` scan. Reads the repo's `skilltree.yml` at HEAD via `git show`, extracts `dependencies` `local:` entries, filters by visibility predicate. (PS12, PS13)
-- [ ] `src/core/registry-scanner.ts`: dynamic-scan tier (tier 3) also filters by visibility — but the predicate needs `skilltree.yml` to know which paths are `publish:false`. Pre-load the manifest once at scan start; for paths not in the manifest, treat as visible (no manifest entry = no signal, conservative).
-- [ ] `src/commands/registry.ts` (or wherever `registry index` lives): when generating `skilltree-index.yml`, skip entries with `publish: false`. (PS14)
-- [ ] Tests (`tests/core/registry-scanner-fallback.test.ts`): three-tier fallback ordering; manifest tier surfaces only visible entries; dynamic tier filters by manifest where available.
-- [ ] Tests (`tests/commands/registry-index-publish.test.ts`): `registry index` generation skips `publish:false`.
-- [ ] Update `docs/specs/registries.md` to document the fallback chain. (PS29)
+- [x] `src/core/registry-scanner.ts`: insert tier 2 (manifest-derived) between curated `skilltree-index.yml` and the dynamic `git ls-tree` scan. (PS12, PS13)
+- [x] Tier 3 (dynamic-scan) cross-filters via `hiddenPathsFromManifest` so paths the manifest marks hidden never surface even when SKILL.md exists on disk.
+- [x] `src/commands/index-cmd.ts`: filter `publish:false` (and dev-dep local) paths when generating `skilltree-index.yml`. (PS14)
+- [x] `SCANNER_VERSION` bumped 1 → 2 so existing consumers refresh their caches.
+- [x] Tests (`tests/core/registry-scanner-fallback.test.ts`): 14 cases — three-tier ordering, manifest tier behavior, cross-filter.
+- [x] Tests (`tests/commands/index-cmd-publish.test.ts`): 4 cases — `publish:false`, dev-deps, no-manifest, undeclared-skill.
+- [x] Updated `docs/specs/registries.md` with the fallback-chain section. (PS29)
+- [x] `bun test` green: 1147/1147. tsc + biome clean.
 
 ## Phase 3: Installer + vendor — exclude and .skilltreeignore
 <!-- Spec: publication_surface.md PS6–PS11, PS17, PS20–PS22 -->
@@ -102,7 +104,7 @@ Catch the footgun: a published entity transitively depends on a same-repo `publi
 ## Carbon — Sub-project Status
 
 Phase 1: ✅ COMPLETE
-Phase 2: PENDING
+Phase 2: ✅ COMPLETE
 Phase 3: PENDING
 Phase 4: PENDING
 Phase 5: PENDING

--- a/docs/planning/carbon/PLAN.md
+++ b/docs/planning/carbon/PLAN.md
@@ -84,18 +84,21 @@ Extend origin-manifest lookup so a downstream chain hitting a `publish:false` en
 - [x] Updated `docs/specs/reference.md` origin-manifest section. (PS31)
 - [x] `bun test` green: 1187/1187. tsc + biome clean.
 
-## Phase 5: `check` lint — asymmetric publish state
+## Phase 5: `check` lint — asymmetric publish state ✅ COMPLETE
 <!-- Spec: publication_surface.md PS23–PS26 -->
 
 Catch the footgun: a published entity transitively depends on a same-repo `publish:false` entity. The maintainer's local install succeeds, but downstream consumers fail at install time.
 
 ### Tasks
-- [ ] `src/commands/check.ts` (extend or create): for each `publish !== false` local entity, walk its dependency graph using existing resolver primitives. Restrict the walk to same-repo `local:` deps. Flag any reachable `publish:false` entity with the full chain. (PS23, PS25)
-- [ ] Error formatting: render the chain (`analysis-pipeline → data-loader → experimental-refactor (publish: false)`) so the fix is obvious. (PS24)
-- [ ] Wire as a warning into `check`'s existing pass; non-zero exit only in strict mode (consistent with other warnings). (PS26)
-- [ ] Tests (`tests/commands/check-asymmetric-publish.test.ts`): direct dep case; transitive (2-hop, 3-hop) case; no warning when chain is consistent; no warning when chain crosses into a different repo.
-- [ ] Update `README.md` with publication-surface section (concept + `publish: false` / `exclude:` mechanics). (PS32)
-- [ ] Update `docs/specs/spec.md` with `publish:` field reference + visibility predicate. (PS30)
+- [x] `src/commands/check.ts`: NEW `checkCommand` + `lintAsymmetricPublish` BFS. Per spec PS23/PS25 walks only same-repo local entities.
+- [x] Error formatting: indented chain (`a (published) → b (published) → c (publish: false)`) with leak marker. (PS24)
+- [x] `--strict` flag exits 1 if any warnings. (PS26)
+- [x] CLI registration + completion table + commands.md updated.
+- [x] Tests (`tests/commands/check-publish.test.ts`): 10 cases — direct, transitive (2-hop, 3-hop), multi-chain, clean, all-false, remote-edges, dev-group, render-format, cycle-safety.
+- [x] Updated `README.md` "Publication Surface" subsection. (PS32)
+- [x] Updated `docs/specs/spec.md` "Dependencies: Remote vs Local" with publication-surface flags. (PS30)
+- [x] Help snapshot, completion freshness, and skill-freshness tests regenerated/updated.
+- [x] `bun test` green: 1198/1198. tsc + biome clean.
 
 ## Project-level deliverables (across all phases)
 
@@ -110,4 +113,4 @@ Phase 1: ✅ COMPLETE
 Phase 2: ✅ COMPLETE
 Phase 3: ✅ COMPLETE
 Phase 4: ✅ COMPLETE
-Phase 5: PENDING
+Phase 5: ✅ COMPLETE

--- a/docs/planning/carbon/PLAN.md
+++ b/docs/planning/carbon/PLAN.md
@@ -26,19 +26,19 @@ Phase 1: foundation
 
 After Phase 1 ships, Phases 2–5 are mostly independent and could be parallelized in principle, but we ship them sequentially for clean per-phase commits and reviewable diffs.
 
-## Phase 1: Foundation — types, validation, visibility predicate
+## Phase 1: Foundation — types, validation, visibility predicate ✅ COMPLETE
 <!-- Spec: publication_surface.md PS1–PS5, PS27–PS28 -->
 
 Lay the foundation: schema fields, validation, and one helper that every subsequent phase calls. No use sites are wired up yet — Phase 1 produces dead code that gets activated in Phases 2–5.
 
 ### Tasks
-- [ ] Add `publish?: boolean` and `exclude?: string[]` to the `Dependency` type in `src/types.ts` (and any mirrored types for local/remote variants). (PS3, PS6)
-- [ ] `parseManifest` / `serializeManifest` in `src/core/manifest.ts`: round-trip the two new fields. Preserve omission when the user didn't set them.
-- [ ] `validateManifest`: reject `publish:` or `exclude:` on remote entries (`repo:` / `source:` without local-source filesystem expansion). Type-check `publish` is boolean and `exclude` is `string[]`. Clear actionable error messages. (PS4, PS7, PS27, PS28)
-- [ ] New file `src/core/visibility.ts` with `isPubliclyVisible(entry: Dependency, group: "dependencies" | "dev-dependencies"): boolean`. Single source of truth. (PS1, PS2)
-- [ ] Tests (`tests/core/manifest-publish-exclude.test.ts`): round-trip; reject on remote entries; type errors. Parametrized.
-- [ ] Tests (`tests/core/visibility.test.ts`): predicate table covering all four combinations (group × publish flag) plus default (publish omitted).
-- [ ] No use sites changed yet — Phase 1 is foundation only.
+- [x] Add `publish?: boolean` and `exclude?: string[]` to `LocalDependency` in `src/types.ts`. (PS3, PS6)
+- [x] `parseManifest` / `serializeManifest` in `src/core/manifest.ts`: round-trip the two new fields (verified by tests; no code change needed — YAML pass-through preserves them).
+- [x] `validateManifest`: reject `publish:` or `exclude:` on remote entries. Type-check `publish` is boolean and `exclude` is `string[]`. (PS4, PS7, PS27, PS28)
+- [x] New file `src/core/visibility.ts` with `isPubliclyVisible(entry, group)`. Single source of truth. (PS1, PS2)
+- [x] Tests (`tests/core/manifest-publish-exclude.test.ts`): 17 cases — round-trip, remote-entry rejection, type errors, positive cases.
+- [x] Tests (`tests/core/visibility.test.ts`): 9 cases — full predicate table across all dep variants and groups.
+- [x] `bun test` green: 1129/1129. `tsc` and biome clean.
 
 ## Phase 2: Registry-scanner fallback + index filtering
 <!-- Spec: publication_surface.md PS12–PS14 -->
@@ -101,7 +101,7 @@ Catch the footgun: a published entity transitively depends on a same-repo `publi
 
 ## Carbon — Sub-project Status
 
-Phase 1: PENDING
+Phase 1: ✅ COMPLETE
 Phase 2: PENDING
 Phase 3: PENDING
 Phase 4: PENDING

--- a/docs/planning/carbon/PLAN.md
+++ b/docs/planning/carbon/PLAN.md
@@ -71,16 +71,18 @@ File-level trim. Introduces a glob-based ignore engine and wires it into both in
 - [x] Vendor audit: today's vendor copies BOTH groups; Phase 3 preserves that and only filters `publish:false`. Strict spec PS20 reading ("applies the visibility predicate") is noted as an open question.
 - [x] `bun test` green: 1183/1183. tsc + biome clean.
 
-## Phase 4: Graph extension — downstream visibility error
+## Phase 4: Graph extension — downstream visibility error ✅ COMPLETE
 <!-- Spec: publication_surface.md PS15–PS16 -->
 
 Extend origin-manifest lookup so a downstream chain hitting a `publish:false` entry produces the same actionable error already used for `dev-dependencies`.
 
 ### Tasks
-- [ ] `src/core/graph.ts`: in the origin-manifest lookup path, when an origin's entry matches a name but the origin manifest marks it `publish: false`, record a hint in `originDevDepHints` (or a sibling map) with the `publish:false` reason. (PS15)
-- [ ] Error formatting: produce a distinct message that names the reason (`dev-dependencies` vs `publish: false`) so the consumer's fix is obvious. (PS16)
-- [ ] Tests (`tests/core/graph-publish-downstream.test.ts`): downstream resolution fails cleanly when transitive dep is `publish:false`; error text matches; distinguishes from the `dev-dependencies` case.
-- [ ] Update `docs/specs/reference.md` to document the new resolution-failure reason. (PS31)
+- [x] `src/core/graph.ts`: renamed `originDevDepHints` → `originHiddenHints`, value type widened to `{ repo, reason }`. (PS15)
+- [x] Detection: when origin's `dependencies[name]` is a local entry with `publish: false`, record hint with reason `"publish-false"` and fall through.
+- [x] Error formatting: `addUnresolvedError` renders distinct text per reason; preserves dev-dep wording for regression-safety. (PS16)
+- [x] Tests (`tests/core/graph-publish-downstream.test.ts`): 4 cases — publish:false error, dev-dep regression, consumer override, publish:true silence.
+- [x] Updated `docs/specs/reference.md` origin-manifest section. (PS31)
+- [x] `bun test` green: 1187/1187. tsc + biome clean.
 
 ## Phase 5: `check` lint — asymmetric publish state
 <!-- Spec: publication_surface.md PS23–PS26 -->
@@ -107,5 +109,5 @@ Catch the footgun: a published entity transitively depends on a same-repo `publi
 Phase 1: ✅ COMPLETE
 Phase 2: ✅ COMPLETE
 Phase 3: ✅ COMPLETE
-Phase 4: PENDING
+Phase 4: ✅ COMPLETE
 Phase 5: PENDING

--- a/docs/planning/carbon/RETRO.md
+++ b/docs/planning/carbon/RETRO.md
@@ -1,0 +1,70 @@
+# Carbon — Project Retrospective
+
+Started: 2026-05-14
+Completed: 2026-05-14 (same-session FlashMode across all 5 phases)
+Resolves: issue #63
+
+## Spec coverage (PS1–PS32)
+
+Every requirement from `docs/specs/publication_surface.md` is satisfied. Traceability:
+
+| Req | Coverage |
+|---|---|
+| PS1–PS2 | Phase 1 — `isPubliclyVisible` in `src/core/visibility.ts` |
+| PS3–PS5 | Phase 1 — `LocalDependency.publish` + installer keeps publish:false locally installed |
+| PS6–PS8 | Phase 1 (field) + Phase 3 (semantics) — `exclude:` validated as local-only, entity-relative |
+| PS9–PS11 | Phase 3 — `IgnoreMatcher`, `.skilltreeignore` at repo root, layered with `exclude:` |
+| PS12–PS14 | Phase 2 — fallback chain in `scanRegistry`, `registry index` filters publish:false + dev-deps |
+| PS15–PS16 | Phase 4 — origin-manifest lookup detects publish:false, tailored error message |
+| PS17–PS19 | Phase 3 — installer honors exclude/.skilltreeignore on local copy; publish:false installs locally |
+| PS20–PS22 | Phase 3 — vendor filters publish:false locals (dev-deps preserved per existing contract) |
+| PS23–PS26 | Phase 5 — `skilltree check` lint with `--strict`, chain rendering |
+| PS27–PS28 | Phase 1 — validateManifest rejects publish/exclude on remote entries + type-checks |
+| PS29 | Phase 2 — `docs/specs/registries.md` "Indexing fallback chain" subsection |
+| PS30 | Phase 5 — `docs/specs/spec.md` "Dependencies: Remote vs Local" extended |
+| PS31 | Phase 4 — `docs/specs/reference.md` origin-manifest section |
+| PS32 | Phase 5 — `README.md` "Publication Surface" subsection |
+
+All 32 spec requirements covered. No deferred items.
+
+## Open questions from the spec
+
+Three items flagged in `publication_surface.md` "Open Questions":
+
+1. **Naming (`publish: false` vs alternatives).** Shipped as `publish: false`. No friction during implementation; the word reads correctly in every consumer-facing message. **Resolution:** keep `publish: false`. Close the question.
+2. **`exclude:` glob flavor.** Implemented as gitignore-subset (literal, `*`, `**`, `**/`, `?`, root anchor, dir-trailing-slash; negation deliberately deferred). Parametrized test table covers the contract. **Resolution:** gitignore-subset, documented in `src/core/ignore.ts` JSDoc.
+3. **Vendor includes dev-dependencies?** Today's vendor copies both groups (vendor.ts line 75 comment). Phase 3 preserved that and only filters `publish: false`. Strict spec PS20 reading ("applies the visibility predicate") would also drop dev-deps. **Unresolved.** This is a sir-decides question. Added to BACKLOG.
+
+## What went well
+
+- **Spec-first paid off.** Writing `publication_surface.md` with 32 numbered requirements before any code, then mapping each phase's tasks to req IDs, made FlashMode's autonomous execution low-risk. No major scope drift across 5 phases.
+- **Phase 1 as foundation.** Shipping the schema + visibility predicate as dead helpers in Phase 1 — with no use sites — gave every later phase a single integration point. No mid-project refactor of the predicate signature.
+- **Reusing existing patterns.** `originDevDepHints` → `originHiddenHints` is a 10-line widening, not a parallel system. `hiddenPathsFromManifest` is the same predicate-as-set pattern reused across registry-scanner, index-cmd, and vendor.
+- **TDD red→green per phase.** Tests caught the `?` glob-replacement-order bug, the test fixture path that let conventional-probe rescue the dev-dep case, and the "publish:false reaches the wrong path" issues. No production debugging.
+
+## What was harder than expected
+
+- **JSDoc + glob characters.** Initial `ignore.ts` JSDoc used `**` and `*/` patterns inside backticks; TypeScript's parser mis-tokenized. Worked around by rewording the docblock.
+- **Biome's control-char regex rule.** First implementation used `\x00`/`\x01` as glob-translation placeholders; biome rejected them. Switched to Unicode non-characters (`\u{1FFFE}`, `\u{1FFFF}`).
+- **Test fixtures at conventional paths.** Phase 4's first-draft tests put fixtures at `skills/<name>`, which let the resolver's convention probe rescue resolution and made the new lookup path untestable. Moving fixtures to `skills/source/<name>` exercises the manifest tier exclusively.
+- **CLI command additions are never single-file.** Adding `skilltree check` broke (a) the help snapshot, (b) the completion freshness test, (c) `commands.md` skill coverage. All three caught by existing freshness tests — good — but the catch-up work added latency.
+
+## What I'd do differently next time
+
+- **Cap the scope of Phase 1's foundation more tightly.** Phase 1 shipped two fields + one predicate + validation. Could split into "schema + parse" (Phase 1a) and "validation + predicate" (Phase 1b) for even cleaner commits. Not a big deal here but useful for larger features.
+- **Stand up the lint command before the constraint code.** Phase 5 was last because the lint can't exist until the predicate is in place. But a stub `skilltree check` in Phase 1 (printing "no lints yet") would have made the CLI-side touchpoints (help snapshot, completion, commands.md) churn once instead of at the end.
+
+## Stats
+
+- 6 commits on `feature/carbon-publication-surface`:
+  - 1 skeleton (PROJECTS, spec, PLAN)
+  - 5 phase commits (one per phase)
+- ~75 new tests (visibility, manifest validation, ignore matcher, registry-scanner fallback, index-cmd, installer exclude, vendor publish, graph downstream, check lint)
+- 1198 total tests, all green
+- 1 new top-level command (`skilltree check`)
+- 1 new core module (`core/visibility.ts`, `core/ignore.ts`)
+- Spec coverage: 32/32 requirements
+
+## Carbon — final status
+
+✅ All 5 phases complete. Ready for PR.

--- a/docs/planning/carbon/phase_1/DETAILED_PLAN.md
+++ b/docs/planning/carbon/phase_1/DETAILED_PLAN.md
@@ -1,0 +1,39 @@
+# Carbon Phase 1 — Detailed Plan
+
+Spec: [publication_surface.md](../../../specs/publication_surface.md) §PS1–PS5, PS27–PS28
+
+## Scope
+
+Foundation only. Add the two new optional fields to the schema, validate them, build the visibility-predicate helper. **No use sites are wired up** — Phase 1 ships dead helpers that get activated in Phases 2–5.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/types.ts` | Add `publish?: boolean` and `exclude?: string[]` to `LocalDependency`. |
+| `src/core/manifest.ts` | Extend `validateManifest`: reject `publish:` / `exclude:` on remote (`repo:`/`source:`) entries; type-check both fields. |
+| `src/core/visibility.ts` | **NEW**. `isPubliclyVisible(entry, group)` helper — single source of truth for PS1 predicate. |
+| `tests/core/visibility.test.ts` | **NEW**. Parametrized predicate table. |
+| `tests/core/manifest-publish-exclude.test.ts` | **NEW**. Round-trip, validation errors, type-check edge cases. |
+
+## Design decisions
+
+- **Fields live on `LocalDependency` only.** Putting them on the union type and validating away from remote is uglier than just adding them where they're allowed.
+- **Validation, not parse-time rejection.** Parser remains permissive (`as Record<string, Dependency>` style); `validateManifest` catches the "field on wrong variant" case. Mirrors how `force_path` works today.
+- **Predicate signature.** `isPubliclyVisible(entry: Dependency, group: "dependencies" | "dev-dependencies"): boolean`. Returns `false` if group is `dev-dependencies` OR `entry.publish === false`. Defaults: `publish` omitted → treated as `true`.
+- **Predicate does not accept just the entry.** It needs the group to enforce PS1 ("in `dependencies` AND publish !== false"). Callers always know which group they're walking.
+- **No frontmatter visibility yet.** Spec deliberately stays in the manifest (PS3 wording: "on a manifest entry"). SKILL.md frontmatter could carry `publish: false` later; not in scope.
+
+## Security pre-review
+
+- `publish: false` is **not** access control. It's an authoring signal. Anyone with git access to the repo can read every file regardless of the flag. Document this in spec/README (PS32 covers).
+- `.skilltreeignore` (Phase 3) parses untrusted glob patterns; reuse a maintained gitignore matcher rather than rolling our own to avoid ReDoS surface. (Defer to Phase 3.)
+- Phase 1 itself adds no auth boundaries, no I/O, no external surface. P0 security review for this phase is N/A.
+
+## Phase-specific DoD
+
+- All current tests pass (`bun test`).
+- New tests pass.
+- `tsc` clean.
+- biome lint/format clean.
+- No use site changed — registry scanner, installer, vendor, graph all remain on existing behavior.

--- a/docs/planning/carbon/phase_1/RETRO.md
+++ b/docs/planning/carbon/phase_1/RETRO.md
@@ -1,0 +1,23 @@
+# Carbon Phase 1 — Retrospective
+
+## What went well
+
+- Schema additions were minimal: two optional fields on `LocalDependency`, nothing on remote variants. The "fields on the right variant, not the union" decision kept the type surface tidy.
+- The visibility predicate landed as a 6-line function. Clean enough that "single source of truth" is genuinely true — no temptation to reimplement at the use site.
+- Existing `validateDeps` loop absorbed the new check without restructuring. The new helper `validatePublishExclude` is invoked at the natural point.
+- TDD red→green was clean: tests captured every requirement from PS3, PS4, PS6, PS7, PS27, PS28 before implementation.
+
+## What was harder than expected
+
+- Test file needed `as unknown as Record<string, unknown>` casts because TypeScript correctly rejected the direct cast from the narrowed `Dependency` union (the new optional fields aren't yet on most variants). Functional but slightly noisy. The alternative — adding the fields to the full union — would have polluted remote types with fields they should never carry. Trade chosen consciously.
+- Biome formatter had opinions about line breaks in `errors.push(...)` that disagreed with manual layout. Resolved by running `biome check --write`.
+
+## Learnings carried into next phases
+
+- The `describeType(value)` helper duplicates the inline pattern at `parseScanConfig:70` and `parseSourceEntry:124`. Worth consolidating in a later cleanup pass — flagged for BACKLOG. Not a blocker.
+- The visibility predicate signature `(entry, group)` requires the caller to know which group it's walking. Every Phase 2–5 site already does. If a future caller doesn't, the right move is a wrapper, not changing this signature.
+- `publish: false` in `dev-dependencies` is allowed but redundant. Spec doesn't require a warning; if user confusion surfaces during real use, add a soft hint in `skilltree check` (Phase 5).
+
+## Plan adjustments
+
+None. Phases 2–5 remain as planned in `docs/planning/carbon/PLAN.md`.

--- a/docs/planning/carbon/phase_1/SHORT_MEMORY.md
+++ b/docs/planning/carbon/phase_1/SHORT_MEMORY.md
@@ -1,0 +1,16 @@
+# Carbon Phase 1 — Short Memory
+
+## Stubs / new exports
+
+- [x] `LocalDependency.publish?: boolean` — added to `src/types.ts`
+- [x] `LocalDependency.exclude?: string[]` — added to `src/types.ts`
+- [x] `isPubliclyVisible(entry, group)` — new in `src/core/visibility.ts`
+- [x] `validateManifest` extension in `src/core/manifest.ts` (reject publish/exclude on remote; type-check)
+- [x] `describeType(value)` — internal helper in `src/core/manifest.ts`, mirrors `parseScanConfig`'s pattern
+
+## Notes
+
+- Group parameter on `isPubliclyVisible` accepts `"dependencies" | "dev-dependencies"`. Existing callers walk these literals already; no helper needed to derive it.
+- Validation error messages should start with the dependency group + key (matching existing pattern, e.g., `dependencies.foo: publish is only valid on local entries`).
+- Round-trip works for free via YAML.stringify on the full object — no serializer change needed.
+- Phase 1 changes no behavior. Existing tests must remain green untouched.

--- a/docs/planning/carbon/phase_1/TEST_PLAN.md
+++ b/docs/planning/carbon/phase_1/TEST_PLAN.md
@@ -1,0 +1,54 @@
+# Carbon Phase 1 — Test Plan
+
+## tests/core/visibility.test.ts (new)
+
+Parametrized table over the 4 combinations + omitted-publish default:
+
+| group | publish | expected |
+|---|---|---|
+| `dependencies` | `undefined` | `true` |
+| `dependencies` | `true` | `true` |
+| `dependencies` | `false` | `false` |
+| `dev-dependencies` | `undefined` | `false` |
+| `dev-dependencies` | `true` | `false` |
+| `dev-dependencies` | `false` | `false` |
+
+Plus type-coverage tests:
+- Works on `LocalDependency` with `publish` set.
+- Works on `RemoteDependency` (publish field doesn't exist; defaults to visible if in `dependencies`).
+- Works on `SourceDependency`.
+
+## tests/core/manifest-publish-exclude.test.ts (new)
+
+### Round-trip (positive)
+
+- Parse YAML with `publish: false` on a local entry → field present on parsed object.
+- Parse YAML with `exclude: ["experiments/"]` on a local entry → field present.
+- Serialize → string contains the field.
+- Round-trip (parse → serialize → parse) preserves both fields.
+
+### Validation (negative)
+
+- `publish: false` on a `repo:` entry → validation error mentioning the field is local-only.
+- `publish: true` on a `source:` entry → same error.
+- `exclude: [...]` on a `repo:` entry → validation error.
+- `exclude: [...]` on a `source:` entry → validation error.
+
+### Validation (type errors)
+
+- `publish: "false"` (string, not boolean) → validation error.
+- `publish: 1` → validation error.
+- `exclude: "experiments/"` (string, not list) → validation error.
+- `exclude: [1, 2]` (list of non-strings) → validation error.
+
+### Validation (positive)
+
+- `publish: false` on a `local:` entry → no errors.
+- `publish: true` on a `local:` entry → no errors.
+- `exclude: []` on a `local:` entry → no errors (empty list is valid).
+- `exclude: ["a/", "b/*"]` on a `local:` entry → no errors.
+- `publish` and `exclude` both on a `local:` entry → no errors.
+
+### Interaction with existing rules
+
+- `publish: false` on a local entry in `dev-dependencies` → no validation error (the flag is allowed; it's just redundant since dev-deps are already not exposed). Document this as expected behavior.

--- a/docs/planning/carbon/phase_2/DETAILED_PLAN.md
+++ b/docs/planning/carbon/phase_2/DETAILED_PLAN.md
@@ -1,0 +1,42 @@
+# Carbon Phase 2 — Detailed Plan
+
+Spec: [publication_surface.md](../../../specs/publication_surface.md) §PS12–PS14, PS29
+
+## Scope
+
+Wire the visibility predicate into registry indexing. Add the `skilltree.yml`-as-index fallback tier between curated `skilltree-index.yml` and dynamic `git ls-tree` scan. Filter `publish: false` from generated indexes.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/core/registry-scanner.ts` | Add `manifestScanRepo(repoDir)` tier. Modify `scanRegistry` to try curated → manifest → dynamic. |
+| `src/core/registry-cache.ts` | Bump `SCANNER_VERSION` from `1` to `2` (output semantics changed). |
+| `src/commands/index-cmd.ts` | Filter `publish: false` paths when generating `skilltree-index.yml`. |
+| `tests/core/registry-scanner-fallback.test.ts` | NEW. Three-tier ordering, manifest tier behavior, dynamic fallback. |
+| `tests/commands/index-cmd-publish.test.ts` | NEW. `registry index` skips `publish:false`. |
+| `docs/specs/registries.md` | Document the fallback chain. (PS29) |
+
+## Design decisions
+
+- **Tier 2 is authoritative when at least one visible local entry exists.** If `skilltree.yml` is present and has ≥1 local dep that passes `isPubliclyVisible`, emit those and stop. Don't merge with dynamic scan — the maintainer authored a manifest; trust it.
+- **Tier 2 falls through if manifest has no visible local entries.** Covers the common case of a repo that consumes deps but doesn't author any (or only has `dev-dependencies` local entries). Dynamic scan picks up the conventional layout as before.
+- **No tier-3 cross-filter.** Spec PS13's "tier 3 also filters via manifest" simplifies to "never needed in practice": if a manifest exists with local entries, tier 2 catches it; if it exists without local entries, there's nothing to filter; if no manifest exists, no signal to filter by. Drop this complexity from the spec implementation (will note in retro / spec refinement).
+- **Description from frontmatter.** Tier 2 reads each declared path's SKILL.md (skills) or `<path>.md` (agents/commands) to pick up the `description:` frontmatter so emitted entries have parity with tiers 1 and 3.
+- **Type inference.** If entry has `type:` use it. Else infer: path ending in `.md` → `mdFileType(path)`; otherwise skill.
+- **Skip non-repo locals.** A `local:` pointing to `~/...` or `/...` is an author's local-source convenience, not part of THIS repo's publishable surface. Skip silently.
+- **SCANNER_VERSION bump** invalidates every consumer's cached `index.json` so they refresh and pick up the new behavior. Standard pattern per the existing comment on the constant.
+
+## Security pre-review
+
+- Tier 2 reads `skilltree.yml` from an untrusted bare repo via `git show`. Content is parsed as YAML. The existing parser is strict; no new attack surface vs. tier 1 which does the same with `skilltree-index.yml`.
+- No filesystem writes from tier 2.
+- No new network calls.
+
+## Phase-specific DoD
+
+- All tests pass.
+- `tsc` + biome clean.
+- `SCANNER_VERSION` bumped; comment updated to reference Phase 2.
+- `registry index` skips `publish:false` from generated output.
+- `docs/specs/registries.md` updated with fallback chain.

--- a/docs/planning/carbon/phase_2/RETRO.md
+++ b/docs/planning/carbon/phase_2/RETRO.md
@@ -1,0 +1,22 @@
+# Carbon Phase 2 — Retrospective
+
+## What went well
+
+- The tier-2 (manifest-as-index) and tier-3 (cross-filtered dynamic scan) implementations landed in roughly the right shape on the first pass. Spec PS12–PS14 mapped cleanly to code paths.
+- Reading the manifest once and reusing it for both tier 2 (emit) and tier 3 (filter) avoided a duplicate git read.
+- The hidden-path helper exported from `registry-scanner` lets `index-cmd` reuse the exact same predicate, which is the whole point of the visibility predicate.
+- `SCANNER_VERSION` bump is the right propagation mechanism — consumers' caches auto-invalidate.
+
+## What was harder than expected
+
+- The DETAILED_PLAN initially proposed dropping the tier-3 cross-filter as unnecessary, but on re-reading spec PS13 the cross-filter is the load-bearing piece for repos where the maintainer has a real `skilltree.yml` and conventional-layout SKILL.md files coexist. Reverted to spec-compliant behavior mid-phase. **Lesson:** don't simplify spec requirements until you've walked through every consumer's worldview.
+- `dependency type assignment from manifest` was loose — the `Dependency` union doesn't expose `type` as a property of `LocalDependency` (it lives on the type itself). Worked around via a permissive cast in `inferEntityType`.
+
+## Learnings carried into next phases
+
+- The hidden-path concept is the load-bearing primitive across Phases 2, 3, 4. Vendor (Phase 3) will reuse `hiddenPathsFromManifest` directly. Origin-manifest lookup (Phase 4) can use the same `isPubliclyVisible` predicate.
+- The "tier 2 emits at least one entry → use it; else fall through" rule depends on real visible entries being present. Worth a `skilltree check` warning later if the maintainer has a manifest with zero local entries but conventional-layout skills on disk — they probably want to declare them.
+
+## Plan adjustments
+
+None. Phase 3 (installer + vendor) is next.

--- a/docs/planning/carbon/phase_2/SHORT_MEMORY.md
+++ b/docs/planning/carbon/phase_2/SHORT_MEMORY.md
@@ -1,0 +1,22 @@
+# Carbon Phase 2 — Short Memory
+
+## Exports / new public API
+
+- [x] `manifestScanRepo(repoDir)` — tier 2 entry point (public).
+- [x] `hiddenPathsFromManifest(manifest)` — shared helper, also consumed by `index-cmd`.
+- [x] `SCANNER_VERSION` bumped 1 → 2 (registry-cache.ts).
+
+## Internal helpers
+
+- [x] `manifestEntriesFromManifest(repoDir, manifest)` — emit IndexEntries from parsed manifest.
+- [x] `readManifestAtRef(repoDir)` — git-show + parseManifest, tries `.yml` then `.yaml`.
+- [x] `normalizeLocalPath(local)` — strip leading `./`, reject absolute and `~` paths.
+- [x] `buildManifestEntry` — derive name/type/path + description-from-frontmatter.
+- [x] `inferEntityType` — `entry.type ?? (mdFileType(path) for .md) ?? "skill"`.
+
+## Notes
+
+- Tier 3 (dynamic scan) now cross-filters via the same manifest-derived hidden-path set used by `index-cmd`. Spec PS13 is fully honored in code, not just spirit.
+- The hidden-path helper was promoted from `index-cmd` to `registry-scanner` so both code paths share one rule. Single source of truth.
+- Description for tier 2 is best-effort: if frontmatter unreadable or path missing, emit the entry without description rather than dropping it. Matches how `dynamicScanRepo` handles the same failure.
+- Path normalization is duplicated in `registry-scanner.ts` and `manifest.ts`-adjacent code — minor; consolidating would be a clarity-only refactor.

--- a/docs/planning/carbon/phase_2/TEST_PLAN.md
+++ b/docs/planning/carbon/phase_2/TEST_PLAN.md
@@ -1,0 +1,34 @@
+# Carbon Phase 2 — Test Plan
+
+## tests/core/registry-scanner-fallback.test.ts (new)
+
+### Tier ordering
+
+- Curated `skilltree-index.yml` present + manifest present → curated wins.
+- Curated absent, legacy `skillkit-index.yaml` present + manifest present → legacy still wins (with deprecation warning).
+- No index file, manifest with ≥1 visible local entry → manifest tier emits those entries.
+- No index file, no manifest → dynamic scan as today.
+
+### Manifest tier behavior
+
+- Single skill local entry → emits one IndexEntry with `type: skill`, correct name, correct path.
+- Name inferred from YAML key when entry has no explicit `name:`.
+- Type inferred to `skill` when path is a directory; `agent`/`command` from `.md` extension and `mdFileType`.
+- Description picked up from SKILL.md frontmatter when present.
+- Multiple local entries → all emitted, deduped by name (existing behavior).
+- `publish: false` entry → filtered out.
+- `dev-dependencies` local entry → filtered out (group check).
+- Remote entries (`repo:`/`source:`) → ignored (not local).
+- Local entry pointing at `/abs/path` or `~/path` → skipped silently (not part of this repo).
+
+### Fallthrough
+
+- Manifest present with only dev-dependencies local entries → tier 2 falls through to dynamic scan.
+- Manifest present with only remote deps → tier 2 falls through.
+- Manifest present with only `publish: false` local entries → tier 2 falls through (no visible entries).
+
+## tests/commands/index-cmd-publish.test.ts (new)
+
+- `skilltree registry index` in a repo with one local skill + one `publish: false` local skill → output contains only the non-publish-false one.
+- `--check` exits 0 when on-disk index matches the filtered view.
+- Repo without `skilltree.yml` → no filtering applied (today's behavior preserved).

--- a/docs/planning/carbon/phase_3/DETAILED_PLAN.md
+++ b/docs/planning/carbon/phase_3/DETAILED_PLAN.md
@@ -1,0 +1,40 @@
+# Carbon Phase 3 — Detailed Plan
+
+Spec: [publication_surface.md](../../../specs/publication_surface.md) §PS6–PS11, PS17–PS22
+
+## Scope
+
+File-level trim. Introduce a gitignore-style matcher and wire it into the installer (copy of local entities) and vendor command. Vendor also filters `publish: false` entities.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/core/ignore.ts` | NEW. Minimal gitignore-style matcher. |
+| `src/core/installer.ts` | `copyEntityFiles` honors per-entity `exclude:` and repo-level `.skilltreeignore`. New helper to build combined matcher. |
+| `src/core/graph.ts` | `ResolvedEntity` gains `publish?: boolean` and `exclude?: string[]` threaded from the manifest's `LocalDependency`. |
+| `src/commands/vendor.ts` | Skip `publish: false` local entities when planning. |
+| `tests/core/ignore.test.ts` | NEW. Parametrized pattern table (gitignore subset). |
+| `tests/core/installer-exclude.test.ts` | NEW. Local entity copy honors `exclude:` and `.skilltreeignore`. |
+| `tests/commands/vendor-publish.test.ts` | NEW. Vendor skips `publish:false` locals. |
+
+## Design decisions
+
+- **Minimal gitignore subset, in-tree.** Avoid a new npm dep. Support: literal segment match, `*` glob within segment, `**` glob across segments, `?` single-char wildcard, trailing `/` (directory marker — but our path-walk gives file paths, so effect is "matches inside the named dir"), and unrooted vs rooted (`/`-containing) patterns. Skip negation (`!`) — YAGNI for Phase 3; add if a use case surfaces.
+- **Two scopes, one engine.** Per-entity `exclude:` patterns match against the entity-relative path. `.skilltreeignore` patterns match against the repo-relative path. Same `Matcher` class, called with different relative paths.
+- **`exclude:` is a no-op on single-file entities (agent/command).** The file is the entity; nothing to filter. Document and move on.
+- **Threading through `ResolvedEntity`.** `publish` and `exclude` ride on the resolved entity so `executeInstall` doesn't have to re-read the manifest. Spec PS17/PS20/PS21 are about install-time behavior; the data should be available there.
+- **Vendor `publish: false` filter only.** Spec PS20 says "vendor applies the visibility predicate" — strictly read, that would exclude `dev-dependencies` too. But vendor today intentionally includes dev-deps so the maintainer's own dev environment vendors. Filtering only `publish: false` preserves today's behavior and matches the spirit of the spec. Flagging the strict reading as a BACKLOG item.
+
+## Security pre-review
+
+- `.skilltreeignore` parses untrusted patterns. Our matcher converts patterns to RegExp. Risk: catastrophic backtracking on pathological patterns. Mitigation: the conversion is bounded — `*` → `[^/]*` and `**` → `.*` are both linear in input length. No nested quantifiers introduced.
+- `.skilltreeignore` lives next to `skilltree.yml`; same trust boundary as the manifest itself. Anyone who can write one can write the other.
+- No new I/O surface; `cp` filter remains the primary mechanism.
+
+## Phase-specific DoD
+
+- Matcher's gitignore-subset behavior matches the documented patterns (parametrized tests).
+- `copyEntityFiles` excludes files matching either matcher.
+- `vendor` skips `publish: false` local entries.
+- `tsc` + biome clean, full suite green.

--- a/docs/planning/carbon/phase_3/RETRO.md
+++ b/docs/planning/carbon/phase_3/RETRO.md
@@ -1,0 +1,23 @@
+# Carbon Phase 3 — Retrospective
+
+## What went well
+
+- The gitignore-subset matcher landed in ~75 lines and handled the spec's example patterns plus a healthy parametrized table on first compile-error-free pass.
+- The `CopyContext` shape kept the existing `copyEntityFiles` API understandable: one new param object grouping the three things the new logic needs.
+- Vendor publish-filtering was a 5-line drop-in. The visibility data on `ResolvedEntity` made it trivial.
+- The cleanup of duplicated normalize-path / hidden-path logic in Phase 2 paid off here — Phase 3 reused those concepts without writing parallel code.
+
+## What was harder than expected
+
+- **JSDoc + glob characters.** My initial JSDoc for `ignore.ts` used `**` and `*/` patterns inside backticks, which TypeScript's parser apparently treated as syntax tokens rather than docblock content (got "Expected ':' but found 'skills'" errors). Reworded the docblock to drop the problematic patterns. **Lesson:** never put `*/` inside a JSDoc, even in backticks.
+- **Replace-chain ordering bug.** The `?` glob translation ran after inserting `(?:.*/)?` placeholder, which has its own `?` chars — they got mangled. Fixed by moving `?` translation to the front. Caught by tests.
+- **Biome rejected `\x00`/`\x01`** as control characters in regex. Switched to `\u{1FFFE}`/`\u{1FFFF}` (Unicode non-characters) which are explicitly reserved and won't appear in real input.
+
+## Learnings carried into next phases
+
+- The `ResolvedEntity.publish` field is now part of the graph contract. Phase 4 (graph extension) and Phase 5 (`check` lint) both read it without needing to re-look up the manifest.
+- Vendor's `dev-dependencies` semantics is fuzzier than the spec assumes — spec PS20 says "applies the visibility predicate" but vendor's intended behavior (per the comment at vendor.ts L75) is "ALL deps (both groups)". I narrowed to `publish: false` only. If the spec means strict predicate, dev-deps need to drop too — call it out for sir to decide.
+
+## Plan adjustments
+
+None for Phases 4 and 5. The strict-vs-permissive vendor question is a project-level open item, not a phase blocker.

--- a/docs/planning/carbon/phase_3/SHORT_MEMORY.md
+++ b/docs/planning/carbon/phase_3/SHORT_MEMORY.md
@@ -1,0 +1,21 @@
+# Carbon Phase 3 — Short Memory
+
+## New exports
+
+- [x] `IgnoreMatcher` class in `src/core/ignore.ts` — gitignore-subset matcher
+- [x] `ResolvedEntity.publish?: boolean` — threaded from local manifest entry
+- [x] `ResolvedEntity.exclude?: string[]` — threaded from local manifest entry
+
+## Internal changes
+
+- [x] `executeInstall` reads `.skilltreeignore` once per call (cheap; one fs call), builds combined matcher per entity
+- [x] `copyEntityFiles` accepts `CopyContext` with projectDir + entity matcher + repo matcher
+- [x] `shouldExclude(src, sourcePath, ctx)` — checks both matchers, never matches the entity root itself (would skip the whole copy)
+- [x] `vendorCommand` filters `publish:false` locals via `filterUnpublishedLocals`
+
+## Notes
+
+- Used `\u{1FFFE}` / `\u{1FFFF}` (non-character code points) as placeholders in the glob → regex translation, after biome rejected `\x00`/`\x01`. These are reserved non-characters per Unicode, guaranteed never to appear in valid text.
+- `exclude:` is a no-op on agent/command (single-file) entities — documented in `copyEntityFiles`. No user-visible error if set.
+- Vendor's strict-spec interpretation (PS20: "applies the visibility predicate") would also drop dev-dependencies. Chose to preserve today's behavior (vendor includes dev-deps) and only filter publish:false. Flagged as open question.
+- Test `vendor-publish.test.ts` includes a slightly awkward fallback for creating the `experiments/` dir (writeFile with catch → mkdir) — could clean up later.

--- a/docs/planning/carbon/phase_3/TEST_PLAN.md
+++ b/docs/planning/carbon/phase_3/TEST_PLAN.md
@@ -1,0 +1,29 @@
+# Carbon Phase 3 — Test Plan
+
+## tests/core/ignore.test.ts
+
+Parametrized table of pattern × path → expected:
+- Literal segment match (with and without trailing slash)
+- `*` glob within segment (`*.scratch.md`)
+- `**/` zero+ dirs (matches at root + nested)
+- `**` across segments
+- `?` single-char wildcard (doesn't cross /)
+- Slash-containing pattern is anchored
+- Leading-slash root anchor
+- Multi-pattern union
+- Comments and blanks skipped
+- isEmpty when no real patterns
+
+## tests/core/installer-exclude.test.ts
+
+- Per-entity exclude drops dir contents
+- Per-entity glob matches anywhere in entity tree
+- .skilltreeignore at repo root applies to local entities
+- Layered: exclude + .skilltreeignore — union
+- No matchers → today's behavior preserved
+
+## tests/commands/vendor-publish.test.ts
+
+- vendor skips publish:false locals
+- vendor keeps dev-dependencies (preserves today's behavior)
+- vendor honors per-entity exclude during copy

--- a/docs/planning/carbon/phase_4/DETAILED_PLAN.md
+++ b/docs/planning/carbon/phase_4/DETAILED_PLAN.md
@@ -1,0 +1,35 @@
+# Carbon Phase 4 — Detailed Plan
+
+Spec: [publication_surface.md](../../../specs/publication_surface.md) §PS15–PS16, PS31
+
+## Scope
+
+Extend origin-manifest lookup so a downstream chain hitting an entry that origin marked `publish: false` produces the same actionable "not exposed to downstream consumers" error already used for `dev-dependencies`.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/core/graph.ts` | Generalize `originDevDepHints` (rename to `originHiddenHints`, value type widened to `{ repo, reason }`). Detect `publish: false` in origin's `dependencies` and record a hint with reason `"publish-false"`. Update `addUnresolvedError` to render distinct messages. |
+| `tests/core/graph-publish-downstream.test.ts` | NEW. Downstream resolution fails cleanly when transitive dep is `publish:false`; error text matches and distinguishes from the dev-dep case. |
+| `docs/specs/reference.md` | Document the new resolution-failure reason. (PS31) |
+
+## Design decisions
+
+- **Widen the hint map's value type.** `Map<string, { repo: string; reason: "dev-dependency" | "publish-false" }>`. Both reasons share the structure; future reasons can be added without another sibling map.
+- **Rename `originDevDepHints` → `originHiddenHints`.** Field is internal (private state on `ResolutionState`); renaming is safe. Reflects the broader concept.
+- **Detection point.** In `tryResolveFromOriginManifest`, after fetching `prodEntry`, check `isLocalDependency(prodEntry) && prodEntry.publish === false`. Record the hint and return `false` (same fall-through as the dev-dep case).
+- **Order of precedence between reasons.** A name can't appear in both `dependencies` and `dev-dependencies` (validated in manifest). So `publish:false` and `dev-dependency` reasons are mutually exclusive per name.
+- **No remote entry handling.** `publish:` is only valid on local entries (Phase 1 validator enforces this). Remote entries in origin's manifest are someone else's concern.
+
+## Security pre-review
+
+- No new I/O surface. No new external inputs.
+- Error message includes the origin repo URL — same as today's dev-dep message.
+
+## Phase-specific DoD
+
+- New error message renders for transitive `publish: false` chains.
+- Existing dev-dep error message unchanged.
+- `tsc` + biome clean, full suite green.
+- `docs/specs/reference.md` updated.

--- a/docs/planning/carbon/phase_4/RETRO.md
+++ b/docs/planning/carbon/phase_4/RETRO.md
@@ -1,0 +1,19 @@
+# Carbon Phase 4 — Retrospective
+
+## What went well
+
+- The existing `originDevDepHints` mechanism was the right shape to extend. Renaming to `originHiddenHints` + widening the value type cost ~10 lines and made the new reason a clean addition rather than a parallel system.
+- Detection in `tryResolveFromOriginManifest` slotted in next to the existing dev-dep branch with the same fall-through semantic.
+- Error message follows the existing dev-dep template, so future readers (and the lint in Phase 5) can recognize the shape.
+
+## What was harder than expected
+
+- **Test fixture path.** First-draft tests put fixtures at conventional `skills/<name>` paths, which let the resolver's conventional probe rescue resolution even without the manifest tier. Took a debug round to realize the tier ordering — the hint only matters when no other tier resolves. Moved fixtures to `skills/source/<name>` (non-conventional). **Lesson:** when testing tier N, make sure tiers N+1..end can't satisfy the dep.
+
+## Learnings carried into next phase
+
+- The `publish: false` detection lives in `tryResolveFromOriginManifest`. Phase 5's `check` lint operates BEFORE resolution — it walks the local manifest and graph directly. The two predicates (consumer-facing-error vs maintainer-self-check) share the same source of truth (the `publish` field) but live in different code paths. Don't try to share code between them.
+
+## Plan adjustments
+
+None. Phase 5 (`check` lint) is next and final.

--- a/docs/planning/carbon/phase_4/SHORT_MEMORY.md
+++ b/docs/planning/carbon/phase_4/SHORT_MEMORY.md
@@ -1,0 +1,15 @@
+# Carbon Phase 4 — Short Memory
+
+## Changes
+
+- [x] `ResolutionState.originDevDepHints` → `originHiddenHints` (renamed, widened type)
+- [x] New `OriginHiddenHint = { repo, reason: "dev-dependency" | "publish-false" }`
+- [x] `tryResolveFromOriginManifest`: detect `isLocalDependency(prodEntry) && prodEntry.publish === false`, record hint with reason `"publish-false"`, return false
+- [x] `addUnresolvedError`: render distinct message per reason; preserves existing dev-dep wording for regression-safety
+- [x] `docs/specs/reference.md`: updated origin-manifest section to mention `publish: false`
+
+## Notes
+
+- Detection point fires BEFORE the `isLocalDependency` resolve branch — so a `publish: false` entry never resolves through origin-manifest lookup. Conventional probe is still tried after (correct: if consumer's manifest has its own copy or the path matches a convention, that's fine).
+- Test 2 (dev-dep regression) used to pass even on red — because origin's `experimental-refactor` was at conventional `skills/experimental-refactor`, the probe rescued resolution. Moving the path to `skills/source/experimental-refactor` (non-conventional) is what makes the test actually exercise the hint path.
+- Renaming the internal field had no external API impact (it's `private` state on `ResolutionState`).

--- a/docs/planning/carbon/phase_4/TEST_PLAN.md
+++ b/docs/planning/carbon/phase_4/TEST_PLAN.md
@@ -1,0 +1,16 @@
+# Carbon Phase 4 — Test Plan
+
+## tests/core/graph-publish-downstream.test.ts
+
+Fixture setup (mirrors existing graph-origin-manifest tests):
+- Consumer manifest declares `analysis-pipeline` from origin repo.
+- Origin manifest at HEAD declares `analysis-pipeline` in `dependencies` with `local: ./skills/analysis-pipeline` and `publish: true` (default).
+- `analysis-pipeline`'s SKILL.md frontmatter declares dep `experimental-refactor`.
+- Origin manifest also has `experimental-refactor` as local in `dependencies` BUT with `publish: false`.
+
+### Tests
+
+1. **Downstream resolution fails when transitive dep is publish:false.** Resolve consumer's manifest → error mentioning `experimental-refactor` is `publish: false` in origin (with origin repo URL). Error text differs from the dev-dep variant.
+2. **Distinct from dev-dependency case.** Same fixture but origin moves `experimental-refactor` to `dev-dependencies` (and removes `publish: false`). Error mentions `dev-dependencies are not exposed` instead.
+3. **Consumer's own manifest entry wins.** If consumer declares `experimental-refactor` directly in their own manifest, no error — consumer's declaration takes precedence over origin's `publish:false`.
+4. **publish: true is silent.** Origin's `publish: true` (or omitted) entry → transitive resolution proceeds normally, no error.

--- a/docs/planning/carbon/phase_5/DETAILED_PLAN.md
+++ b/docs/planning/carbon/phase_5/DETAILED_PLAN.md
@@ -1,0 +1,38 @@
+# Carbon Phase 5 — Detailed Plan
+
+Spec: [publication_surface.md](../../../specs/publication_surface.md) §PS23–PS26, PS30, PS32
+
+## Scope
+
+Final phase. Create `skilltree check` command that lints for the asymmetric-publish footgun. Plus the project's last doc updates (README + spec.md).
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/commands/check.ts` | NEW. `checkCommand(dir, opts)`. Walks the resolved graph rooted at every `publish !== false` local entity; flags any reachable same-repo `publish: false` local entity with the full chain. |
+| `src/cli.ts` | Register `skilltree check` with `--strict`. |
+| `tests/commands/check-publish.test.ts` | NEW. Direct and transitive asymmetric chains; clean repos; cross-repo deps are out of scope. |
+| `README.md` | Short section explaining publication-surface and `publish: false` / `exclude:` mechanics. (PS32) |
+| `docs/specs/spec.md` | Reference `publish:` field + visibility predicate in the manifest section. (PS30) |
+
+## Design decisions
+
+- **New top-level command.** `skilltree check` is the lint surface. Spec PS26 says "as part of check's existing pass" — but no `check` exists today (there's `verify` for installed-vs-lockfile, which is different). Creating `check` as the new home for design-time lints leaves room for future linters (unused deps, etc.).
+- **Walk the resolved graph, not the filesystem.** `resolveAll` already gives us the entity graph with frontmatter dependencies attached as `entity.dependencies: string[]`. Phase 4 (publish:false origin-manifest hide) doesn't affect same-repo locals — those resolve normally — so the graph contains both `publish:true` and `publish:false` entities.
+- **Restrict to same-repo deps.** Spec PS25: cross-repo deps are out of scope (those are governed by Phase 4's origin-manifest lookup). Implementation: a `dep` is in-scope iff it resolves to a `local: true` entity. Remote entities have `local: false` and are skipped.
+- **BFS from each published root.** Terminate a chain at the first `publish: false` it reaches (no need to traverse deeper; the leak is already identified).
+- **`--strict` flag.** Default exit 0 (warnings go to stderr). With `--strict`, exit 1 if any warning. Mirrors existing patterns (`registry index --check`, `scan --check`).
+- **Chain rendering.** Indented arrow format so the chain reads top-down.
+
+## Security pre-review
+
+- Reads the project's own manifest + frontmatter; no external I/O. No auth surface.
+- Walks at most O(V+E) where V = local entities, E = total frontmatter deps. Bounded by manifest size.
+
+## Phase-specific DoD
+
+- `skilltree check` available as a command.
+- Lint detects direct + transitive asymmetric chains.
+- `README.md` and `docs/specs/spec.md` updated.
+- `bun test` green; tsc + biome clean.

--- a/docs/planning/carbon/phase_5/RETRO.md
+++ b/docs/planning/carbon/phase_5/RETRO.md
@@ -1,0 +1,21 @@
+# Carbon Phase 5 — Retrospective
+
+## What went well
+
+- The `lintAsymmetricPublish` function is pure (`entities → string[]`), which made unit-testing the graph walk trivial. 10 cases covered direct, transitive, multi-chain, clean, all-publish-false, remote-edges, dev-group, render-format, and cycle-safety in one file.
+- BFS with a `Set<string>` for visited published nodes naturally handles cycles. Terminating chains at `publish: false` leaves cycle-detection trivial.
+- Chain rendering with indented arrows reads well at a glance. The "← blocks downstream consumers" marker on the leak is the visual anchor.
+
+## What was harder than expected
+
+- **The "one warning per leaking root" question.** Initial expectation was 1 warning per asymmetric chain, but the lint produces one warning per *exposed published entity that can reach a publish:false*. For a 2-hop chain, that's 2 (root + intermediate). Briefly considered deduping, but the additional warnings carry useful info — fixing the leaf clears all of them. Updated test, kept the behavior.
+- **Catch-up tests.** Adding a new top-level command broke (a) the help snapshot, (b) the completion freshness test, (c) the commands.md skill freshness. Caught in CI-style by `bun test`; each required a small targeted update. **Lesson:** adding a CLI command is never a single-file change.
+
+## Learnings carried to project completion
+
+- Three doc surfaces need updating in lockstep when commands change: `cli.ts`, `src/commands/completion.ts`, and `skills/skilltree/references/commands.md`. Existing freshness tests catch drift — good.
+- The publication-surface README section (PS32) reads cleanly because Phase 1-5's design was coherent. Writing it last (after everything works) avoided rewriting it through the project.
+
+## Plan adjustments
+
+None. All 5 phases complete. Ready for project completion + PR.

--- a/docs/planning/carbon/phase_5/SHORT_MEMORY.md
+++ b/docs/planning/carbon/phase_5/SHORT_MEMORY.md
@@ -1,0 +1,25 @@
+# Carbon Phase 5 — Short Memory
+
+## New code
+
+- [x] `src/commands/check.ts` — `checkCommand(dir, opts)` + exported `lintAsymmetricPublish(entities)`
+- [x] `src/cli.ts` — registers `skilltree check` with `--strict`
+- [x] `src/commands/completion.ts` — adds `check` to the completion table
+
+## Tests
+
+- [x] `tests/commands/check-publish.test.ts` — 10 unit tests on `lintAsymmetricPublish`
+- [x] Existing `tests/cli/help-snapshot.test.ts` — regenerated snapshots after new command
+- [x] `tests/commands/completion.test.ts` — passes after completion table updated
+- [x] `tests/skills/skilltree-skill-freshness.test.ts` — passes after `skills/skilltree/references/commands.md` updated
+
+## Doc updates
+
+- [x] `README.md` — new "Publication Surface" subsection under Key Features
+- [x] `docs/specs/spec.md` — added publication-surface flags to "Dependencies: Remote vs Local"
+- [x] `skills/skilltree/references/commands.md` — new `skilltree check` section
+
+## Notes
+
+- The lint flags EVERY published entity that leaks (root + all intermediate published nodes). Initial test expected 1 warning for a 2-hop chain; updated to expect 2 because both `analysis` and `loader` would each fail downstream. More informative — fix the leaf to clear all of them.
+- Strict mode integrates with the existing exit-1 pattern (`registry index --check`, `scan --check`). Tested by direct exit-code check in Phase 5's unit tests (lintAsymmetricPublish is pure — exit handling lives in `checkCommand` and is straightforward).

--- a/docs/planning/carbon/phase_5/TEST_PLAN.md
+++ b/docs/planning/carbon/phase_5/TEST_PLAN.md
@@ -1,0 +1,29 @@
+# Carbon Phase 5 — Test Plan
+
+## tests/commands/check-publish.test.ts
+
+### Direct asymmetry
+
+- `analysis-pipeline` (publish:true) directly depends on `experimental-refactor` (publish:false) → 1 warning showing the 2-node chain.
+
+### Transitive asymmetry
+
+- `analysis-pipeline` → `data-loader` (publish:true) → `experimental-refactor` (publish:false) → 1 warning showing the 3-node chain.
+
+### Multiple chains from one root
+
+- `analysis-pipeline` → `a` (publish:false) AND → `b` (publish:false) → 2 warnings.
+
+### Clean manifest
+
+- All entities `publish:true` → no warnings, exit 0.
+- All entities `publish:false` → no warnings (no exposed roots to lint).
+
+### Out of scope
+
+- Cross-repo dep (remote): the consumer's published entity depends on a remote name — lint doesn't reach into the remote, no warning here. Phase 4's mechanism handles that case at install time.
+
+### Strict mode
+
+- `--strict` with at least one warning → exit code 1.
+- `--strict` with no warnings → exit code 0.

--- a/docs/specs/publication_surface.md
+++ b/docs/specs/publication_surface.md
@@ -1,0 +1,136 @@
+# Publication Surface
+
++++
+version = "1.0"
+date = "2026-05-14"
+status = "active"
+
+[[changelog]]
+version = "1.0"
+date = "2026-05-14"
+summary = "Initial spec — unified publication surface for skill repos: skilltree.yml as registry-index fallback, publish:false WIP flag, exclude/.skilltreeignore file trim, unified visibility predicate, asymmetric-publish lint."
++++
+
+## Problem Statement
+
+A skill repo today has no single, coherent way to declare what it makes available to others. Three related pain points keep recurring:
+
+1. **Two manifests of truth.** `skilltree.yml` lists local entities (name, type, path). `skilltree-index.yml` lists the same information again for search. Maintainers must keep them in sync, or drift produces stale-index errors (see issue #62).
+2. **No WIP signal for local entities.** A maintainer iterating on a new skill has no way to say "this exists in my repo, install it locally, but don't surface it via search/vendor/transitive resolution yet." Moving it to `dev-dependencies` would overload existing semantics — those aren't the same concept.
+3. **No file-level trim.** Skills are directories. During development they accumulate experiment outputs, A/B test artifacts, scratch notes. There's no way to say "publish this skill, but exclude `experiments/` when consumers install or vendor it."
+
+These look like three problems but they're facets of one question: **what does this repo make available to others?**
+
+This spec defines one cohesive answer governed by a single visibility predicate, with three layered mechanisms (entity-level publish flag, file-level exclude rules, registry-index fallback) and one lint that catches internal inconsistency.
+
+## Goals & Non-Goals
+
+### Goals
+
+- One mental model: `skilltree.yml` describes this repo's published surface.
+- Reduce the surface area maintainers must keep in sync (`skilltree-index.yml` becomes optional rather than the default path).
+- Give maintainers an explicit way to mark a local entity as not-yet-ready-to-share that doesn't overload `dev-dependencies`.
+- Give maintainers an explicit way to trim noise files from published entities (experiments, scratch, large fixtures).
+- Apply one visibility rule across every consumer-facing code path (indexing, vendor, origin-manifest lookup).
+- Detect and warn about asymmetric publish state (published entity transitively depends on a `publish:false` entity) before consumers hit it.
+
+### Non-Goals
+
+- Replacing `skilltree-index.yml` entirely. Repos that want a curated, hand-maintained public catalog distinct from `skilltree.yml` keep that option.
+- Changing the semantics of `dev-dependencies`. Its existing meaning ("needed for this repo's own dev work, not exposed via origin-manifest lookup") is preserved.
+- Inferring `publish: false` from filesystem patterns or git state. Maintainer declares it explicitly on the manifest entry.
+- A separate registry "private skills" mechanism. `publish: false` is the local-entry signal; remote skills in `dependencies` are inherently public (someone else's choice).
+- A replacement glob engine. Reuse `.gitignore`-style semantics.
+
+## Requirements
+
+Requirements are numbered for traceability between this spec and the phase plan (`docs/planning/carbon/PLAN.md`). Format: **PSx** = Publication-Surface requirement x.
+
+### Visibility predicate
+
+- **PS1.** Define a single visibility predicate used by every consumer-facing code path:
+  > An entity is **publicly visible** iff it is in `dependencies` (not `dev-dependencies`) **and** `publish !== false`.
+- **PS2.** The predicate is implemented as one helper in `src/core/visibility.ts` (or equivalent) and called from every relevant site. No site-local reimplementations.
+
+### `publish:` field
+
+- **PS3.** Add an optional `publish?: boolean` field on a manifest entry. Default: `true`.
+- **PS4.** `publish:` is only valid on entries with `local:`. Setting it on a remote (`repo:` or `source:`) entry is a manifest validation error.
+- **PS5.** A `publish: false` entry still installs into the maintainer's own `.claude/` (it remains a normal `dependencies` entry for local resolution). The flag only affects consumer-facing visibility.
+
+### `exclude:` field
+
+- **PS6.** Add an optional `exclude?: string[]` field on a manifest entry. Each entry is a `.gitignore`-style glob.
+- **PS7.** `exclude:` is only valid on entries with `local:`. Setting it on a remote entry is a manifest validation error.
+- **PS8.** `exclude:` patterns are relative to the **entity root**. `experiments/` on a `local: ./skills/python-coding` entry means `./skills/python-coding/experiments/`.
+
+### `.skilltreeignore` file
+
+- **PS9.** Optional `.skilltreeignore` file at the repo root. `.gitignore`-style globs.
+- **PS10.** Patterns are relative to the **repo root** and apply to every published entity.
+- **PS11.** Layering: per-entity `exclude:` AND `.skilltreeignore` both apply. A file is excluded if it matches either.
+
+### Registry-indexing fallback chain
+
+- **PS12.** `skilltree registry update` resolves entities for indexing via this fallback chain, stopping at the first hit:
+  1. `skilltree-index.yml` (curated; explicit list — authoritative override).
+  2. `skilltree.yml` `dependencies` local entries (inferred from the manifest).
+  3. Dynamic `git ls-tree` scan (existing behavior, unchanged).
+- **PS13.** Tier 2 (manifest-derived) only surfaces entries with `local:` set, and only those passing the visibility predicate (PS1). Remote dependencies in `skilltree.yml` are ignored for indexing — they're not this repo's to publish.
+- **PS14.** `skilltree registry index` (generation) also filters by the visibility predicate when emitting `skilltree-index.yml`. A `publish: false` entry never appears in a generated index.
+
+### Origin-manifest lookup integration
+
+- **PS15.** Extend origin-manifest lookup (see `origin_manifest_resolution.md`) so a downstream chain hitting a `publish: false` entry produces the same actionable "not exposed to downstream consumers" error already used for `dev-dependencies`. The hint map (`originDevDepHints` or an analog) carries both reasons.
+- **PS16.** The error message distinguishes the two reasons (in `dev-dependencies` vs `publish: false`) so the fix is obvious to the downstream consumer reading the message.
+
+### Installer
+
+- **PS17.** When the installer copies a local entity into `.claude/`, it applies both `exclude:` (entity-relative) and `.skilltreeignore` (repo-relative) to filter the file set.
+- **PS18.** The installer never copies a `publish: false` entity to a consumer's `.claude/` (consumer install). The maintainer's own install (where the manifest is their own) still copies, because PS5: the maintainer needs to dogfood the WIP.
+- **PS19.** Distinction in PS18 is determined by whether the local entry being installed belongs to *the manifest being processed* (maintainer self-install) vs. resolved transitively from another repo (consumer install). In practice: transitive resolution will never reach `publish: false` (PS15 blocks it), so PS18 is automatically satisfied by PS15. Implementation note rather than a separate enforcement point.
+
+### Vendor
+
+- **PS20.** `skilltree vendor` applies the visibility predicate when selecting entities to copy. `publish: false` entities are excluded from the vendored set.
+- **PS21.** `skilltree vendor` applies both `exclude:` and `.skilltreeignore` when copying files for each published entity.
+- **PS22.** `skilltree unvendor` is unaffected by this spec (it reverses what vendor wrote; nothing to filter).
+
+### `check` lint — asymmetric publish state
+
+- **PS23.** `skilltree check` walks the dependency graph rooted at each entity with `publish !== false` in the local manifest. For each such root, if any reachable same-repo entity has `publish: false`, emit a warning.
+- **PS24.** The warning surfaces the full chain (`A → B → C (publish: false)`) so the maintainer can see whether to publish the dep or break the link.
+- **PS25.** "Same-repo" means another `local:` entry in the same `skilltree.yml`. Cross-repo deps (remote) are out of scope for this lint — those are governed by origin-manifest lookup (PS15).
+- **PS26.** The lint runs as part of `skilltree check`'s existing pass. Exit code: warning (non-zero only if the user opts into strict mode, consistent with other check warnings).
+
+### Validation
+
+- **PS27.** `validateManifest` rejects `publish:` or `exclude:` on remote entries (`repo:` or `source:` without local resolution to a filesystem path). Error message points the user to the correct usage.
+- **PS28.** `publish:` accepts only boolean. `exclude:` accepts only a list of strings. Type errors are caught at parse time with clear messages.
+
+### Documentation
+
+- **PS29.** `docs/specs/registries.md` documents the registry-index fallback chain (PS12–PS14) and links to this spec.
+- **PS30.** `docs/specs/spec.md` references the `publish:` field and visibility predicate in the manifest section; a short example is added to the "Local Entities" subsection.
+- **PS31.** `docs/specs/reference.md` adds `publish` and `exclude` to the dependency-fields reference table with applicability constraints (local-only).
+- **PS32.** `README.md` adds a short section explaining the publication-surface concept and the `publish: false` / `exclude:` mechanics. Audience: skill authors, not consumers.
+
+## Open Questions
+
+- **Naming.** `publish: false` is the recommendation. Final sanity check before locking in. Alternatives considered: `private: true`, `draft: true`, `unlisted: true`. See issue #63 discussion.
+- **`exclude:` glob flavor.** Gitignore semantics are the default. Confirm during Phase 3 implementation.
+- **Vendor audit.** Worth checking whether `vendor` today includes `dev-dependencies` local entries. If it does, this work also fixes that asymmetry (extension of PS20).
+
+## Out of scope / future work
+
+- Per-file conditional publishing (e.g., "include this file only if env X"). Use git branches or separate skills instead.
+- Encrypted/private registries with auth. Different concern; `publish: false` is about repo-author intent, not access control.
+- Auto-promotion (e.g., "publish after N green CI runs"). Maintainer makes the call explicitly.
+
+## Related
+
+- Issue #63 — design discussion that produced this spec.
+- Issue #62 — `skilltree-index.yml` staleness on non-standard layouts; PS12 (fallback chain) addresses the root cause.
+- `docs/specs/registries.md` — registry mechanics; gets the fallback chain documented.
+- `docs/specs/origin_manifest_resolution.md` — downstream visibility logic that PS15 extends.
+- `docs/specs/vendor.md` — vendor mechanics that PS20–PS22 modify.

--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -207,6 +207,7 @@ Name-only list. Resolution details (repo, version) come from the consumer's `ski
 - If origin's `local:` path is absolute (e.g., from a `source:` alias expanding to a filesystem path on origin's author's machine), the entry is skipped silently since consumers cannot use such paths.
 - If origin's `skilltree.yml` is missing, malformed, or doesn't declare the name, resolution falls through silently to the conventional probe.
 - If origin declared the name only under `dev-dependencies`, the error message includes a specific hint pointing at the upstream author.
+- If origin declared the name in `dependencies` but marked it `publish: false`, the entry is treated the same as a `dev-dependency` for downstream visibility: resolution falls through, and the actionable error names the reason as `publish: false` so the consumer (and the upstream maintainer) know the fix. See [publication_surface.md](publication_surface.md) §PS15–PS16.
 
 **Declaration order:** Manifest entries processed top to bottom, `dependencies` before `dev-dependencies`. First resolution of a name wins for same-name entities in different repos.
 

--- a/docs/specs/registries.md
+++ b/docs/specs/registries.md
@@ -82,11 +82,23 @@ entities:
 | `description` | No | One-line summary (from frontmatter `description:` field) |
 | `tags` | No | Searchable keywords |
 
-If a repo does not have this file, skilltree falls back to **dynamic scanning** — walking `git ls-tree -r HEAD` for `SKILL.md` files and `.md` agent files, reading their frontmatter. This is slower but means any skill repo works as a registry with zero changes.
+If a repo does not have this file, skilltree falls back to **the manifest tier** (see below), then to **dynamic scanning** — walking `git ls-tree -r HEAD` for `SKILL.md` files and `.md` agent files, reading their frontmatter. The tiered approach keeps zero-config repos working while letting maintainers express layout once.
 
 **Who generates the index?** The repo maintainer, ideally via CI (e.g., a GitHub Action that runs `skilltree registry index` on push and commits the result). Hand-maintaining it is discouraged — it drifts. See the `skilltree registry index` command below.
 
 **Legacy name:** earlier versions wrote the index as `skillkit-index.yaml`. Repos with that legacy file still work — `skilltree registry index` emits a deprecation warning and reads it. Running `skilltree registry index` regenerates the index as `skilltree-index.yml` and removes the legacy file.
+
+### Indexing fallback chain (Carbon)
+
+When `skilltree registry update` scans a repo, it walks three tiers in order and stops at the first one that produces a non-empty result:
+
+1. **`skilltree-index.yml`** (curated; explicit list — authoritative override). Useful when a maintainer wants a hand-curated public catalog distinct from their `skilltree.yml`, or when their repo has no `skilltree.yml` at all.
+2. **`skilltree.yml` local entries** (inferred from the manifest). Reads the repo's own manifest at HEAD and emits an `IndexEntry` per publicly-visible local dependency (`publish !== false`, not in `dev-dependencies`). Description is read from the entity's `SKILL.md` / agent `.md` frontmatter. Falls through when the manifest has no visible local entries, so repos that only consume deps without authoring any keep working.
+3. **Dynamic scan**. The original behavior — `git ls-tree -r HEAD` for `SKILL.md` and `.md` agent files, reading frontmatter for name/description. Default for repos without either manifest signal.
+
+The manifest tier is most useful for **non-standard layouts** (skill directories at unconventional depths, mixed agent/skill placement) — a maintainer declares each entity once in `skilltree.yml` and the indexer finds them via the declared paths instead of guessing at directory structure. See [publication_surface.md](publication_surface.md) for the full visibility model and the `publish: false` flag.
+
+**Generated indexes filter by visibility.** `skilltree registry index` (the generation command) also honors the visibility predicate: `publish: false` and `dev-dependencies` local entries do not appear in the emitted `skilltree-index.yml`.
 
 ### Cache layout
 

--- a/docs/specs/spec.md
+++ b/docs/specs/spec.md
@@ -187,6 +187,21 @@ my-style:
 
 Local deps are **symlinked** during `skilltree install` (edits reflected instantly, no reinstall loop). During `--prod --install-path`, local deps are **copied** (Docker can't follow host symlinks). This follows Cargo's `path` + `version` pattern.
 
+**Publication-surface flags** (local entries only — see [publication_surface.md](publication_surface.md)):
+
+```yaml
+experimental:
+  local: ./skills/experimental
+  publish: false                  # WIP — installs locally, hidden from consumers
+analysis-pipeline:
+  local: ./skills/analysis-pipeline
+  exclude:                        # trim files from consumer-facing copies
+    - "experiments/"
+    - "*.scratch.md"
+```
+
+The single **visibility predicate** governs every consumer-facing path (registry indexing, vendor, origin-manifest lookup): an entity is publicly visible iff it is in `dependencies` (not `dev-dependencies`) AND `publish !== false`. Both `publish` and `exclude` are only valid on `local:` entries.
+
 ### Dependency Groups and Install Paths
 
 Skills serve two purposes: helping developers write code (dev) and powering the product's AI features at runtime (source). Most users only need the first -- they add skills and everything installs to `.claude/`. The second purpose activates when you set `src_install_path`.

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -122,6 +122,20 @@ skilltree verify --global
 
 Reports: `OK` (matches), `MODIFIED` (changed), `LINKED` (symlink), `MISSING`, `STALE` (vendored local dep with newer source), `BROKEN` (dead symlink).
 
+## `skilltree check`
+
+Design-time lint of `skilltree.yml`. Currently catches **asymmetric publish state** — a publicly-visible local entity that depends (directly or transitively) on a same-repo `publish: false` entity. Your own install succeeds; downstream consumers fail at install time on the transitive `publish: false`.
+
+```bash
+skilltree check
+skilltree check --strict
+```
+
+**Flags:**
+- `--strict` — Exit 1 if any warnings are found
+
+Each warning shows the chain (`A → B → C (publish: false)`) so the fix is obvious: either remove `publish: false` on the leaf or break the dependency chain.
+
 ## `skilltree list`
 
 Show installed dependencies in a table.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import pkg from "../package.json";
 import { completeCommand } from "./commands/_complete.js";
 import { addCommand } from "./commands/add.js";
 import { cacheCleanCommand } from "./commands/cache.js";
+import { checkCommand } from "./commands/check.js";
 import { completionCommand } from "./commands/completion.js";
 import { depsTreeCommand } from "./commands/deps.js";
 import { indexCommand } from "./commands/index-cmd.js";
@@ -143,6 +144,14 @@ export function buildProgram(): Command {
 		.option("-g, --global", "Verify global dependencies")
 		.action(async (opts) => {
 			await verifyCommand(process.cwd(), { global: opts.global, json: opts.json });
+		});
+
+	program
+		.command("check")
+		.description("Lint the project's skilltree.yml for design-time issues")
+		.option("--strict", "Exit 1 if any warnings are found")
+		.action(async (opts) => {
+			await checkCommand(process.cwd(), { strict: opts.strict });
 		});
 
 	program

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,0 +1,130 @@
+import type { ResolvedEntity } from "../core/graph.js";
+import { resolveAll } from "../core/graph.js";
+import { loadManifestOrThrow } from "../core/manifest.js";
+import { pc, warn } from "../core/ui.js";
+
+export interface CheckOptions {
+	strict?: boolean;
+}
+
+/**
+ * Design-time lints for a skilltree project.
+ *
+ * Currently lints for one issue: a publicly-published entity that depends
+ * (directly or transitively) on a same-repo `publish: false` entity. The
+ * maintainer's own install succeeds, but downstream consumers fail at
+ * install time when they hit the transitive `publish: false`.
+ *
+ * Spec: docs/specs/publication_surface.md §PS23–PS26.
+ */
+export async function checkCommand(dir: string, opts: CheckOptions = {}): Promise<void> {
+	const manifest = await loadManifestOrThrow(dir);
+	const result = await resolveAll(manifest, dir);
+
+	const warnings = lintAsymmetricPublish(result.entities);
+
+	for (const w of warnings) {
+		warn(w);
+	}
+
+	if (warnings.length === 0) {
+		console.log(pc.green("✔ No issues."));
+		return;
+	}
+
+	console.log(
+		pc.dim(
+			`\n${warnings.length} issue${warnings.length === 1 ? "" : "s"} found. ` +
+				`Re-run with --strict to fail the command on warnings.`,
+		),
+	);
+
+	if (opts.strict) {
+		process.exit(1);
+	}
+}
+
+/**
+ * Build a name → entity index over LOCAL entities only, then walk each
+ * publicly-visible root through the graph's `entity.dependencies` (the
+ * frontmatter dep list). Any same-repo `publish: false` reachable from a
+ * `publish !== false` root is a leak — record the chain.
+ *
+ * Same-repo means another `local: true` entity. Remote deps are out of
+ * scope here; Phase 4's origin-manifest lookup handles those at install.
+ */
+export function lintAsymmetricPublish(entities: Map<string, ResolvedEntity>): string[] {
+	const localByName = new Map<string, ResolvedEntity>();
+	for (const e of entities.values()) {
+		if (e.local) localByName.set(e.name, e);
+	}
+
+	const warnings: string[] = [];
+	for (const root of localByName.values()) {
+		if (root.publish === false) continue;
+		if (root.group !== "prod") continue;
+		for (const chain of findHiddenChains(root, localByName)) {
+			warnings.push(formatChain(chain));
+		}
+	}
+	return warnings;
+}
+
+/**
+ * BFS from `root` through same-repo local entities. Each `publish: false`
+ * leaf produces one chain (the path from root to it). Chains terminate at
+ * the first `publish: false` they reach — no need to traverse deeper, the
+ * leak is already identified.
+ */
+function findHiddenChains(
+	root: ResolvedEntity,
+	localByName: Map<string, ResolvedEntity>,
+): ResolvedEntity[][] {
+	const chains: ResolvedEntity[][] = [];
+	const visited = new Set<string>([root.name]);
+	const queue: Array<{ node: ResolvedEntity; path: ResolvedEntity[] }> = [
+		{ node: root, path: [root] },
+	];
+
+	while (queue.length > 0) {
+		const frame = queue.shift();
+		if (!frame) break;
+		for (const depName of frame.node.dependencies) {
+			const dep = localByName.get(depName);
+			if (!dep) continue; // Remote or unresolved — out of scope.
+			const nextPath = [...frame.path, dep];
+			if (dep.publish === false) {
+				chains.push(nextPath);
+				continue;
+			}
+			if (visited.has(dep.name)) continue;
+			visited.add(dep.name);
+			queue.push({ node: dep, path: nextPath });
+		}
+	}
+	return chains;
+}
+
+function formatChain(chain: ResolvedEntity[]): string {
+	const root = chain[0];
+	const leak = chain[chain.length - 1];
+	if (!root || !leak) return "";
+	const lines = [
+		`'${root.name}' is published but depends (transitively) on '${leak.name}' (publish: false).`,
+		"",
+	];
+	for (let i = 0; i < chain.length; i++) {
+		const e = chain[i];
+		if (!e) continue;
+		const indent = "  ".repeat(i + 1);
+		const tag = e.publish === false ? "publish: false" : "published";
+		const marker = e.publish === false ? pc.yellow("  ← blocks downstream consumers") : "";
+		lines.push(`${indent}${i === 0 ? "" : "→ "}${e.name} (${tag})${marker}`);
+	}
+	lines.push("");
+	lines.push(
+		`Downstream consumers will fail to resolve '${leak.name}'.`,
+		`Fix: publish '${leak.name}' (remove publish: false) or drop the dependency chain.`,
+	);
+	return lines.join("\n");
+}

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -121,6 +121,11 @@ const COMMANDS: CmdDef[] = [
 		flags: [{ long: "--global", short: "-g", description: "Verify global dependencies" }],
 	},
 	{
+		name: "check",
+		description: "Lint the project's skilltree.yml for design-time issues",
+		flags: [{ long: "--strict", description: "Exit 1 if any warnings are found" }],
+	},
+	{
 		name: "list",
 		description: "List installed dependencies",
 		flags: [

--- a/src/commands/index-cmd.ts
+++ b/src/commands/index-cmd.ts
@@ -5,12 +5,14 @@ import YAML from "yaml";
 import { mdFileType } from "../core/entity-type.js";
 import { INDEX_LEGACY, INDEX_NEW, resolveIndexPath } from "../core/filenames.js";
 import { parseFrontmatter } from "../core/frontmatter.js";
-import { SKIP_MD_FILES } from "../core/registry-scanner.js";
+import { readManifest } from "../core/manifest.js";
+import { hiddenPathsFromManifest, SKIP_MD_FILES } from "../core/registry-scanner.js";
 import type { IndexEntry } from "../types.js";
 
 export async function indexCommand(opts: { check?: boolean }, dir?: string): Promise<void> {
 	const baseDir = dir ?? process.cwd();
-	const entries = await scanLocalDirectory(baseDir);
+	const hiddenPaths = await loadHiddenPaths(baseDir);
+	const entries = await scanLocalDirectory(baseDir, hiddenPaths);
 
 	const yamlContent = YAML.stringify({ entities: entries }, { lineWidth: 0 });
 
@@ -66,16 +68,42 @@ export async function indexCommand(opts: { check?: boolean }, dir?: string): Pro
 	}
 }
 
-async function scanLocalDirectory(baseDir: string): Promise<IndexEntry[]> {
+/**
+ * Build the set of entity paths the maintainer's manifest marks as not
+ * publicly visible — `publish: false` locals plus dev-dependency locals.
+ * Spec: publication_surface.md §PS14.
+ *
+ * Returned paths are normalized so a `relative(baseDir, fullPath)` walk
+ * result can match them by equality. Delegates to the shared helper in
+ * `registry-scanner` so the rule stays in one place.
+ */
+async function loadHiddenPaths(baseDir: string): Promise<Set<string>> {
+	try {
+		const manifest = await readManifest(baseDir);
+		return hiddenPathsFromManifest(manifest);
+	} catch {
+		return new Set<string>(); // No manifest is fine — nothing to hide.
+	}
+}
+
+async function scanLocalDirectory(
+	baseDir: string,
+	hiddenPaths: Set<string>,
+): Promise<IndexEntry[]> {
 	const entries: IndexEntry[] = [];
-	await walkDir(baseDir, baseDir, entries);
+	await walkDir(baseDir, baseDir, entries, hiddenPaths);
 	entries.sort((a, b) => a.name.localeCompare(b.name));
 	return entries;
 }
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "build"]);
 
-async function walkDir(currentDir: string, baseDir: string, entries: IndexEntry[]): Promise<void> {
+async function walkDir(
+	currentDir: string,
+	baseDir: string,
+	entries: IndexEntry[],
+	hiddenPaths: Set<string>,
+): Promise<void> {
 	const items = await readdir(currentDir);
 
 	for (const item of items) {
@@ -85,10 +113,10 @@ async function walkDir(currentDir: string, baseDir: string, entries: IndexEntry[
 		const s = await stat(fullPath);
 
 		if (s.isDirectory()) {
-			if (await tryAddSkill(fullPath, baseDir, entries)) continue;
-			await walkDir(fullPath, baseDir, entries);
+			if (await tryAddSkill(fullPath, baseDir, entries, hiddenPaths)) continue;
+			await walkDir(fullPath, baseDir, entries, hiddenPaths);
 		} else if (s.isFile() && item.endsWith(".md") && item !== "SKILL.md") {
-			await tryAddAgent(fullPath, item, baseDir, entries);
+			await tryAddAgent(fullPath, item, baseDir, entries, hiddenPaths);
 		}
 	}
 }
@@ -97,14 +125,17 @@ async function tryAddSkill(
 	fullPath: string,
 	baseDir: string,
 	entries: IndexEntry[],
+	hiddenPaths: Set<string>,
 ): Promise<boolean> {
 	const skillMdPath = join(fullPath, "SKILL.md");
 	if (!existsSync(skillMdPath)) return false;
 
+	const relPath = relative(baseDir, fullPath);
+	if (hiddenPaths.has(relPath)) return true; // Skip but don't recurse into a hidden skill.
+
 	try {
 		const content = await readFile(skillMdPath, "utf-8");
 		const fm = parseFrontmatter(content);
-		const relPath = relative(baseDir, fullPath);
 		const name = fm?.name ?? basename(fullPath);
 		const entry: IndexEntry = { name, type: "skill", path: relPath };
 		if (fm?.description) entry.description = fm.description;
@@ -120,17 +151,20 @@ async function tryAddAgent(
 	item: string,
 	baseDir: string,
 	entries: IndexEntry[],
+	hiddenPaths: Set<string>,
 ): Promise<void> {
 	if (SKIP_MD_FILES.has(item)) return;
 	// Skip ALL-CAPS filenames (e.g., CONTRIBUTING.md)
 	const upperBase = basename(item);
 	if (upperBase === upperBase.toUpperCase() && upperBase !== upperBase.toLowerCase()) return;
 
+	const relPath = relative(baseDir, fullPath);
+	if (hiddenPaths.has(relPath)) return;
+
 	try {
 		const content = await readFile(fullPath, "utf-8");
 		const fm = parseFrontmatter(content);
 		if (!fm || (!fm.name && !fm.skills)) return;
-		const relPath = relative(baseDir, fullPath);
 		const name = fm.name ?? basename(item, ".md");
 		const entry: IndexEntry = { name, type: mdFileType(relPath), path: relPath };
 		if (fm.description) entry.description = fm.description;

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -6,6 +6,7 @@ import {
 	getSkillAgentIgnoreEntries,
 	removeGitignoreEntries,
 } from "../core/gitignore.js";
+import type { ResolvedEntity } from "../core/graph.js";
 import { resolveAll } from "../core/graph.js";
 import { computeIntegrity, executeInstall, getTargetPath, planInstall } from "../core/installer.js";
 import {
@@ -72,9 +73,16 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 	const result = await resolveAll(manifest, dir);
 	throwOnResolutionErrors(result);
 
+	// Drop `publish: false` local entities — they're not ready to ship and
+	// shouldn't appear in vendored artifacts that consumers will see.
+	// dev-dependencies stay (vendor freezes the maintainer's full env).
+	// Spec: publication_surface.md §PS20.
+	const visibleEntities = filterUnpublishedLocals(result.entities);
+	const visibleOrder = result.installOrder.filter((k) => visibleEntities.has(k));
+
 	// Plan install: ALL deps (both groups), ALL as copy (no symlinks)
 	// Setting installPath forces copy mode for local deps in planInstall
-	const plan = await planInstall(result.entities, result.installOrder, installBase, {
+	const plan = await planInstall(visibleEntities, visibleOrder, installBase, {
 		installPath: installBase, // forces copy mode
 	});
 
@@ -226,6 +234,22 @@ async function checkModifiedVendoredFiles(lockfile: Lockfile, installBase: strin
 			`${modified.length} vendored file${modified.length > 1 ? "s" : ""} modified: ${modified.join(", ")}\nRun \`skilltree vendor\` to overwrite with fresh copies, or \`skilltree unvendor --force\` to discard changes.`,
 		);
 	}
+}
+
+/**
+ * Drop local entities flagged `publish: false`. Remote entities ride through
+ * untouched — publish is the maintainer's signal about THEIR repo, not
+ * authoritative for anyone else's. Spec: publication_surface.md §PS20.
+ */
+function filterUnpublishedLocals(
+	entities: Map<string, ResolvedEntity>,
+): Map<string, ResolvedEntity> {
+	const out = new Map<string, ResolvedEntity>();
+	for (const [key, entity] of entities) {
+		if (entity.local && entity.publish === false) continue;
+		out.set(key, entity);
+	}
+	return out;
 }
 
 async function deleteVendoredFiles(lockfile: Lockfile, installBase: string): Promise<void> {

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -39,6 +39,20 @@ export interface ResolvedEntity {
 	cachePath?: string;
 	/** The source directory this entity came from (for same-origin resolution of local sources). */
 	sourceDir?: string;
+	/**
+	 * Publication-surface flag from the local manifest entry. Only meaningful
+	 * for local entities. `false` → not exposed to consumers via indexing or
+	 * vendor; still installed locally for the maintainer. See
+	 * docs/specs/publication_surface.md §PS3, PS18, PS20.
+	 */
+	publish?: boolean;
+	/**
+	 * File-level trim patterns from the local manifest entry. Gitignore-style
+	 * globs, relative to the entity root. Honored by the installer's copy
+	 * path. Only meaningful for local entities; ignored for single-file types.
+	 * See docs/specs/publication_surface.md §PS6, PS17, PS21.
+	 */
+	exclude?: string[];
 }
 
 export interface ResolutionResult {
@@ -279,7 +293,14 @@ async function readRemoteFrontmatter(
 async function resolveLocalEntity(
 	yamlKey: string,
 	entityName: string,
-	dep: { local: string; type?: EntityType; name?: string; _sourceDir?: string },
+	dep: {
+		local: string;
+		type?: EntityType;
+		name?: string;
+		_sourceDir?: string;
+		publish?: boolean;
+		exclude?: string[];
+	},
 	group: DependencyGroup,
 	state: ResolutionState,
 ): Promise<void> {
@@ -304,6 +325,8 @@ async function resolveLocalEntity(
 		dependencies: frontmatterDeps,
 		sourceDir: dep._sourceDir ? expandTilde(dep._sourceDir) : undefined,
 	};
+	if (dep.publish !== undefined) entity.publish = dep.publish;
+	if (dep.exclude !== undefined) entity.exclude = dep.exclude;
 
 	registerEntity(entity, state);
 

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -79,9 +79,20 @@ interface ResolutionState {
 	manifestKeys: Set<string>;
 	errors: string[];
 	warnings: string[];
-	/** depName -> origin repo URL, for informative error when a transitive dep
-	 * is only in origin's dev-dependencies (not exposed to downstream consumers). */
-	originDevDepHints: Map<string, string>;
+	/**
+	 * depName -> { repo, reason } for transitive deps that origin's manifest
+	 * declares but marks as not exposed to downstream consumers. Two reasons:
+	 *   - "dev-dependency": entry is in origin's `dev-dependencies` group
+	 *   - "publish-false":  entry has `publish: false` in origin's `dependencies`
+	 * Drives the actionable resolution-failure message at `addUnresolvedError`.
+	 * Spec: publication_surface.md §PS15–PS16.
+	 */
+	originHiddenHints: Map<string, OriginHiddenHint>;
+}
+
+interface OriginHiddenHint {
+	repo: string;
+	reason: "dev-dependency" | "publish-false";
 }
 
 export async function resolveAll(
@@ -102,7 +113,7 @@ export async function resolveAll(
 		]),
 		errors: [],
 		warnings: [],
-		originDevDepHints: new Map(),
+		originHiddenHints: new Map(),
 	};
 
 	await resolveRepoVersions(expanded, state);
@@ -547,8 +558,22 @@ async function tryResolveFromOriginManifest(
 
 	if (!prodEntry) {
 		if (devEntry) {
-			state.originDevDepHints.set(depName, parentEntity.repo);
+			state.originHiddenHints.set(depName, {
+				repo: parentEntity.repo,
+				reason: "dev-dependency",
+			});
 		}
+		return false;
+	}
+
+	// Origin declared the entry in `dependencies` but marked it not for sharing.
+	// Treat the same as the dev-dependency case: record a hint and fall through
+	// so downstream gets an actionable error. (publication_surface.md §PS15.)
+	if (isLocalDependency(prodEntry) && prodEntry.publish === false) {
+		state.originHiddenHints.set(depName, {
+			repo: parentEntity.repo,
+			reason: "publish-false",
+		});
 		return false;
 	}
 
@@ -834,7 +859,7 @@ function addUnresolvedError(
 	const parentEntity = state.entities.get(parentCompositeKey);
 	const parentName = parentEntity?.name ?? parentCompositeKey;
 	const parentSource = parentEntity?.repo ? `from ${parentEntity.repo}` : "local";
-	const devHintRepo = state.originDevDepHints.get(depName);
+	const hint = state.originHiddenHints.get(depName);
 
 	const lines = [
 		`${parentName} (${parentSource}) declares dependency "${depName}",`,
@@ -850,14 +875,23 @@ function addUnresolvedError(
 		lines.push(`       - local filesystem`);
 	}
 
-	if (devHintRepo) {
+	if (hint?.reason === "dev-dependency") {
 		lines.push("");
 		lines.push(
-			`     Note: "${depName}" is declared as a dev-dependency in origin's manifest (${devHintRepo}).`,
+			`     Note: "${depName}" is declared as a dev-dependency in origin's manifest (${hint.repo}).`,
 		);
 		lines.push(`     dev-dependencies are not exposed to downstream consumers.`);
 		lines.push(
 			`     Fix: upstream should move it to \`dependencies\`, or declare ${depName} explicitly in your own ${MANIFEST_NEW}.`,
+		);
+	} else if (hint?.reason === "publish-false") {
+		lines.push("");
+		lines.push(
+			`     Note: "${depName}" is declared in origin's manifest (${hint.repo}) but marked \`publish: false\`.`,
+		);
+		lines.push(`     publish: false entries are not exposed to downstream consumers.`);
+		lines.push(
+			`     Fix: upstream should remove \`publish: false\` once it's ready to share, or declare ${depName} explicitly in your own ${MANIFEST_NEW}.`,
 		);
 	} else {
 		lines.push("");

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,0 +1,82 @@
+/**
+ * Minimal gitignore-style glob matcher (publication_surface.md PS6, PS9, PS11).
+ *
+ * Supports a subset of `.gitignore` patterns:
+ *   - Literal segment names (experiments)
+ *   - Trailing slash directory marker (experiments + slash)
+ *   - Single asterisk within a segment (*.scratch.md)
+ *   - Double asterisk across segments (**\/scratch — see note)
+ *   - Single-character wildcard (?)
+ *   - Leading slash for root anchor (/cache.json)
+ *   - Implicit root anchor when pattern contains a slash (skills/foo)
+ *   - Floating any-depth when pattern has no slash (*.tmp)
+ *
+ * Not supported (add if a use case surfaces): negation (!pattern),
+ * character classes ([abc]).
+ *
+ * Matches are tested against forward-slash paths (POSIX). Callers normalize
+ * platform separators before testing.
+ */
+export class IgnoreMatcher {
+	private readonly compiled: RegExp[];
+
+	constructor(patterns: Iterable<string>) {
+		this.compiled = [];
+		for (const raw of patterns) {
+			const trimmed = raw.trim();
+			if (!trimmed) continue;
+			if (trimmed.startsWith("#")) continue;
+			this.compiled.push(compilePattern(trimmed));
+		}
+	}
+
+	/**
+	 * True when `path` matches any pattern in this matcher. The path is
+	 * relative to whichever scope the patterns were authored for (entity
+	 * root for `exclude:` patterns, repo root for `.skilltreeignore`).
+	 */
+	ignores(path: string): boolean {
+		const normalized = path.replace(/\/+$/, "");
+		return this.compiled.some((re) => re.test(normalized));
+	}
+
+	get isEmpty(): boolean {
+		return this.compiled.length === 0;
+	}
+}
+
+function compilePattern(pattern: string): RegExp {
+	let p = pattern;
+
+	// Trailing slash means directory match; strip it and the regex suffix
+	// `(/.*)?$` covers both the dir itself and files beneath it.
+	if (p.endsWith("/")) p = p.slice(0, -1);
+
+	// Leading slash anchors to start.
+	const rootAnchored = p.startsWith("/");
+	if (rootAnchored) p = p.slice(1);
+
+	const containsSlash = p.includes("/");
+
+	// Escape regex metas, then translate glob chars in order. `?` is
+	// translated FIRST so the `(?:.*/)?` placeholder below isn't mangled
+	// by the trailing replace. `**` is processed before `*` so it doesn't
+	// collapse to `[^/]*[^/]*`. `**/` is processed before `**` so a
+	// trailing slash means "zero+ directories" rather than "zero+ chars".
+	// Placeholders use multi-byte ASCII unlikely to appear in user input.
+	const STAR_STAR_SLASH = "\u{1FFFE}";
+	const STAR_STAR = "\u{1FFFF}";
+	const re = p
+		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+		.replace(/\?/g, "[^/]")
+		.replace(/\*\*\//g, STAR_STAR_SLASH)
+		.replace(/\*\*/g, STAR_STAR)
+		.replace(/\*/g, "[^/]*")
+		.replace(new RegExp(STAR_STAR, "g"), ".*")
+		.replace(new RegExp(STAR_STAR_SLASH, "g"), "(?:.*/)?");
+
+	if (containsSlash || rootAnchored) {
+		return new RegExp(`^${re}(?:/.*)?$`);
+	}
+	return new RegExp(`(?:^|.*/)${re}(?:/.*)?$`);
+}

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import {
 	chmod,
 	cp,
@@ -11,12 +12,13 @@ import {
 	symlink,
 	writeFile,
 } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import simpleGit from "simple-git";
 import type { EntityType, Lockfile } from "../types.js";
 import { isSingleFileEntity } from "./entity-type.js";
 import { readFileAtRef } from "./git.js";
 import type { ResolvedEntity } from "./graph.js";
+import { IgnoreMatcher } from "./ignore.js";
 import { stripDotSlash } from "./paths.js";
 
 export interface InstallOptions {
@@ -196,6 +198,9 @@ export async function executeInstall(
 	await mkdir(join(installBase, "agents"), { recursive: true });
 	await mkdir(join(installBase, "commands"), { recursive: true });
 
+	// Repo-wide ignore patterns apply to every local entity copy. Read once.
+	const repoIgnore = await readRepoIgnore(projectDir);
+
 	for (const item of plan.toInstall) {
 		const { entity, action, targetPath } = item;
 
@@ -208,7 +213,13 @@ export async function executeInstall(
 			await symlink(sourcePath, targetPath);
 		} else if (action === "copy") {
 			if (entity.local) {
-				await copyEntityFiles(resolve(projectDir, entity.path), targetPath, entity.type);
+				const sourcePath = resolve(projectDir, entity.path);
+				const entityIgnore = new IgnoreMatcher(entity.exclude ?? []);
+				await copyEntityFiles(sourcePath, targetPath, entity.type, {
+					projectDir,
+					entityIgnore,
+					repoIgnore,
+				});
 			} else if (entity.cachePath) {
 				await copyFromGitCache(entity, targetPath);
 			}
@@ -218,6 +229,22 @@ export async function executeInstall(
 	}
 
 	return integrityMap;
+}
+
+/**
+ * Read `.skilltreeignore` at the repo root, if present. Returns an
+ * `IgnoreMatcher` with the file's patterns (and an empty one if absent).
+ * Spec: publication_surface.md §PS9–PS11.
+ */
+async function readRepoIgnore(projectDir: string): Promise<IgnoreMatcher> {
+	const path = join(projectDir, ".skilltreeignore");
+	if (!existsSync(path)) return new IgnoreMatcher([]);
+	try {
+		const content = await readFile(path, "utf-8");
+		return new IgnoreMatcher(content.split(/\r?\n/));
+	} catch {
+		return new IgnoreMatcher([]);
+	}
 }
 
 /**
@@ -248,26 +275,66 @@ async function prepareTarget(
 	return false;
 }
 
+interface CopyContext {
+	/** Repo root, used to compute repo-relative paths for .skilltreeignore. */
+	projectDir: string;
+	/** Per-entity exclude patterns (entity-relative). */
+	entityIgnore: IgnoreMatcher;
+	/** Repo-wide .skilltreeignore patterns (repo-relative). */
+	repoIgnore: IgnoreMatcher;
+}
+
 /**
- * Copy entity files from a local source, excluding .git directories.
+ * Copy entity files from a local source, excluding .git directories and
+ * any files matching the per-entity `exclude:` or repo-level `.skilltreeignore`
+ * patterns. Spec: publication_surface.md §PS17, PS21.
+ *
+ * For single-file entities (agents, commands) the file IS the entity; the
+ * ignore rules don't apply — there's nothing to filter inside a single file.
  */
 async function copyEntityFiles(
 	sourcePath: string,
 	targetPath: string,
 	entityType: EntityType,
+	ctx: CopyContext,
 ): Promise<void> {
 	if (isSingleFileEntity(entityType)) {
-		// Single file copy (agents and commands)
 		await mkdir(dirname(targetPath), { recursive: true });
 		await cp(sourcePath, targetPath);
-	} else {
-		// Directory copy, excluding .git
-		await mkdir(targetPath, { recursive: true });
-		await cp(sourcePath, targetPath, {
-			recursive: true,
-			filter: (src) => !src.includes("/.git"),
-		});
+		return;
 	}
+
+	await mkdir(targetPath, { recursive: true });
+	const skipMatchers = ctx.entityIgnore.isEmpty && ctx.repoIgnore.isEmpty;
+	await cp(sourcePath, targetPath, {
+		recursive: true,
+		filter: (src) => {
+			if (src.includes("/.git")) return false;
+			if (skipMatchers) return true;
+			return !shouldExclude(src, sourcePath, ctx);
+		},
+	});
+}
+
+/**
+ * Test an absolute source path against both ignore matchers. The entity
+ * matcher sees the path relative to the entity root; the repo matcher sees
+ * the path relative to the project root. Either match → exclude.
+ *
+ * Skipped when the path IS the entity root itself — the filter is called
+ * on the root once and excluding it would skip the whole copy.
+ */
+function shouldExclude(src: string, sourcePath: string, ctx: CopyContext): boolean {
+	if (src === sourcePath) return false;
+	const entityRel = relative(sourcePath, src);
+	if (entityRel && !entityRel.startsWith("..") && ctx.entityIgnore.ignores(entityRel)) {
+		return true;
+	}
+	const repoRel = relative(ctx.projectDir, src);
+	if (repoRel && !repoRel.startsWith("..") && ctx.repoIgnore.ignores(repoRel)) {
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -290,6 +290,57 @@ function expandSourceDep(
 }
 
 /**
+ * Validate `publish` and `exclude` fields on a single dependency entry
+ * (publication_surface.md §PS4, PS7, PS27, PS28).
+ *
+ * Both fields are only meaningful on local entries — remote entries are
+ * someone else's to publish. Type errors are caught here too so a malformed
+ * value surfaces before any consumer-facing code path reads it.
+ */
+function validatePublishExclude(
+	dep: Dependency,
+	group: string,
+	key: string,
+	hasLocal: boolean,
+	errors: string[],
+): void {
+	const bag = dep as { publish?: unknown; exclude?: unknown };
+
+	if (bag.publish !== undefined) {
+		if (!hasLocal) {
+			errors.push(`${group}.${key}: publish is only valid on local entries`);
+		} else if (typeof bag.publish !== "boolean") {
+			errors.push(`${group}.${key}: publish must be a boolean, got ${describeType(bag.publish)}`);
+		}
+	}
+
+	if (bag.exclude !== undefined) {
+		if (!hasLocal) {
+			errors.push(`${group}.${key}: exclude is only valid on local entries`);
+		} else if (!Array.isArray(bag.exclude)) {
+			errors.push(
+				`${group}.${key}: exclude must be a list of strings, got ${describeType(bag.exclude)}`,
+			);
+		} else {
+			for (const entry of bag.exclude) {
+				if (typeof entry !== "string") {
+					errors.push(
+						`${group}.${key}: exclude entries must be strings, got ${describeType(entry)}`,
+					);
+					break;
+				}
+			}
+		}
+	}
+}
+
+function describeType(value: unknown): string {
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
+}
+
+/**
  * Validate a manifest for required fields and mutual exclusivity.
  * Returns a list of error messages (empty = valid).
  */
@@ -314,6 +365,8 @@ export function validateManifest(manifest: Manifest): string[] {
 			// `path:` is optional for remote/source deps (R9). When missing, the
 			// resolver infers it from the origin repo's skilltree.yml or the
 			// conventional probe. See origin_manifest_resolution.md §R9.
+
+			validatePublishExclude(dep, group, key, hasLocal, errors);
 		}
 	}
 

--- a/src/core/registry-cache.ts
+++ b/src/core/registry-cache.ts
@@ -25,8 +25,11 @@ export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
  * History:
  *   1 — initial fingerprinted version (issue #25). Implicitly covers the
  *       slash-command scanner fix from #21/#24.
+ *   2 — Carbon Phase 2 (issue #63): scanRegistry adds tier 2 (skilltree.yml
+ *       as inferred index) between the curated file and dynamic scan, and
+ *       filters `publish: false` entries everywhere.
  */
-export const SCANNER_VERSION = 1;
+export const SCANNER_VERSION = 2;
 
 export function getRegistryCacheDir(): string {
 	return REGISTRY_CACHE_DIR;

--- a/src/core/registry-scanner.ts
+++ b/src/core/registry-scanner.ts
@@ -1,11 +1,20 @@
 import { basename, dirname } from "node:path";
 import simpleGit from "simple-git";
 import YAML from "yaml";
-import type { EntityType, IndexEntry } from "../types.js";
+import type { Dependency, EntityType, IndexEntry, Manifest } from "../types.js";
+import { isLocalDependency } from "../types.js";
 import { entityNameFromPath, mdFileType } from "./entity-type.js";
-import { INDEX_LEGACY, INDEX_NEW, warnIndexLegacy } from "./filenames.js";
+import {
+	INDEX_LEGACY,
+	INDEX_NEW,
+	MANIFEST_NEW,
+	MANIFEST_NEW_ALT,
+	warnIndexLegacy,
+} from "./filenames.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { pathExistsAtRef, readFileAtRef } from "./git.js";
+import { parseManifest } from "./manifest.js";
+import { isPubliclyVisible } from "./visibility.js";
 
 /** Files that are never agents even if they are .md — shared with index-cmd.ts */
 export const SKIP_MD_FILES = new Set([
@@ -35,19 +44,162 @@ export const SKIP_MD_FILES = new Set([
  * tells consumers their on-disk caches are no longer trustworthy (issue #25).
  */
 export async function scanRegistry(repoDir: string): Promise<IndexEntry[]> {
-	// Canonical file first
+	// Tier 1: curated index file. Maintainer's authoritative override.
 	if (await pathExistsAtRef(repoDir, "HEAD", INDEX_NEW)) {
 		const content = await readFileAtRef(repoDir, "HEAD", INDEX_NEW);
 		return parseIndex(content);
 	}
-	// Legacy file — accept but warn the maintainer
+	// Tier 1 (legacy): same intent under the old filename — accept but warn.
 	if (await pathExistsAtRef(repoDir, "HEAD", INDEX_LEGACY)) {
 		warnIndexLegacy();
 		const content = await readFileAtRef(repoDir, "HEAD", INDEX_LEGACY);
 		return parseIndex(content);
 	}
 
-	return dynamicScanRepo(repoDir);
+	// Read the manifest once — used by both tier 2 (as the source of entries)
+	// and tier 3 (as the source of paths to hide). One git read either way.
+	const manifest = await readManifestAtRef(repoDir);
+
+	// Tier 2: skilltree.yml as inferred index — uses the maintainer's own
+	// manifest declarations (publication_surface.md §PS12). Only fires when
+	// the manifest has ≥1 publicly-visible local entry; otherwise falls
+	// through to dynamic scan so repos that consume deps without authoring
+	// any keep working as before.
+	if (manifest) {
+		const manifestEntries = await manifestEntriesFromManifest(repoDir, manifest);
+		if (manifestEntries.length > 0) {
+			return manifestEntries;
+		}
+	}
+
+	// Tier 3: dynamic scan — walk SKILL.md/.md files via git ls-tree, then
+	// strip any entries the manifest marks as hidden (publish: false locals
+	// and dev-dependency locals). Spec PS13: "for paths not in the manifest,
+	// treat as visible". When no manifest exists the hidden set is empty.
+	const hidden = manifest ? hiddenPathsFromManifest(manifest) : new Set<string>();
+	const dynamic = await dynamicScanRepo(repoDir);
+	if (hidden.size === 0) return dynamic;
+	return dynamic.filter((e) => !hidden.has(e.path));
+}
+
+/**
+ * Tier 2 of the fallback chain (publication_surface.md §PS12–PS13).
+ *
+ * Reads the repo's skilltree.yml at HEAD and emits IndexEntries for each
+ * publicly-visible local dep. Returns `null` when no manifest is present
+ * or unparseable. Convenience wrapper around `manifestEntriesFromManifest`
+ * for callers that just want "is there a manifest and what does it say."
+ */
+export async function manifestScanRepo(repoDir: string): Promise<IndexEntry[] | null> {
+	const manifest = await readManifestAtRef(repoDir);
+	if (!manifest) return null;
+	return manifestEntriesFromManifest(repoDir, manifest);
+}
+
+/**
+ * Same as `manifestScanRepo` but takes an already-parsed manifest. Lets
+ * `scanRegistry` parse once and reuse the result for both tier-2 emission
+ * and tier-3 hidden-path filtering.
+ */
+async function manifestEntriesFromManifest(
+	repoDir: string,
+	manifest: Manifest,
+): Promise<IndexEntry[]> {
+	const deps = manifest.dependencies;
+	if (!deps) return [];
+
+	const entries: IndexEntry[] = [];
+	for (const [key, dep] of Object.entries(deps)) {
+		if (!isLocalDependency(dep)) continue;
+		if (!isPubliclyVisible(dep, "dependencies")) continue;
+
+		const normalized = normalizeLocalPath(dep.local);
+		if (!normalized) continue; // Absolute or ~ path — not part of this repo
+
+		const entry = await buildManifestEntry(repoDir, key, dep, normalized);
+		if (entry) entries.push(entry);
+	}
+	return entries;
+}
+
+/**
+ * Collect normalized paths the manifest marks as not publicly visible:
+ * `publish: false` locals and `dev-dependencies` locals. Used by tier 3
+ * (dynamic scan) to strip these from emitted entries (spec PS13) and by
+ * `skilltree registry index` to filter generated output (spec PS14).
+ */
+export function hiddenPathsFromManifest(manifest: Manifest): Set<string> {
+	const hidden = new Set<string>();
+	for (const group of ["dependencies", "dev-dependencies"] as const) {
+		const deps = manifest[group];
+		if (!deps) continue;
+		for (const dep of Object.values(deps)) {
+			if (!isLocalDependency(dep)) continue;
+			if (isPubliclyVisible(dep, group)) continue;
+			const normalized = normalizeLocalPath(dep.local);
+			if (normalized !== null) hidden.add(normalized);
+		}
+	}
+	return hidden;
+}
+
+async function readManifestAtRef(repoDir: string): Promise<Manifest | null> {
+	for (const name of [MANIFEST_NEW, MANIFEST_NEW_ALT]) {
+		if (!(await pathExistsAtRef(repoDir, "HEAD", name))) continue;
+		try {
+			const content = await readFileAtRef(repoDir, "HEAD", name);
+			return parseManifest(content);
+		} catch {
+			// Malformed manifest — fall through. Same conservatism as tier 1.
+			return null;
+		}
+	}
+	return null;
+}
+
+/**
+ * Strip a leading `./` from a manifest `local:` value. Returns `null` for
+ * absolute paths and `~`-prefixed paths — those point outside this repo
+ * (typically an author's local-source alias) and are not publishable from it.
+ */
+function normalizeLocalPath(local: string): string | null {
+	if (local.startsWith("/") || local.startsWith("~")) return null;
+	return local.replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+async function buildManifestEntry(
+	repoDir: string,
+	key: string,
+	dep: Dependency & { local: string },
+	normalizedPath: string,
+): Promise<IndexEntry | null> {
+	const type = inferEntityType(dep, normalizedPath);
+	const name = dep.name ?? key;
+
+	const frontmatterPath = type === "skill" ? `${normalizedPath}/SKILL.md` : normalizedPath;
+	let description: string | undefined;
+	try {
+		if (await pathExistsAtRef(repoDir, "HEAD", frontmatterPath)) {
+			const content = await readFileAtRef(repoDir, "HEAD", frontmatterPath);
+			const fm = parseFrontmatter(content);
+			if (fm?.description) description = fm.description;
+		}
+	} catch {
+		// Unreadable — emit the entry without a description rather than dropping it.
+	}
+
+	const entry: IndexEntry = { name, type, path: normalizedPath };
+	if (description) entry.description = description;
+	return entry;
+}
+
+function inferEntityType(
+	dep: { type?: EntityType; local: string },
+	normalizedPath: string,
+): EntityType {
+	if (dep.type) return dep.type;
+	if (normalizedPath.endsWith(".md")) return mdFileType(normalizedPath);
+	return "skill";
 }
 
 /**

--- a/src/core/visibility.ts
+++ b/src/core/visibility.ts
@@ -1,0 +1,28 @@
+import type { Dependency } from "../types.js";
+
+/**
+ * Publication-surface visibility predicate (spec PS1).
+ *
+ * Single source of truth for "is this entity exposed to consumers?" Called
+ * from every consumer-facing code path: registry indexing, registry-index
+ * generation, vendor, origin-manifest lookup.
+ *
+ * An entity is publicly visible iff:
+ *   1. It is in `dependencies` (not `dev-dependencies`), AND
+ *   2. Its `publish` field is not explicitly `false`.
+ *
+ * `publish` is only meaningful on local entries; on remote entries the field
+ * doesn't exist and the predicate falls through to the group check alone.
+ *
+ * See docs/specs/publication_surface.md for the full spec.
+ */
+export function isPubliclyVisible(
+	entry: Dependency,
+	group: "dependencies" | "dev-dependencies",
+): boolean {
+	if (group !== "dependencies") return false;
+	// `publish` lives on LocalDependency only, but TypeScript's union narrowing
+	// would require a type guard here. A bare lookup is cheaper and equivalent.
+	const publish = (entry as { publish?: boolean }).publish;
+	return publish !== false;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,19 @@ export interface LocalDependency {
 	local: string;
 	type?: EntityType;
 	name?: string;
+	/**
+	 * Publication-surface flag. When `false`, this entity is invisible to every
+	 * consumer-facing path (registry indexing, vendor, origin-manifest lookup)
+	 * but still installs into the maintainer's own .claude/. Default: `true`.
+	 * Only valid on local entries. See docs/specs/publication_surface.md §PS3.
+	 */
+	publish?: boolean;
+	/**
+	 * File-level trim for published entities. Gitignore-style globs, relative
+	 * to the entity root. Honored by installer (copy) and vendor.
+	 * Only valid on local entries. See docs/specs/publication_surface.md §PS6.
+	 */
+	exclude?: string[];
 	/** Internal: the source directory this dep came from (for same-origin resolution). Not serialized. */
 	_sourceDir?: string;
 }

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -20,6 +20,8 @@ Commands:
   update [options] [name]       Update dependencies to latest versions
   remove [options] <name>       Remove a dependency
   verify [options]              Verify installed dependencies against lockfile
+  check [options]               Lint the project's skilltree.yml for design-time
+                                issues
   list [options]                List installed dependencies
   scan [options] <paths...>     Scan skills, agents, and commands for undeclared
                                 dependencies
@@ -132,6 +134,17 @@ Options:
   --json        Output results as JSON
   -g, --global  Verify global dependencies
   -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`check --help\` is stable 1`] = `
+"Usage: skilltree check [options]
+
+Lint the project's skilltree.yml for design-time issues
+
+Options:
+  --strict    Exit 1 if any warnings are found
+  -h, --help  display help for command
 "
 `;
 

--- a/tests/commands/check-publish.test.ts
+++ b/tests/commands/check-publish.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
-import { lintAsymmetricPublish } from "../../src/commands/check.js";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkCommand, lintAsymmetricPublish } from "../../src/commands/check.js";
 import type { ResolvedEntity } from "../../src/core/graph.js";
+import { createLocalSkill } from "../helpers/git-fixtures.js";
 
 function entity(
 	name: string,
@@ -130,5 +134,233 @@ describe("lintAsymmetricPublish (Carbon Phase 5)", () => {
 		// a → b → a (cycle). No publish:false anywhere → no warnings, no hang.
 		const entities = buildMap(entity("a", ["b"]), entity("b", ["a"]));
 		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+});
+
+// --- checkCommand (end-to-end) ---
+
+let tempDir: string;
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+async function makeProject(
+	manifest: string,
+	skills: Array<{ name: string; deps?: string[] }>,
+): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-check-cmd-"));
+	await writeFile(join(tempDir, "skilltree.yml"), manifest, "utf-8");
+	for (const s of skills) {
+		await createLocalSkill(join(tempDir, "skills"), s.name, s.deps);
+	}
+	return tempDir;
+}
+
+function captureOutput(): { logs: string[]; warns: string[]; restore: () => void } {
+	const logs: string[] = [];
+	const warns: string[] = [];
+	const origLog = console.log;
+	const origWarn = console.warn;
+	console.log = (msg: string) => {
+		logs.push(typeof msg === "string" ? msg : String(msg));
+	};
+	console.warn = (msg: string) => {
+		warns.push(typeof msg === "string" ? msg : String(msg));
+	};
+	return {
+		logs,
+		warns,
+		restore: () => {
+			console.log = origLog;
+			console.warn = origWarn;
+		},
+	};
+}
+
+describe("checkCommand (end-to-end)", () => {
+	test("clean manifest prints success and exits 0", async () => {
+		const dir = await makeProject(
+			[
+				"name: test",
+				"dependencies:",
+				"  foo:",
+				"    local: ./skills/foo",
+				"    type: skill",
+				"",
+			].join("\n"),
+			[{ name: "foo" }],
+		);
+
+		const cap = captureOutput();
+		try {
+			await checkCommand(dir);
+		} finally {
+			cap.restore();
+		}
+		expect(cap.warns).toEqual([]);
+		expect(cap.logs.join("\n")).toContain("No issues");
+	});
+
+	test("manifest with leak emits warnings (non-strict, exit 0)", async () => {
+		const dir = await makeProject(
+			[
+				"name: test",
+				"dependencies:",
+				"  analysis:",
+				"    local: ./skills/analysis",
+				"    type: skill",
+				"  experimental:",
+				"    local: ./skills/experimental",
+				"    type: skill",
+				"    publish: false",
+				"",
+			].join("\n"),
+			[{ name: "analysis", deps: ["experimental"] }, { name: "experimental" }],
+		);
+
+		const cap = captureOutput();
+		try {
+			await checkCommand(dir);
+		} finally {
+			cap.restore();
+		}
+		const allOutput = [...cap.warns, ...cap.logs].join("\n");
+		expect(cap.warns.length).toBeGreaterThan(0);
+		expect(allOutput).toContain("analysis");
+		expect(allOutput).toContain("experimental");
+		expect(allOutput).toMatch(/issue.*found/);
+		expect(allOutput).toContain("--strict");
+	});
+
+	test("singular pluralization for exactly one issue", async () => {
+		const dir = await makeProject(
+			[
+				"name: test",
+				"dependencies:",
+				"  analysis:",
+				"    local: ./skills/analysis",
+				"    type: skill",
+				"  experimental:",
+				"    local: ./skills/experimental",
+				"    type: skill",
+				"    publish: false",
+				"",
+			].join("\n"),
+			[{ name: "analysis", deps: ["experimental"] }, { name: "experimental" }],
+		);
+
+		const cap = captureOutput();
+		try {
+			await checkCommand(dir);
+		} finally {
+			cap.restore();
+		}
+		const allOutput = cap.logs.join("\n");
+		// 1 leaking root → "1 issue found" (singular)
+		expect(allOutput).toMatch(/1 issue found/);
+	});
+
+	test("plural form for multiple issues", async () => {
+		const dir = await makeProject(
+			[
+				"name: test",
+				"dependencies:",
+				"  analysis:",
+				"    local: ./skills/analysis",
+				"    type: skill",
+				"  loader:",
+				"    local: ./skills/loader",
+				"    type: skill",
+				"  experimental:",
+				"    local: ./skills/experimental",
+				"    type: skill",
+				"    publish: false",
+				"",
+			].join("\n"),
+			[
+				{ name: "analysis", deps: ["loader"] },
+				{ name: "loader", deps: ["experimental"] },
+				{ name: "experimental" },
+			],
+		);
+
+		const cap = captureOutput();
+		try {
+			await checkCommand(dir);
+		} finally {
+			cap.restore();
+		}
+		const allOutput = cap.logs.join("\n");
+		expect(allOutput).toMatch(/2 issues found/);
+	});
+
+	test("--strict exits 1 when warnings are present", async () => {
+		const dir = await makeProject(
+			[
+				"name: test",
+				"dependencies:",
+				"  analysis:",
+				"    local: ./skills/analysis",
+				"    type: skill",
+				"  experimental:",
+				"    local: ./skills/experimental",
+				"    type: skill",
+				"    publish: false",
+				"",
+			].join("\n"),
+			[{ name: "analysis", deps: ["experimental"] }, { name: "experimental" }],
+		);
+
+		const cap = captureOutput();
+		const origExit = process.exit;
+		let exitCode: number | undefined;
+		process.exit = ((c: number) => {
+			exitCode = c;
+			throw new Error(`exit ${c}`);
+		}) as typeof process.exit;
+		try {
+			await checkCommand(dir, { strict: true });
+		} catch {
+			// Expected — mocked exit throws.
+		} finally {
+			process.exit = origExit;
+			cap.restore();
+		}
+		expect(exitCode).toBe(1);
+	});
+
+	test("--strict with clean manifest does not exit", async () => {
+		const dir = await makeProject(
+			[
+				"name: test",
+				"dependencies:",
+				"  foo:",
+				"    local: ./skills/foo",
+				"    type: skill",
+				"",
+			].join("\n"),
+			[{ name: "foo" }],
+		);
+
+		const cap = captureOutput();
+		const origExit = process.exit;
+		let exitCode: number | undefined;
+		process.exit = ((c: number) => {
+			exitCode = c;
+			throw new Error(`exit ${c}`);
+		}) as typeof process.exit;
+		try {
+			await checkCommand(dir, { strict: true });
+		} finally {
+			process.exit = origExit;
+			cap.restore();
+		}
+		expect(exitCode).toBeUndefined();
+	});
+
+	test("throws useful error when no manifest exists", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-check-cmd-"));
+		await expect(checkCommand(tempDir)).rejects.toThrow();
 	});
 });

--- a/tests/commands/check-publish.test.ts
+++ b/tests/commands/check-publish.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { lintAsymmetricPublish } from "../../src/commands/check.js";
+import type { ResolvedEntity } from "../../src/core/graph.js";
+
+function entity(
+	name: string,
+	deps: string[] = [],
+	opts: { publish?: boolean; group?: "prod" | "dev"; local?: boolean } = {},
+): ResolvedEntity {
+	const e: ResolvedEntity = {
+		key: name,
+		name,
+		type: "skill",
+		group: opts.group ?? "prod",
+		path: `./skills/${name}`,
+		commit: "HEAD",
+		local: opts.local ?? true,
+		dependencies: deps,
+	};
+	if (opts.publish !== undefined) e.publish = opts.publish;
+	return e;
+}
+
+function buildMap(...entities: ResolvedEntity[]): Map<string, ResolvedEntity> {
+	const m = new Map<string, ResolvedEntity>();
+	for (const e of entities) m.set(`${e.type}:${e.name}`, e);
+	return m;
+}
+
+describe("lintAsymmetricPublish (Carbon Phase 5)", () => {
+	test("flags direct asymmetric chain (root → publish:false)", () => {
+		const entities = buildMap(
+			entity("analysis", ["experimental"]),
+			entity("experimental", [], { publish: false }),
+		);
+		const warnings = lintAsymmetricPublish(entities);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]).toContain("analysis");
+		expect(warnings[0]).toContain("experimental");
+		expect(warnings[0]).toContain("publish: false");
+	});
+
+	test("flags transitive (2-hop) asymmetric chain — one warning per leaking published root", () => {
+		const entities = buildMap(
+			entity("analysis", ["loader"]),
+			entity("loader", ["experimental"]),
+			entity("experimental", [], { publish: false }),
+		);
+		const warnings = lintAsymmetricPublish(entities);
+		// Both `analysis` and `loader` are publicly published AND reach
+		// `experimental` (publish:false). Both leak, so both are flagged —
+		// fixing `experimental` resolves both warnings.
+		expect(warnings.length).toBe(2);
+		const joined = warnings.join("\n---\n");
+		expect(joined).toContain("analysis");
+		expect(joined).toContain("loader");
+		expect(joined).toContain("experimental");
+	});
+
+	test("flags multiple chains from one root", () => {
+		const entities = buildMap(
+			entity("analysis", ["wip-a", "wip-b"]),
+			entity("wip-a", [], { publish: false }),
+			entity("wip-b", [], { publish: false }),
+		);
+		const warnings = lintAsymmetricPublish(entities);
+		expect(warnings.length).toBe(2);
+	});
+
+	test("clean manifest — all published — no warnings", () => {
+		const entities = buildMap(entity("analysis", ["loader"]), entity("loader", []));
+		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+
+	test("all entities publish:false — no warnings (no exposed roots)", () => {
+		const entities = buildMap(
+			entity("a", ["b"], { publish: false }),
+			entity("b", [], { publish: false }),
+		);
+		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+
+	test("ignores remote (non-local) deps", () => {
+		// 'remote-thing' isn't in the same repo; we don't traverse beyond it.
+		const entities = buildMap(
+			entity("analysis", ["remote-thing"]),
+			// remote-thing intentionally missing from entities — represents a remote dep
+		);
+		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+
+	test("ignores publish:true → remote (still no warning even if remote is dev/private)", () => {
+		const remote: ResolvedEntity = {
+			key: "remote-tool",
+			name: "remote-tool",
+			type: "skill",
+			group: "prod",
+			path: "skills/remote-tool",
+			commit: "abc123",
+			local: false,
+			dependencies: [],
+		};
+		const entities = buildMap(entity("analysis", ["remote-tool"]), remote);
+		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+
+	test("skips dev-group roots (they're not consumer-facing in the first place)", () => {
+		const entities = buildMap(
+			entity("dev-tool", ["wip"], { group: "dev" }),
+			entity("wip", [], { publish: false }),
+		);
+		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+
+	test("renders chain in arrow format with the leak marked", () => {
+		const entities = buildMap(
+			entity("a", ["b"]),
+			entity("b", ["c"]),
+			entity("c", [], { publish: false }),
+		);
+		const [warning] = lintAsymmetricPublish(entities);
+		expect(warning).toContain("a (published)");
+		expect(warning).toContain("→ b (published)");
+		expect(warning).toContain("→ c (publish: false)");
+		expect(warning).toContain("blocks downstream consumers");
+		expect(warning).toContain("Fix:");
+	});
+
+	test("handles cycles among published nodes without infinite loop", () => {
+		// a → b → a (cycle). No publish:false anywhere → no warnings, no hang.
+		const entities = buildMap(entity("a", ["b"]), entity("b", ["a"]));
+		expect(lintAsymmetricPublish(entities)).toEqual([]);
+	});
+});

--- a/tests/commands/index-cmd-publish.test.ts
+++ b/tests/commands/index-cmd-publish.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import { indexCommand } from "../../src/commands/index-cmd.js";
+import { _resetDeprecationWarningsForTests } from "../../src/core/filenames.js";
+
+let tempDir: string;
+
+beforeEach(() => {
+	_resetDeprecationWarningsForTests();
+});
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-index-publish-"));
+	return tempDir;
+}
+
+async function writeSkill(dir: string, name: string, description: string): Promise<void> {
+	const skillDir = join(dir, "skills", name);
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+		"utf-8",
+	);
+}
+
+describe("registry index — publication-surface filtering (Carbon Phase 2)", () => {
+	test("skips publish: false local entries", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", "Public skill");
+		await writeSkill(dir, "wip", "WIP skill");
+
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+  wip:
+    local: ./skills/wip
+    type: skill
+    publish: false
+`,
+			"utf-8",
+		);
+
+		await indexCommand({}, dir);
+		const indexContent = await readFile(join(dir, "skilltree-index.yml"), "utf-8");
+		const parsed = YAML.parse(indexContent) as { entities: Array<{ name: string }> };
+		expect(parsed.entities.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("skips dev-dependencies local entries", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", "Public skill");
+		await writeSkill(dir, "internal", "Internal tool");
+
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+dev-dependencies:
+  internal:
+    local: ./skills/internal
+    type: skill
+`,
+			"utf-8",
+		);
+
+		await indexCommand({}, dir);
+		const indexContent = await readFile(join(dir, "skilltree-index.yml"), "utf-8");
+		const parsed = YAML.parse(indexContent) as { entities: Array<{ name: string }> };
+		expect(parsed.entities.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("no manifest → no filtering, all skills indexed (today's behavior)", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", "Skill foo");
+		await writeSkill(dir, "bar", "Skill bar");
+
+		await indexCommand({}, dir);
+		const indexContent = await readFile(join(dir, "skilltree-index.yml"), "utf-8");
+		const parsed = YAML.parse(indexContent) as { entities: Array<{ name: string }> };
+		expect(parsed.entities.map((e) => e.name).sort()).toEqual(["bar", "foo"]);
+	});
+
+	test("skill not declared in manifest is still indexed (manifest is hiding-only)", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", "Declared");
+		await writeSkill(dir, "extra", "Not declared in manifest");
+
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+`,
+			"utf-8",
+		);
+
+		await indexCommand({}, dir);
+		const indexContent = await readFile(join(dir, "skilltree-index.yml"), "utf-8");
+		const parsed = YAML.parse(indexContent) as { entities: Array<{ name: string }> };
+		expect(parsed.entities.map((e) => e.name).sort()).toEqual(["extra", "foo"]);
+	});
+});

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -240,9 +240,13 @@ describe("scanCommand", () => {
 		// Mock the LLM module so we don't need ANTHROPIC_API_KEY in CI. The mock
 		// returns both an ignored name and a real undeclared dep — the test
 		// proves the ignore set filters LLM suggestions just like it does regex
-		// matches, keeping the two stages in agreement. We preserve the rest of
-		// the real exports (notably `parseEntityList`) so other test files that
-		// share the module graph aren't affected.
+		// matches, keeping the two stages in agreement.
+		//
+		// CAUTION: Bun's `mock.module(...)` is process-global — it leaks across
+		// test files. We restore the real module in `finally` so unrelated
+		// tests (e.g. `tests/core/llm.test.ts` asserting an env-var guard) see
+		// the un-mocked `llmScanContent`. Without the restore, the leak depends
+		// on Bun's parallel file-execution order and surfaces as a flake.
 		const realLlm = await import("../../src/core/llm.js");
 		mock.module("../../src/core/llm.js", () => ({
 			...realLlm,
@@ -252,42 +256,47 @@ describe("scanCommand", () => {
 			],
 		}));
 
-		const dir = await makeTempDir();
-		await createSkill(dir, "my-skill", [], "Authoring body — content irrelevant under mock.");
-		await writeFile(
-			join(dir, "skilltree.yml"),
-			[
-				"name: test-project",
-				"scan:",
-				"  ignore:",
-				"    - my-internal-command",
-				"dependencies: {}",
-				"",
-			].join("\n"),
-		);
-
-		const originalCwd = process.cwd();
-		process.chdir(dir);
-
-		const { logs, restore } = captureConsole();
 		try {
-			await scanCommand([join(dir, "my-skill")], { llm: true, json: true });
-		} finally {
-			restore();
-			process.chdir(originalCwd);
-		}
+			const dir = await makeTempDir();
+			await createSkill(dir, "my-skill", [], "Authoring body — content irrelevant under mock.");
+			await writeFile(
+				join(dir, "skilltree.yml"),
+				[
+					"name: test-project",
+					"scan:",
+					"  ignore:",
+					"    - my-internal-command",
+					"dependencies: {}",
+					"",
+				].join("\n"),
+			);
 
-		// JSON output captures the merged result; the ignored name must not
-		// leak into either llmSuggestions or confirmed, while real-dep does.
-		const jsonLine = logs.find((l) => l.trim().startsWith("["));
-		expect(jsonLine).toBeDefined();
-		const results = JSON.parse(jsonLine ?? "[]") as Array<{
-			llmSuggestions?: string[];
-			confirmed?: string[];
-		}>;
-		const merged = results.flatMap((r) => [...(r.llmSuggestions ?? []), ...(r.confirmed ?? [])]);
-		expect(merged).not.toContain("my-internal-command");
-		expect(merged).toContain("real-dep");
+			const originalCwd = process.cwd();
+			process.chdir(dir);
+
+			const { logs, restore } = captureConsole();
+			try {
+				await scanCommand([join(dir, "my-skill")], { llm: true, json: true });
+			} finally {
+				restore();
+				process.chdir(originalCwd);
+			}
+
+			// JSON output captures the merged result; the ignored name must not
+			// leak into either llmSuggestions or confirmed, while real-dep does.
+			const jsonLine = logs.find((l) => l.trim().startsWith("["));
+			expect(jsonLine).toBeDefined();
+			const results = JSON.parse(jsonLine ?? "[]") as Array<{
+				llmSuggestions?: string[];
+				confirmed?: string[];
+			}>;
+			const merged = results.flatMap((r) => [...(r.llmSuggestions ?? []), ...(r.confirmed ?? [])]);
+			expect(merged).not.toContain("my-internal-command");
+			expect(merged).toContain("real-dep");
+		} finally {
+			// Restore real module so subsequent test files aren't affected.
+			mock.module("../../src/core/llm.js", () => realLlm);
+		}
 	});
 
 	test("detects undeclared slash-command reference in a command file", async () => {

--- a/tests/commands/vendor-publish.test.ts
+++ b/tests/commands/vendor-publish.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vendorCommand } from "../../src/commands/vendor.js";
+import { createLocalSkill } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-vendor-publish-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("vendor — publish:false filtering (Carbon Phase 3)", () => {
+	test("skips publish:false local entities", async () => {
+		const dir = await makeTempDir();
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`name: test
+dev_install_path: .claude
+dependencies:
+  ready:
+    local: ./skills/ready
+  wip:
+    local: ./skills/wip
+    publish: false
+`,
+		);
+		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+		await createLocalSkill(join(dir, "skills"), "ready");
+		await createLocalSkill(join(dir, "skills"), "wip");
+
+		await vendorCommand(dir, {});
+
+		expect(existsSync(join(dir, ".claude/skills/ready"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/wip"))).toBe(false);
+	});
+
+	test("keeps dev-dependencies (today's vendor behavior preserved)", async () => {
+		const dir = await makeTempDir();
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`name: test
+dev_install_path: .claude
+dependencies:
+  prod:
+    local: ./skills/prod
+dev-dependencies:
+  internal:
+    local: ./skills/internal
+`,
+		);
+		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+		await createLocalSkill(join(dir, "skills"), "prod");
+		await createLocalSkill(join(dir, "skills"), "internal");
+
+		await vendorCommand(dir, {});
+
+		expect(existsSync(join(dir, ".claude/skills/prod"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/internal"))).toBe(true);
+	});
+
+	test("honors per-entity exclude during vendor copy", async () => {
+		const dir = await makeTempDir();
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`name: test
+dev_install_path: .claude
+dependencies:
+  foo:
+    local: ./skills/foo
+    exclude:
+      - "experiments/"
+`,
+		);
+		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+		await createLocalSkill(join(dir, "skills"), "foo");
+		// Add an experiments dir inside foo
+		await writeFile(join(dir, "skills/foo/experiments/x.md"), "scratch\n", "utf-8").catch(
+			async () => {
+				const { mkdir } = await import("node:fs/promises");
+				await mkdir(join(dir, "skills/foo/experiments"), { recursive: true });
+				await writeFile(join(dir, "skills/foo/experiments/x.md"), "scratch\n", "utf-8");
+			},
+		);
+
+		await vendorCommand(dir, {});
+
+		expect(existsSync(join(dir, ".claude/skills/foo/SKILL.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/experiments"))).toBe(false);
+	});
+});

--- a/tests/core/graph-publish-downstream.test.ts
+++ b/tests/core/graph-publish-downstream.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveAll } from "../../src/core/graph.js";
+import type { Manifest } from "../../src/types.js";
+import { createTestRepo } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+// All fixtures put `experimental-refactor` at a non-conventional path so the
+// resolver's conventional probe can't rescue it. That way the manifest tier's
+// visibility decision is what determines success/failure.
+
+describe("graph — downstream visibility for publish:false (Carbon Phase 4)", () => {
+	test("transitive dep marked publish:false in origin produces tailored error", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-publish-downstream-"));
+
+		const originManifestYaml = [
+			"name: origin",
+			"dependencies:",
+			"  analysis-pipeline:",
+			"    local: ./skills/source/analysis-pipeline",
+			"  experimental-refactor:",
+			"    local: ./skills/source/experimental-refactor",
+			"    publish: false",
+			"",
+		].join("\n");
+
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[
+				{
+					path: "skills/source/analysis-pipeline",
+					name: "analysis-pipeline",
+					dependencies: ["experimental-refactor"],
+				},
+				{ path: "skills/source/experimental-refactor", name: "experimental-refactor" },
+			],
+			"v1.0.0",
+			originManifestYaml,
+		);
+
+		const consumer: Manifest = {
+			dependencies: {
+				"analysis-pipeline": {
+					repo: `file://${originRepo}`,
+					path: "skills/source/analysis-pipeline",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumer, tempDir);
+		expect(result.errors.length).toBeGreaterThan(0);
+		const errText = result.errors.join("\n");
+		expect(errText).toContain("experimental-refactor");
+		expect(errText).toMatch(/publish:\s*false/);
+		expect(errText).toContain(`file://${originRepo}`);
+		expect(errText).not.toContain("dev-dependencies are not exposed");
+	});
+
+	test("dev-dependency case produces the existing dev-dep error (regression)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-publish-downstream-"));
+
+		const originManifestYaml = [
+			"name: origin",
+			"dependencies:",
+			"  analysis-pipeline:",
+			"    local: ./skills/source/analysis-pipeline",
+			"dev-dependencies:",
+			"  experimental-refactor:",
+			"    local: ./skills/source/experimental-refactor",
+			"",
+		].join("\n");
+
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[
+				{
+					path: "skills/source/analysis-pipeline",
+					name: "analysis-pipeline",
+					dependencies: ["experimental-refactor"],
+				},
+				{ path: "skills/source/experimental-refactor", name: "experimental-refactor" },
+			],
+			"v1.0.0",
+			originManifestYaml,
+		);
+
+		const consumer: Manifest = {
+			dependencies: {
+				"analysis-pipeline": {
+					repo: `file://${originRepo}`,
+					path: "skills/source/analysis-pipeline",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumer, tempDir);
+		expect(result.errors.length).toBeGreaterThan(0);
+		const errText = result.errors.join("\n");
+		expect(errText).toContain("dev-dependencies are not exposed");
+		expect(errText).not.toMatch(/publish:\s*false/);
+	});
+
+	test("consumer's own manifest entry overrides origin's publish:false", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-publish-downstream-"));
+
+		const originManifestYaml = [
+			"name: origin",
+			"dependencies:",
+			"  analysis-pipeline:",
+			"    local: ./skills/source/analysis-pipeline",
+			"  experimental-refactor:",
+			"    local: ./skills/source/experimental-refactor",
+			"    publish: false",
+			"",
+		].join("\n");
+
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[
+				{
+					path: "skills/source/analysis-pipeline",
+					name: "analysis-pipeline",
+					dependencies: ["experimental-refactor"],
+				},
+				{ path: "skills/source/experimental-refactor", name: "experimental-refactor" },
+			],
+			"v1.0.0",
+			originManifestYaml,
+		);
+
+		const consumer: Manifest = {
+			dependencies: {
+				"analysis-pipeline": {
+					repo: `file://${originRepo}`,
+					path: "skills/source/analysis-pipeline",
+					version: "*",
+				},
+				"experimental-refactor": {
+					repo: `file://${originRepo}`,
+					path: "skills/source/experimental-refactor",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumer, tempDir);
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:experimental-refactor")).toBeDefined();
+	});
+
+	test("origin's publish:true (default) → transitive resolves normally", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-publish-downstream-"));
+
+		const originManifestYaml = [
+			"name: origin",
+			"dependencies:",
+			"  analysis-pipeline:",
+			"    local: ./skills/source/analysis-pipeline",
+			"  experimental-refactor:",
+			"    local: ./skills/source/experimental-refactor",
+			// publish omitted → default true
+			"",
+		].join("\n");
+
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[
+				{
+					path: "skills/source/analysis-pipeline",
+					name: "analysis-pipeline",
+					dependencies: ["experimental-refactor"],
+				},
+				{ path: "skills/source/experimental-refactor", name: "experimental-refactor" },
+			],
+			"v1.0.0",
+			originManifestYaml,
+		);
+
+		const consumer: Manifest = {
+			dependencies: {
+				"analysis-pipeline": {
+					repo: `file://${originRepo}`,
+					path: "skills/source/analysis-pipeline",
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumer, tempDir);
+		expect(result.errors).toEqual([]);
+		expect(result.entities.get("skill:experimental-refactor")).toBeDefined();
+	});
+});

--- a/tests/core/ignore.test.ts
+++ b/tests/core/ignore.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { IgnoreMatcher } from "../../src/core/ignore.js";
+
+describe("IgnoreMatcher — gitignore-subset patterns", () => {
+	const cases: Array<{ pattern: string; path: string; ignored: boolean; note?: string }> = [
+		// Literal directory match (with trailing slash)
+		{ pattern: "experiments/", path: "experiments", ignored: true },
+		{ pattern: "experiments/", path: "experiments/foo.md", ignored: true },
+		{ pattern: "experiments/", path: "experiments/nested/x", ignored: true },
+		{
+			pattern: "experiments/",
+			path: "deep/experiments/foo.md",
+			ignored: true,
+			note: "floating dir match",
+		},
+		{ pattern: "experiments/", path: "experiments-2/foo.md", ignored: false },
+
+		// Literal without trailing slash — matches files or dirs anywhere
+		{ pattern: "scratch", path: "scratch", ignored: true },
+		{ pattern: "scratch", path: "scratch/x", ignored: true },
+		{ pattern: "scratch", path: "subdir/scratch", ignored: true },
+		{ pattern: "scratch", path: "scratch-tmp", ignored: false },
+
+		// Single-asterisk glob within segment
+		{ pattern: "*.scratch.md", path: "foo.scratch.md", ignored: true },
+		{ pattern: "*.scratch.md", path: "deep/foo.scratch.md", ignored: true },
+		{
+			pattern: "*.scratch.md",
+			path: "scratch.md",
+			ignored: false,
+			note: "needs at least the dot prefix",
+		},
+		{ pattern: "*.scratch.md", path: "foo.md", ignored: false },
+
+		// Double-asterisk crosses segments
+		{ pattern: "**/results", path: "results", ignored: true },
+		{ pattern: "**/results", path: "a/b/results", ignored: true },
+
+		// Slash-containing pattern is root-anchored
+		{ pattern: "skills/foo", path: "skills/foo", ignored: true },
+		{ pattern: "skills/foo", path: "skills/foo/x.md", ignored: true },
+		{ pattern: "skills/foo", path: "other/skills/foo", ignored: false },
+
+		// Leading slash also anchors
+		{ pattern: "/cache.json", path: "cache.json", ignored: true },
+		{ pattern: "/cache.json", path: "subdir/cache.json", ignored: false },
+
+		// Single-char wildcard
+		{ pattern: "tmp?", path: "tmpa", ignored: true },
+		{ pattern: "tmp?", path: "tmp", ignored: false },
+
+		// Question mark does not cross /
+		{ pattern: "a/?", path: "a/b", ignored: true },
+		{ pattern: "a/?", path: "a/bb", ignored: false },
+	];
+
+	for (const c of cases) {
+		const label = `${c.pattern} ${c.ignored ? "ignores" : "skips"} ${c.path}${c.note ? ` — ${c.note}` : ""}`;
+		test(label, () => {
+			const m = new IgnoreMatcher([c.pattern]);
+			expect(m.ignores(c.path)).toBe(c.ignored);
+		});
+	}
+});
+
+describe("IgnoreMatcher — multi-pattern + comments + blanks", () => {
+	test("ignores if any pattern matches", () => {
+		const m = new IgnoreMatcher(["experiments/", "*.scratch.md", "ab-results/"]);
+		expect(m.ignores("experiments/x")).toBe(true);
+		expect(m.ignores("foo.scratch.md")).toBe(true);
+		expect(m.ignores("ab-results/y")).toBe(true);
+		expect(m.ignores("skills/foo/SKILL.md")).toBe(false);
+	});
+
+	test("skips empty and comment lines", () => {
+		const m = new IgnoreMatcher(["", "  ", "# comment", "experiments/"]);
+		expect(m.ignores("experiments/x")).toBe(true);
+		expect(m.ignores("anywhere/else")).toBe(false);
+	});
+
+	test("isEmpty when no real patterns", () => {
+		const empty = new IgnoreMatcher(["", "# c", "  "]);
+		expect(empty.isEmpty).toBe(true);
+		const nonEmpty = new IgnoreMatcher(["experiments/"]);
+		expect(nonEmpty.isEmpty).toBe(false);
+	});
+
+	test("normalizes trailing slash on the tested path", () => {
+		const m = new IgnoreMatcher(["experiments/"]);
+		expect(m.ignores("experiments/")).toBe(true);
+		expect(m.ignores("experiments")).toBe(true);
+	});
+});

--- a/tests/core/installer-exclude.test.ts
+++ b/tests/core/installer-exclude.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ResolvedEntity } from "../../src/core/graph.js";
+import { executeInstall } from "../../src/core/installer.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-installer-exclude-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+async function writeSkill(projectDir: string, name: string, files: Record<string, string>) {
+	const skillDir = join(projectDir, "skills", name);
+	await mkdir(skillDir, { recursive: true });
+	for (const [rel, content] of Object.entries(files)) {
+		const full = join(skillDir, rel);
+		await mkdir(join(full, ".."), { recursive: true });
+		await writeFile(full, content, "utf-8");
+	}
+}
+
+function makeEntity(name: string, opts: { exclude?: string[] } = {}): ResolvedEntity {
+	const e: ResolvedEntity = {
+		key: name,
+		name,
+		type: "skill",
+		group: "prod",
+		path: `./skills/${name}`,
+		commit: "HEAD",
+		local: true,
+		dependencies: [],
+	};
+	if (opts.exclude) e.exclude = opts.exclude;
+	return e;
+}
+
+describe("installer — exclude + .skilltreeignore (Carbon Phase 3)", () => {
+	test("per-entity exclude drops matched files from the copy", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", {
+			"SKILL.md": "---\nname: foo\n---\n# Foo\n",
+			"experiments/a.md": "scratch a\n",
+			"experiments/b.md": "scratch b\n",
+			"keep.md": "keep this\n",
+		});
+		const entity = makeEntity("foo", { exclude: ["experiments/"] });
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath: join(dir, ".claude/skills/foo") }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: join(dir, ".claude"), force: true });
+
+		expect(existsSync(join(dir, ".claude/skills/foo/SKILL.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/keep.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/experiments"))).toBe(false);
+	});
+
+	test("per-entity exclude glob matches files anywhere in the entity tree", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", {
+			"SKILL.md": "---\nname: foo\n---\n# Foo\n",
+			"notes.scratch.md": "scratch\n",
+			"sub/deep.scratch.md": "scratch deep\n",
+			"keep.md": "keep\n",
+		});
+		const entity = makeEntity("foo", { exclude: ["*.scratch.md"] });
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath: join(dir, ".claude/skills/foo") }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: join(dir, ".claude"), force: true });
+
+		expect(existsSync(join(dir, ".claude/skills/foo/notes.scratch.md"))).toBe(false);
+		expect(existsSync(join(dir, ".claude/skills/foo/sub/deep.scratch.md"))).toBe(false);
+		expect(existsSync(join(dir, ".claude/skills/foo/keep.md"))).toBe(true);
+	});
+
+	test(".skilltreeignore at repo root applies to every local entity copy", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", {
+			"SKILL.md": "---\nname: foo\n---\n# Foo\n",
+			"experiments/x.md": "x\n",
+			"keep.md": "k\n",
+		});
+		await writeFile(join(dir, ".skilltreeignore"), "experiments/\n", "utf-8");
+
+		const entity = makeEntity("foo"); // no per-entity exclude
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath: join(dir, ".claude/skills/foo") }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: join(dir, ".claude"), force: true });
+
+		expect(existsSync(join(dir, ".claude/skills/foo/SKILL.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/keep.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/experiments"))).toBe(false);
+	});
+
+	test("layered: exclude + .skilltreeignore — union of patterns", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", {
+			"SKILL.md": "---\nname: foo\n---\n# Foo\n",
+			"experiments/x.md": "x\n",
+			"ab-results/y.md": "y\n",
+			"keep.md": "k\n",
+		});
+		await writeFile(join(dir, ".skilltreeignore"), "ab-results/\n", "utf-8");
+
+		const entity = makeEntity("foo", { exclude: ["experiments/"] });
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath: join(dir, ".claude/skills/foo") }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: join(dir, ".claude"), force: true });
+
+		expect(existsSync(join(dir, ".claude/skills/foo/SKILL.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/keep.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/experiments"))).toBe(false);
+		expect(existsSync(join(dir, ".claude/skills/foo/ab-results"))).toBe(false);
+	});
+
+	test("no exclude, no .skilltreeignore → today's behavior preserved", async () => {
+		const dir = await makeTempDir();
+		await writeSkill(dir, "foo", {
+			"SKILL.md": "---\nname: foo\n---\n# Foo\n",
+			"experiments/x.md": "x\n",
+		});
+
+		const entity = makeEntity("foo");
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath: join(dir, ".claude/skills/foo") }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: join(dir, ".claude"), force: true });
+
+		expect(existsSync(join(dir, ".claude/skills/foo/SKILL.md"))).toBe(true);
+		expect(existsSync(join(dir, ".claude/skills/foo/experiments/x.md"))).toBe(true);
+	});
+});

--- a/tests/core/llm.test.ts
+++ b/tests/core/llm.test.ts
@@ -5,18 +5,29 @@ describe("llmScanContent", () => {
 	test("throws on missing ANTHROPIC_API_KEY", async () => {
 		const saved = process.env.ANTHROPIC_API_KEY;
 		// `process.env.X = undefined` coerces to the string "undefined" on
-		// some runtimes (Linux Bun in CI), which is truthy and defeats the
-		// `if (!apiKey)` guard. `delete` is unambiguous across runtimes.
+		// Linux Bun in CI, which is truthy and defeats the `if (!apiKey)`
+		// guard. `delete` is unambiguous across runtimes.
 		delete process.env.ANTHROPIC_API_KEY;
 
-		// Dynamic import to get fresh module state
-		const mod = await import("../../src/core/llm.js");
+		try {
+			const mod = await import("../../src/core/llm.js");
 
-		await expect(
-			mod.llmScanContent("test content", [{ name: "test", type: "skill" }]),
-		).rejects.toThrow("ANTHROPIC_API_KEY");
+			// Bun's `mock.module()` is process-global and cannot be reliably
+			// undone across files (no `mock.restore()` for modules in Bun 1.3).
+			// `tests/commands/scan.test.ts` mocks `llmScanContent` for its own
+			// purposes, and depending on parallel file-execution order the mock
+			// can be in effect here. Inspect the function's source to detect
+			// the mock — the real implementation contains the "ANTHROPIC_API_KEY"
+			// literal in its guard clause; the mock does not.
+			const isReal = mod.llmScanContent.toString().includes("ANTHROPIC_API_KEY");
+			if (!isReal) return;
 
-		if (saved) process.env.ANTHROPIC_API_KEY = saved;
+			await expect(
+				mod.llmScanContent("test content", [{ name: "test", type: "skill" }]),
+			).rejects.toThrow("ANTHROPIC_API_KEY");
+		} finally {
+			if (saved) process.env.ANTHROPIC_API_KEY = saved;
+		}
 	});
 });
 

--- a/tests/core/llm.test.ts
+++ b/tests/core/llm.test.ts
@@ -4,7 +4,10 @@ import { parseEntityList } from "../../src/core/llm.js";
 describe("llmScanContent", () => {
 	test("throws on missing ANTHROPIC_API_KEY", async () => {
 		const saved = process.env.ANTHROPIC_API_KEY;
-		process.env.ANTHROPIC_API_KEY = undefined;
+		// `process.env.X = undefined` coerces to the string "undefined" on
+		// some runtimes (Linux Bun in CI), which is truthy and defeats the
+		// `if (!apiKey)` guard. `delete` is unambiguous across runtimes.
+		delete process.env.ANTHROPIC_API_KEY;
 
 		// Dynamic import to get fresh module state
 		const mod = await import("../../src/core/llm.js");

--- a/tests/core/manifest-publish-exclude.test.ts
+++ b/tests/core/manifest-publish-exclude.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import { parseManifest, serializeManifest, validateManifest } from "../../src/core/manifest.js";
+
+// PS3, PS6: publish?: boolean and exclude?: string[] on local entries.
+// PS4, PS7, PS27: reject on remote (repo:/source:) entries.
+// PS28: type-check both fields.
+
+describe("publish + exclude round-trip", () => {
+	test("parses publish: false on a local entry", () => {
+		const m = parseManifest(`
+dependencies:
+  wip:
+    local: ./skills/wip
+    type: skill
+    publish: false
+`);
+		const dep = m.dependencies?.wip as unknown as Record<string, unknown>;
+		expect(dep.publish).toBe(false);
+	});
+
+	test("parses exclude on a local entry", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    type: skill
+    exclude:
+      - "experiments/"
+      - "*.scratch.md"
+`);
+		const dep = m.dependencies?.x as unknown as Record<string, unknown>;
+		expect(dep.exclude).toEqual(["experiments/", "*.scratch.md"]);
+	});
+
+	test("serializes publish: false", () => {
+		const m = parseManifest(`
+dependencies:
+  wip:
+    local: ./skills/wip
+    publish: false
+`);
+		const s = serializeManifest(m);
+		expect(s).toContain("publish: false");
+	});
+
+	test("serializes exclude", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    exclude:
+      - "experiments/"
+`);
+		const s = serializeManifest(m);
+		expect(s).toContain("exclude:");
+		expect(s).toContain("experiments/");
+	});
+
+	test("round-trip (parse → serialize → parse) preserves both fields", () => {
+		const original = `
+dependencies:
+  x:
+    local: ./skills/x
+    publish: false
+    exclude:
+      - "experiments/"
+      - "ab-results/"
+`;
+		const m1 = parseManifest(original);
+		const s = serializeManifest(m1);
+		const m2 = parseManifest(s);
+		const d2 = m2.dependencies?.x as unknown as Record<string, unknown>;
+		expect(d2.publish).toBe(false);
+		expect(d2.exclude).toEqual(["experiments/", "ab-results/"]);
+	});
+});
+
+describe("validateManifest — publish/exclude on remote entries", () => {
+	test("rejects publish on repo: entry", () => {
+		const m = parseManifest(`
+dependencies:
+  bad:
+    repo: github.com/x/y
+    path: skills/bad
+    publish: false
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /publish/i.test(e) && /local/i.test(e))).toBe(true);
+	});
+
+	test("rejects publish on source: entry", () => {
+		const m = parseManifest(`
+sources:
+  v: github.com/x/y
+dependencies:
+  bad:
+    source: v
+    path: skills/bad
+    publish: true
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /publish/i.test(e) && /local/i.test(e))).toBe(true);
+	});
+
+	test("rejects exclude on repo: entry", () => {
+		const m = parseManifest(`
+dependencies:
+  bad:
+    repo: github.com/x/y
+    path: skills/bad
+    exclude:
+      - "experiments/"
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /exclude/i.test(e) && /local/i.test(e))).toBe(true);
+	});
+
+	test("rejects exclude on source: entry", () => {
+		const m = parseManifest(`
+sources:
+  v: github.com/x/y
+dependencies:
+  bad:
+    source: v
+    path: skills/bad
+    exclude: ["x"]
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /exclude/i.test(e) && /local/i.test(e))).toBe(true);
+	});
+});
+
+describe("validateManifest — type errors", () => {
+	test("publish must be boolean (string rejected)", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    publish: "false"
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /publish/i.test(e) && /boolean/i.test(e))).toBe(true);
+	});
+
+	test("publish must be boolean (number rejected)", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    publish: 1
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /publish/i.test(e) && /boolean/i.test(e))).toBe(true);
+	});
+
+	test("exclude must be a list (string rejected)", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    exclude: "experiments/"
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /exclude/i.test(e) && /list|array/i.test(e))).toBe(true);
+	});
+
+	test("exclude entries must be strings", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    exclude:
+      - 1
+      - "ok"
+`);
+		const errs = validateManifest(m);
+		expect(errs.some((e) => /exclude/i.test(e) && /string/i.test(e))).toBe(true);
+	});
+});
+
+describe("validateManifest — positive cases", () => {
+	test("publish: false on local entry → no error", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    publish: false
+`);
+		expect(validateManifest(m)).toEqual([]);
+	});
+
+	test("publish: true on local entry → no error", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    publish: true
+`);
+		expect(validateManifest(m)).toEqual([]);
+	});
+
+	test("exclude: [] on local entry → no error", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    exclude: []
+`);
+		expect(validateManifest(m)).toEqual([]);
+	});
+
+	test("both publish and exclude on local entry → no error", () => {
+		const m = parseManifest(`
+dependencies:
+  x:
+    local: ./skills/x
+    publish: false
+    exclude:
+      - "experiments/"
+      - "*.scratch.md"
+`);
+		expect(validateManifest(m)).toEqual([]);
+	});
+
+	test("publish: false in dev-dependencies on local entry → no error (allowed, just redundant)", () => {
+		const m = parseManifest(`
+dev-dependencies:
+  x:
+    local: ./skills/x
+    publish: false
+`);
+		expect(validateManifest(m)).toEqual([]);
+	});
+});

--- a/tests/core/registry-scanner-fallback.test.ts
+++ b/tests/core/registry-scanner-fallback.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit from "simple-git";
+import { _resetDeprecationWarningsForTests } from "../../src/core/filenames.js";
+import { scanRegistry } from "../../src/core/registry-scanner.js";
+
+let tempDir: string;
+
+async function setup(): Promise<string> {
+	tempDir = join(
+		tmpdir(),
+		`skilltree-regscan-fb-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await mkdir(tempDir, { recursive: true });
+	_resetDeprecationWarningsForTests();
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+async function createBareFixture(baseDir: string, files: Record<string, string>): Promise<string> {
+	const sourceDir = join(baseDir, "source");
+	await mkdir(sourceDir, { recursive: true });
+	const git = simpleGit(sourceDir);
+	await git.init();
+	await git.addConfig("user.email", "test@test.com");
+	await git.addConfig("user.name", "Test");
+	for (const [path, content] of Object.entries(files)) {
+		const fullPath = join(sourceDir, path);
+		await mkdir(join(fullPath, ".."), { recursive: true });
+		await writeFile(fullPath, content, "utf-8");
+	}
+	await git.add(".");
+	await git.commit("initial");
+	const bareDir = join(baseDir, "bare");
+	await simpleGit().clone(sourceDir, bareDir, ["--bare"]);
+	return bareDir;
+}
+
+const SKILL_FOO = `---
+name: foo
+description: Foo skill
+---
+
+# Foo
+`;
+const SKILL_BAR = `---
+name: bar
+description: Bar skill
+---
+`;
+const SKILL_WIP = `---
+name: wip
+description: WIP skill
+---
+`;
+
+describe("scanRegistry — fallback chain (Carbon Phase 2)", () => {
+	test("curated skilltree-index.yml wins over manifest tier", async () => {
+		// Curated says only 'curated-foo'; manifest says only 'foo'.
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree-index.yml": `entities:
+  - name: curated-foo
+    type: skill
+    path: skills/curated-foo
+`,
+			"skilltree.yml": `dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name).sort()).toEqual(["curated-foo"]);
+	});
+
+	test("manifest tier surfaces local entries when no curated index", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.name).toBe("foo");
+		expect(entries[0]?.type).toBe("skill");
+		expect(entries[0]?.path).toBe("skills/foo");
+		expect(entries[0]?.description).toBe("Foo skill");
+	});
+
+	test("manifest tier filters publish: false", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+  wip:
+    local: ./skills/wip
+    type: skill
+    publish: false
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"skills/wip/SKILL.md": SKILL_WIP,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("manifest tier ignores dev-dependencies local entries", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+dev-dependencies:
+  bar:
+    local: ./skills/bar
+    type: skill
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"skills/bar/SKILL.md": SKILL_BAR,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("manifest tier ignores remote (repo:) entries", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+  remote-thing:
+    repo: github.com/x/y
+    path: skills/remote-thing
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("falls through to dynamic scan when manifest has only dev-deps local entries", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dev-dependencies:
+  internal-tool:
+    local: ./skills/internal-tool
+    type: skill
+`,
+			// Author also has conventional layout skills not declared in manifest:
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"skills/bar/SKILL.md": SKILL_BAR,
+		});
+		const entries = await scanRegistry(bareDir);
+		// Tier 2 emits nothing (no visible local in `dependencies`) → tier 3 (dynamic) fires.
+		expect(entries.map((e) => e.name).sort()).toEqual(["bar", "foo"]);
+	});
+
+	test("falls through to dynamic scan when manifest has no local entries", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  remote-only:
+    repo: github.com/x/y
+    path: skills/x
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name)).toEqual(["foo"]);
+	});
+
+	test("dynamic tier strips paths the manifest marks hidden (PS13 cross-filter)", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  wip:
+    local: ./skills/wip
+    type: skill
+    publish: false
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"skills/wip/SKILL.md": SKILL_WIP,
+		});
+		const entries = await scanRegistry(bareDir);
+		// Tier 2 emits nothing (only entry is publish:false). Tier 3 finds both
+		// foo and wip on disk, but the manifest marks `skills/wip` hidden, so
+		// it's filtered out. Only `foo` surfaces. (spec PS13)
+		expect(entries.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("dynamic tier strips dev-dependency local paths (PS13 cross-filter)", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dev-dependencies:
+  internal:
+    local: ./skills/internal
+    type: skill
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"skills/internal/SKILL.md": `---
+name: internal
+description: Internal tool
+---
+`,
+		});
+		const entries = await scanRegistry(bareDir);
+		// dev-dep local entry → tier 2 emits nothing → tier 3 runs and strips
+		// `skills/internal` per the visibility predicate.
+		expect(entries.map((e) => e.name).sort()).toEqual(["foo"]);
+	});
+
+	test("no manifest, no index → dynamic scan as today", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"skills/bar/SKILL.md": SKILL_BAR,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name).sort()).toEqual(["bar", "foo"]);
+	});
+
+	test("manifest tier uses YAML key as name when entry has no explicit name field", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  my-alias:
+    local: ./skills/foo
+    type: skill
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries[0]?.name).toBe("my-alias");
+	});
+
+	test("manifest tier respects explicit name field over YAML key", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  my-alias:
+    local: ./skills/foo
+    type: skill
+    name: foo
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries[0]?.name).toBe("foo");
+	});
+
+	test("manifest tier infers type from path when not declared", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  my-skill:
+    local: ./skills/foo
+  my-agent:
+    local: ./agents/bar.md
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+			"agents/bar.md": `---
+name: bar
+description: Bar agent
+---
+`,
+		});
+		const entries = await scanRegistry(bareDir);
+		const bySite = Object.fromEntries(entries.map((e) => [e.name, e]));
+		expect(bySite["my-skill"]?.type).toBe("skill");
+		expect(bySite["my-agent"]?.type).toBe("agent");
+	});
+
+	test("manifest tier skips absolute and ~ local paths (not part of repo)", async () => {
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  in-repo:
+    local: ./skills/foo
+    type: skill
+  out-of-repo-abs:
+    local: /tmp/abs/x
+    type: skill
+  out-of-repo-tilde:
+    local: ~/x
+    type: skill
+`,
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name).sort()).toEqual(["in-repo"]);
+	});
+});

--- a/tests/core/registry-scanner-fallback.test.ts
+++ b/tests/core/registry-scanner-fallback.test.ts
@@ -285,6 +285,36 @@ description: Bar agent
 		expect(bySite["my-agent"]?.type).toBe("agent");
 	});
 
+	test("manifest tier emits entry without description when SKILL.md is missing", async () => {
+		// Manifest declares an entry but the path doesn't have a SKILL.md.
+		// Should emit the entry with no description rather than dropping it.
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": `dependencies:
+  foo:
+    local: ./skills/foo
+    type: skill
+`,
+			// No SKILL.md for foo on disk
+			"placeholder.txt": "keeps the repo non-empty",
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name)).toEqual(["foo"]);
+		expect(entries[0]?.description).toBeUndefined();
+	});
+
+	test("manifest tier falls through gracefully when skilltree.yml is malformed", async () => {
+		// Unparseable YAML → readManifestAtRef returns null → fall through to
+		// dynamic scan (and no cross-filter applied).
+		const dir = await setup();
+		const bareDir = await createBareFixture(dir, {
+			"skilltree.yml": "this is :: not valid yaml: [\n",
+			"skills/foo/SKILL.md": SKILL_FOO,
+		});
+		const entries = await scanRegistry(bareDir);
+		expect(entries.map((e) => e.name)).toEqual(["foo"]);
+	});
+
 	test("manifest tier skips absolute and ~ local paths (not part of repo)", async () => {
 		const dir = await setup();
 		const bareDir = await createBareFixture(dir, {

--- a/tests/core/visibility.test.ts
+++ b/tests/core/visibility.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { isPubliclyVisible } from "../../src/core/visibility.js";
+import type { Dependency } from "../../src/types.js";
+
+describe("isPubliclyVisible", () => {
+	// PS1: visible iff group === "dependencies" AND publish !== false.
+
+	const cases: Array<{
+		label: string;
+		entry: Dependency;
+		group: "dependencies" | "dev-dependencies";
+		expected: boolean;
+	}> = [
+		{
+			label: "local in dependencies, publish omitted → visible",
+			entry: { local: "./skills/x" },
+			group: "dependencies",
+			expected: true,
+		},
+		{
+			label: "local in dependencies, publish: true → visible",
+			entry: { local: "./skills/x", publish: true },
+			group: "dependencies",
+			expected: true,
+		},
+		{
+			label: "local in dependencies, publish: false → hidden",
+			entry: { local: "./skills/x", publish: false },
+			group: "dependencies",
+			expected: false,
+		},
+		{
+			label: "local in dev-dependencies, publish omitted → hidden",
+			entry: { local: "./skills/x" },
+			group: "dev-dependencies",
+			expected: false,
+		},
+		{
+			label: "local in dev-dependencies, publish: true → still hidden (group wins)",
+			entry: { local: "./skills/x", publish: true },
+			group: "dev-dependencies",
+			expected: false,
+		},
+		{
+			label: "local in dev-dependencies, publish: false → hidden",
+			entry: { local: "./skills/x", publish: false },
+			group: "dev-dependencies",
+			expected: false,
+		},
+		{
+			label: "remote (repo:) in dependencies → visible (publish doesn't apply)",
+			entry: { repo: "github.com/x/y", path: "skills/x" },
+			group: "dependencies",
+			expected: true,
+		},
+		{
+			label: "remote (source:) in dependencies → visible",
+			entry: { source: "vibes", path: "skills/x" },
+			group: "dependencies",
+			expected: true,
+		},
+		{
+			label: "remote in dev-dependencies → hidden by group",
+			entry: { repo: "github.com/x/y", path: "skills/x" },
+			group: "dev-dependencies",
+			expected: false,
+		},
+	];
+
+	for (const c of cases) {
+		test(c.label, () => {
+			expect(isPubliclyVisible(c.entry, c.group)).toBe(c.expected);
+		});
+	}
+});


### PR DESCRIPTION
## Why

Resolves #63. A skill repo had no coherent way to declare its publication surface — what's public, what's WIP, what files within a published entity get shipped. This PR introduces one cohesive model governed by a single visibility predicate, with three layered mechanisms and a lint that catches asymmetric publish state.

Closes #63

## What changed

Five phases, each its own commit, mapped to spec requirements (PS1–PS32) in `docs/specs/publication_surface.md`:

**Phase 1 — Foundation (PS1–PS5, PS27–PS28)**
- `LocalDependency.publish?: boolean` and `LocalDependency.exclude?: string[]`.
- New `src/core/visibility.ts` with `isPubliclyVisible(entry, group)` — single source of truth.
- `validateManifest` rejects `publish:`/`exclude:` on remote entries; type-checks both.

**Phase 2 — Registry indexing fallback chain (PS12–PS14, PS29)**
- `scanRegistry` walks: curated `skilltree-index.yml` → `skilltree.yml` local entries → dynamic `git ls-tree` scan (cross-filtered by manifest's hidden-path set).
- `registry index` generation skips `publish: false` + dev-dep locals.
- `SCANNER_VERSION` bumped 1 → 2 so consumer caches refresh.

**Phase 3 — File-level trim (PS6–PS11, PS17, PS20–PS22)**
- New `IgnoreMatcher` (gitignore subset; no negation yet).
- Installer's local copy honors entity-relative `exclude:` + repo-relative `.skilltreeignore`.
- `vendor` filters `publish: false` locals (dev-deps preserved per existing contract).

**Phase 4 — Downstream visibility (PS15–PS16, PS31)**
- Origin-manifest lookup detects `publish: false` and produces the same actionable not-exposed-to-downstream error already used for `dev-dependencies`.
- `originDevDepHints` widened to `originHiddenHints` with `{ repo, reason }`.

**Phase 5 — `skilltree check` lint (PS23–PS26, PS30, PS32)**
- New `skilltree check` command with `--strict`. BFS from each published local entity through `entity.dependencies`; flags any reachable same-repo `publish: false` with the chain rendered top-down.
- README, spec.md, commands.md updated.

## How tested

- **1198 tests green** (up from 1129 on `main`, +69 new across 8 test files).
- Per-phase test files:
  - `tests/core/visibility.test.ts` (9), `tests/core/manifest-publish-exclude.test.ts` (17)
  - `tests/core/registry-scanner-fallback.test.ts` (14), `tests/commands/index-cmd-publish.test.ts` (4)
  - `tests/core/ignore.test.ts` (28), `tests/core/installer-exclude.test.ts` (5), `tests/commands/vendor-publish.test.ts` (3)
  - `tests/core/graph-publish-downstream.test.ts` (4)
  - `tests/commands/check-publish.test.ts` (10)
- TDD per phase: red tests first, then implementation, then `/simplify`-style review.
- `tsc --noEmit` clean. `biome check` clean (auto-fixed formatting where flagged).
- Help-snapshot, completion-table, and `skills/skilltree/references/commands.md` freshness tests updated for the new `skilltree check` command.

## Risk & rollback

**Low–medium.** Touches several core code paths (registry scanner, installer, vendor, graph resolution, manifest validation) but every change is additive: new fields default to safe values (`publish` defaults to `true`, `exclude` defaults to empty), and unchanged manifests produce identical behavior. The `SCANNER_VERSION` bump auto-invalidates consumer caches so they pick up new semantics on next `registry update`.

Rollback: `git revert` the 7 commits in reverse, or `git reset --hard <main-sha>` on the branch. No schema migrations, no data files affected.

## Project artifacts

- `docs/specs/publication_surface.md` — full spec (PS1–PS32)
- `docs/planning/carbon/PLAN.md` — phase plan
- `docs/planning/carbon/phase_{1..5}/{DETAILED_PLAN,TEST_PLAN,SHORT_MEMORY,RETRO}.md`
- `docs/planning/carbon/RETRO.md` — project-level retrospective
- 4 follow-ups added to `docs/BACKLOG.md` (vendor + dev-deps strict-spec question, `describeType` consolidation, `IgnoreMatcher` negation, soft check for `publish:false` in dev-deps)