### PR TITLE
fix: registry index --check accepts hand-authored entries for non-standard paths

### DIFF
--- a/docs/specs/registries.md
+++ b/docs/specs/registries.md
@@ -84,7 +84,7 @@ entities:
 
 If a repo does not have this file, skilltree falls back to **the manifest tier** (see below), then to **dynamic scanning** — walking `git ls-tree -r HEAD` for `SKILL.md` files and `.md` agent files, reading their frontmatter. The tiered approach keeps zero-config repos working while letting maintainers express layout once.
 
-**Who generates the index?** The repo maintainer, ideally via CI (e.g., a GitHub Action that runs `skilltree registry index` on push and commits the result). Hand-maintaining it is discouraged — it drifts. See the `skilltree registry index` command below.
+**Who generates the index?** The repo maintainer, ideally via CI (e.g., a GitHub Action that runs `skilltree registry index` on push and commits the result). Hand-maintaining the *scanner-discoverable* portion is discouraged — it drifts. **Hand-authored entries for non-standard paths** (skills nested below a parent `SKILL.md`, monorepo packages, agents under directories the scanner doesn't recurse into) and curated `tags:` are explicitly supported: `--check` (issue #62) validates them by checking the path resolves to a real entity on disk, not by demanding byte-for-byte equality with scanner output. See the `skilltree registry index` command below.
 
 **Legacy name:** earlier versions wrote the index as `skillkit-index.yaml`. Repos with that legacy file still work — `skilltree registry index` emits a deprecation warning and reads it. Running `skilltree registry index` regenerates the index as `skilltree-index.yml` and removes the legacy file.
 
@@ -380,11 +380,13 @@ $ skilltree registry index --check
   Exit 1
 ```
 
+`--check` is not a strict byte-comparison against scanner output. It enforces two invariants: (1) every scanner-discoverable entity is present in the index with matching `name`/`type`/`description`, and (2) every other entry in the index resolves to a real on-disk entity (issue #62). Hand-authored entries for non-standard paths and curated `tags:` therefore pass `--check` without modification.
+
 **CI integration:**
 ```yaml
 # .github/workflows/index.yml
 - run: skilltree registry index --check
-  # Fails if index is stale — author must regenerate
+  # Fails if the index drifts from on-disk reality — author must regenerate
 ```
 
 ## What This Does NOT Change
@@ -445,8 +447,8 @@ Different lifecycles (TTL vs on-demand), different purposes (search vs resolutio
 ### 4. Dynamic scanning as fallback
 Any git repo with skills works as a registry without adding `skilltree-index.yml`. The index is a performance optimization, not a requirement. Rationale: zero barrier to entry. A team can `skilltree registry add` their existing skill repo and start searching immediately.
 
-### 5. `skilltree-index.yml` is a CI artifact
-Generating the index is an authoring concern, checked with `skilltree index --check` in CI. Not hand-maintained. Rationale: hand-maintained indexes drift from reality, producing wrong search results (worse than slow results).
+### 5. `skilltree-index.yml` is a CI artifact (with curated extras allowed)
+Generating the bulk of the index is an authoring concern, checked with `skilltree registry index --check` in CI. The scanner-discoverable portion should not be hand-edited — it drifts. Rationale: hand-maintained indexes drift from reality, producing wrong search results. **Exception (issue #62):** entries for non-standard paths the scanner can't reach, and `tags:`, are deliberately hand-authored. `--check` validates these against on-disk reality (does the path exist? does it have a `SKILL.md` or frontmatter?) rather than rejecting them.
 
 ### 6. No auto-fetch on search
 `skilltree search` uses cached data even if stale, with a warning. Rationale: search should be fast and predictable. `registry update` is the explicit fetch. Users shouldn't be surprised by network calls during search.

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -287,6 +287,8 @@ skilltree registry index --check   # Exit 1 if stale (CI mode)
 **Flags:**
 - `--check` — Exit 0 if up to date, exit 1 if stale
 
+**What `--check` validates:** every entity the scanner finds must be present in the index with matching `name`, `type`, and `description`; every other entry in the index must point to a real on-disk entity (a `SKILL.md` for skills, or a markdown file with `name:`/`skills:` frontmatter for agents and commands). Hand-authored entries for skills/agents at scanner-unreachable paths (nested under a parent `SKILL.md`, monorepo packages, etc.) and curated `tags:` are preserved — they do not trip `--check` as long as the path resolves. Phantom entries (paths that don't exist) still fail.
+
 **Publishing workflow:** run `skilltree registry index` and commit `skilltree-index.yml`. Wire `--check` into CI so the index never drifts from the actual skill set. Legacy `skillkit-index.yaml` files are migrated automatically — the new file replaces the old one and a deprecation warning is emitted on read until you regenerate.
 
 ## `skilltree vendor`

--- a/src/commands/index-cmd.ts
+++ b/src/commands/index-cmd.ts
@@ -33,13 +33,33 @@ export async function indexCommand(opts: { check?: boolean }, dir?: string): Pro
 			);
 			process.exit(1);
 		}
+		// Issue #62: --check used to compare scanner output against the file
+		// as raw YAML text. That treated hand-authored entries for skills at
+		// non-standard paths (scanner-unreachable depths, nested under a
+		// parent SKILL.md, etc.) as "stale" — which made the index file
+		// unusable for the very purpose docs/specs/registries.md advertises:
+		// "a hand-curated public catalog... useful for non-standard layouts."
+		//
+		// New semantics: validate the index file is *consistent with reality*,
+		// not byte-identical to a scanner dump.
+		//   1. Every scanner-discoverable entity must be present in the index
+		//      with the same name/type/description.
+		//   2. Every "extra" entry in the index (a path the scanner did not
+		//      visit) must point to a real on-disk entity. Phantom entries
+		//      still fail --check; hand-authored entries for real
+		//      non-standard skills/agents do not.
+		// `tags` are scanner-invisible by design and are always preserved.
 		const existing = await readFile(indexPath, "utf-8");
-		if (existing.trim() === yamlContent.trim()) {
+		const staleReasons = await diagnoseIndex(baseDir, existing, entries);
+		if (staleReasons.length === 0) {
 			console.log(`${INDEX_NEW} is up to date`);
 		} else {
 			console.log(
 				`${INDEX_NEW} is stale (${entries.length} entities found). Run 'skilltree registry index' to update.`,
 			);
+			for (const reason of staleReasons) {
+				console.log(`  - ${reason}`);
+			}
 			process.exit(1);
 		}
 		return;
@@ -144,6 +164,133 @@ async function tryAddSkill(
 		// Skip unreadable
 	}
 	return true; // Don't recurse into skill directories
+}
+
+/**
+ * Compute the list of reasons (if any) that the existing index file is out
+ * of sync with on-disk reality. Empty array = index is fine.
+ *
+ * Two failure modes (issue #62):
+ *   1. Scanner discovers an entity the index is missing or has wrong data for.
+ *   2. Index contains an entry whose path doesn't resolve to a real entity.
+ *
+ * Hand-authored entries at scanner-unreachable paths are valid and do not
+ * trigger either failure mode, as long as a SKILL.md (skill) or markdown
+ * file with frontmatter (agent/command) exists at the declared path.
+ */
+async function diagnoseIndex(
+	baseDir: string,
+	existingYaml: string,
+	scannerEntries: IndexEntry[],
+): Promise<string[]> {
+	const reasons: string[] = [];
+
+	let parsed: unknown;
+	try {
+		parsed = YAML.parse(existingYaml);
+	} catch (err) {
+		reasons.push(`existing index is not valid YAML: ${(err as Error).message}`);
+		return reasons;
+	}
+	const fileEntries = extractEntities(parsed);
+	if (fileEntries === null) {
+		reasons.push("existing index is missing an `entities` list");
+		return reasons;
+	}
+
+	const fileByPath = new Map<string, IndexEntry>();
+	for (const e of fileEntries) {
+		fileByPath.set(e.path, e);
+	}
+
+	// 1. Scanner-discoverable entities must each be represented in the file.
+	for (const scanned of scannerEntries) {
+		const found = fileByPath.get(scanned.path);
+		if (!found) {
+			reasons.push(`missing entry for ${scanned.path}`);
+			continue;
+		}
+		const mismatch = compareScannerFields(scanned, found);
+		if (mismatch) {
+			reasons.push(`entry for ${scanned.path}: ${mismatch}`);
+		}
+	}
+
+	// 2. Extras (entries the scanner didn't produce) must point to real
+	//    entities on disk. This catches typos and stale paths without
+	//    rejecting legitimate hand-authored entries.
+	const scannerPaths = new Set(scannerEntries.map((e) => e.path));
+	for (const fileEntry of fileEntries) {
+		if (scannerPaths.has(fileEntry.path)) continue;
+		const validity = await validateExtraEntry(baseDir, fileEntry);
+		if (validity !== null) {
+			reasons.push(`entry for ${fileEntry.path}: ${validity}`);
+		}
+	}
+
+	return reasons;
+}
+
+/** Defensive `entities:` extraction from arbitrary YAML input. */
+function extractEntities(parsed: unknown): IndexEntry[] | null {
+	if (parsed === null || typeof parsed !== "object") return null;
+	const entities = (parsed as { entities?: unknown }).entities;
+	if (!Array.isArray(entities)) return null;
+	const out: IndexEntry[] = [];
+	for (const raw of entities) {
+		if (raw === null || typeof raw !== "object") continue;
+		const e = raw as Record<string, unknown>;
+		if (typeof e.name !== "string" || typeof e.path !== "string") continue;
+		if (e.type !== "skill" && e.type !== "agent" && e.type !== "command") continue;
+		const entry: IndexEntry = { name: e.name, type: e.type, path: e.path };
+		if (typeof e.description === "string") entry.description = e.description;
+		if (Array.isArray(e.tags)) {
+			entry.tags = e.tags.filter((t): t is string => typeof t === "string");
+		}
+		out.push(entry);
+	}
+	return out;
+}
+
+/**
+ * Return a human-readable mismatch reason, or null if `file` matches what the
+ * scanner produced. `tags` are intentionally ignored — the scanner never
+ * emits tags, so hand-curated tags on otherwise-matching entries are kept.
+ */
+function compareScannerFields(scanner: IndexEntry, file: IndexEntry): string | null {
+	if (file.name !== scanner.name) {
+		return `name mismatch (have "${file.name}", expected "${scanner.name}")`;
+	}
+	if (file.type !== scanner.type) {
+		return `type mismatch (have "${file.type}", expected "${scanner.type}")`;
+	}
+	if ((file.description ?? "") !== (scanner.description ?? "")) {
+		return "description is out of date";
+	}
+	return null;
+}
+
+/**
+ * Verify that an index entry whose path the scanner did not visit still
+ * corresponds to a real entity on disk. Returns null when valid, or a
+ * one-line reason otherwise.
+ */
+async function validateExtraEntry(baseDir: string, entry: IndexEntry): Promise<string | null> {
+	const fullPath = join(baseDir, entry.path);
+	if (entry.type === "skill") {
+		return existsSync(join(fullPath, "SKILL.md")) ? null : "path does not contain a SKILL.md";
+	}
+	if (!existsSync(fullPath)) return "path does not exist";
+	try {
+		const content = await readFile(fullPath, "utf-8");
+		const fm = parseFrontmatter(content);
+		if (!fm || (!fm.name && !fm.skills)) {
+			return "file has no usable frontmatter (`name` or `skills`)";
+		}
+		return null;
+	} catch (err) {
+		return `path is unreadable: ${(err as Error).message}`;
+	}
 }
 
 async function tryAddAgent(

--- a/tests/commands/index-cmd.test.ts
+++ b/tests/commands/index-cmd.test.ts
@@ -277,4 +277,172 @@ describe("indexCommand", () => {
 			/Both skilltree-index\.yml and skillkit-index\.yaml/,
 		);
 	});
+
+	// --- Issue #62: --check must respect hand-authored entries for skills at
+	// non-standard paths (the scanner only walks the standard layout). ---
+
+	test("--check passes when index contains a hand-authored entry for a skill at a non-standard path", async () => {
+		const dir = await makeTempDir();
+
+		// Standard-layout skill — scanner-discoverable
+		await mkdir(join(dir, "crawl4ai"), { recursive: true });
+		await writeFile(join(dir, "crawl4ai", "SKILL.md"), "---\nname: crawl4ai\n---\n");
+
+		// Outer "esql-details" is itself a skill — scanner-discoverable. Since
+		// the scanner stops at the first SKILL.md and does not recurse into
+		// skill directories, the nested skill below is unreachable to it.
+		await mkdir(join(dir, "esql-details", "esql-details-inner"), { recursive: true });
+		await writeFile(join(dir, "esql-details", "SKILL.md"), "---\nname: esql-details\n---\n");
+		await writeFile(
+			join(dir, "esql-details", "esql-details-inner", "SKILL.md"),
+			"---\nname: esql-details-inner\n---\n",
+		);
+
+		// Hand-authored index that includes all three — the third one is the
+		// manual addition for the non-standard, scanner-unreachable path.
+		await writeFile(
+			join(dir, "skilltree-index.yml"),
+			YAML.stringify({
+				entities: [
+					{ name: "crawl4ai", type: "skill", path: "crawl4ai" },
+					{ name: "esql-details", type: "skill", path: "esql-details" },
+					{
+						name: "esql-details-inner",
+						type: "skill",
+						path: "esql-details/esql-details-inner",
+					},
+				],
+			}),
+		);
+
+		const exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
+		expect(exitCode).toBeUndefined();
+	});
+
+	test("--check passes when index contains a hand-authored entry for an agent at a non-standard path", async () => {
+		const dir = await makeTempDir();
+
+		// Nested agent that the scanner won't reach because it lives inside a
+		// directory that the scanner doesn't conventionally walk into.
+		await mkdir(join(dir, "custom", "nested"), { recursive: true });
+		await writeFile(
+			join(dir, "custom", "nested", "deep-agent.md"),
+			"---\nname: deep-agent\nskills: foo\n---\n",
+		);
+
+		// Tell the scanner not to recurse into `custom/` by placing a SKILL.md
+		// at `custom/` (skills are not recursed into), so the agent stays
+		// scanner-invisible while still existing on disk.
+		await writeFile(join(dir, "custom", "SKILL.md"), "---\nname: custom-skill\n---\n");
+
+		await writeFile(
+			join(dir, "skilltree-index.yml"),
+			YAML.stringify({
+				entities: [
+					{ name: "custom-skill", type: "skill", path: "custom" },
+					{
+						name: "deep-agent",
+						type: "agent",
+						path: "custom/nested/deep-agent.md",
+					},
+				],
+			}),
+		);
+
+		const exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
+		expect(exitCode).toBeUndefined();
+	});
+
+	test("--check fails when a hand-authored entry points to a non-existent path", async () => {
+		const dir = await makeTempDir();
+		await mkdir(join(dir, "real-skill"), { recursive: true });
+		await writeFile(join(dir, "real-skill", "SKILL.md"), "---\nname: real-skill\n---\n");
+
+		await writeFile(
+			join(dir, "skilltree-index.yml"),
+			YAML.stringify({
+				entities: [
+					{ name: "real-skill", type: "skill", path: "real-skill" },
+					{ name: "phantom", type: "skill", path: "does/not/exist" },
+				],
+			}),
+		);
+
+		const exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
+		expect(exitCode).toBe(1);
+	});
+
+	test("--check fails when a scanner-discoverable entity is missing from the index", async () => {
+		const dir = await makeTempDir();
+		await mkdir(join(dir, "alpha"), { recursive: true });
+		await writeFile(join(dir, "alpha", "SKILL.md"), "---\nname: alpha\n---\n");
+		await mkdir(join(dir, "beta"), { recursive: true });
+		await writeFile(join(dir, "beta", "SKILL.md"), "---\nname: beta\n---\n");
+
+		// Index lists only one of the two — `beta` is missing.
+		await writeFile(
+			join(dir, "skilltree-index.yml"),
+			YAML.stringify({
+				entities: [{ name: "alpha", type: "skill", path: "alpha" }],
+			}),
+		);
+
+		const exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
+		expect(exitCode).toBe(1);
+	});
+
+	test("--check preserves hand-authored tags on scanner-discoverable entries", async () => {
+		const dir = await makeTempDir();
+		await mkdir(join(dir, "my-skill"), { recursive: true });
+		await writeFile(
+			join(dir, "my-skill", "SKILL.md"),
+			"---\nname: my-skill\ndescription: A test\n---\n",
+		);
+
+		// Scanner never produces `tags`. Hand-curated tags on an otherwise
+		// scanner-equivalent entry must NOT trip --check.
+		await writeFile(
+			join(dir, "skilltree-index.yml"),
+			YAML.stringify({
+				entities: [
+					{
+						name: "my-skill",
+						type: "skill",
+						path: "my-skill",
+						description: "A test",
+						tags: ["custom", "curated"],
+					},
+				],
+			}),
+		);
+
+		const exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
+		expect(exitCode).toBeUndefined();
+	});
+
+	test("--check fails when a scanner-discoverable entry has a wrong description", async () => {
+		const dir = await makeTempDir();
+		await mkdir(join(dir, "my-skill"), { recursive: true });
+		await writeFile(
+			join(dir, "my-skill", "SKILL.md"),
+			"---\nname: my-skill\ndescription: Real description\n---\n",
+		);
+
+		await writeFile(
+			join(dir, "skilltree-index.yml"),
+			YAML.stringify({
+				entities: [
+					{
+						name: "my-skill",
+						type: "skill",
+						path: "my-skill",
+						description: "Outdated description",
+					},
+				],
+			}),
+		);
+
+		const exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
+		expect(exitCode).toBe(1);
+	});
 });


### PR DESCRIPTION
## Why

`skilltree registry index --check` was a strict byte-comparison between the existing `skilltree-index.yml` and what the scanner would produce. Any hand-authored entry for a skill or agent the scanner can't reach — nested under a parent `SKILL.md`, monorepo packages, etc. — got reported as "stale", making `--check` unusable in CI for any repo with a non-standard layout. This directly contradicts the docs, which advertise `skilltree-index.yml` as the answer for non-standard layouts.

Closes #62

## What changed

- `src/commands/index-cmd.ts` — `--check` no longer compares raw YAML text. New `diagnoseIndex` helper validates the index against on-disk reality in two passes: (1) every scanner-discovered entity must be present in the file with matching `name`/`type`/`description`; (2) every other entry must point to a real on-disk entity (a `SKILL.md` for skills, or a markdown file with `name:`/`skills:` frontmatter for agents/commands). `tags:` is scanner-invisible and always preserved.
- Stale output now lists *which* entries are out of sync (one bullet per reason) — much easier to diagnose in CI logs than the previous one-line "is stale".
- Phantom entries (paths that don't resolve) still fail `--check`.
- `docs/specs/registries.md` + `skills/skilltree/references/commands.md` — clarify the new `--check` semantics and that hand-authored entries for non-standard paths are explicitly supported.

## How tested

- Six new tests in `tests/commands/index-cmd.test.ts` covering the new behavior, written TDD-style (red → green):
  - hand-authored skill entry at a path nested under a parent `SKILL.md` (scanner-unreachable) — passes `--check`
  - hand-authored agent entry at a path inside a skill dir (scanner-unreachable) — passes `--check`
  - phantom entry (path doesn't exist) — fails `--check`
  - scanner-discoverable entity missing from the index — fails `--check`
  - hand-authored `tags:` on an otherwise-matching entry — passes `--check`
  - description mismatch on a scanner-discoverable entry — fails `--check`
- Full suite: 1213/1213 pass; lint + typecheck clean.

## Risk & rollback

Low. The change is local to `indexCommand`'s `--check` branch — the write path (`skilltree registry index` without `--check`) is untouched, the legacy `skillkit-index.yaml` deprecation flow is untouched, and no other command depends on the comparison logic. Rollback: `git revert <sha>`.