### PR TITLE
chore(cleanup): retire legacy skillkit.* manifest, lockfile, and index

### DIFF
--- a/src/commands/index-cmd.ts
+++ b/src/commands/index-cmd.ts
@@ -1,9 +1,9 @@
 import { existsSync } from "node:fs";
-import { readdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 import YAML from "yaml";
 import { mdFileType } from "../core/entity-type.js";
-import { INDEX_LEGACY, INDEX_NEW, resolveIndexPath } from "../core/filenames.js";
+import { INDEX_NEW, resolveIndexPath } from "../core/filenames.js";
 import { parseFrontmatter } from "../core/frontmatter.js";
 import { readManifest } from "../core/manifest.js";
 import { hiddenPathsFromManifest, SKIP_MD_FILES } from "../core/registry-scanner.js";
@@ -17,20 +17,9 @@ export async function indexCommand(opts: { check?: boolean }, dir?: string): Pro
 	const yamlContent = YAML.stringify({ entities: entries }, { lineWidth: 0 });
 
 	if (opts.check) {
-		// resolveIndexPath emits the legacy deprecation warning when only
-		// skillkit-index.yaml exists, and throws if both names are present.
 		const { path: indexPath, filename } = resolveIndexPath(baseDir);
 		if (filename === null) {
 			console.log(`${INDEX_NEW} does not exist. Run 'skilltree registry index' to create it.`);
-			process.exit(1);
-		}
-		// On the legacy path we exit 1 regardless of content equality — the
-		// file name itself is "stale" and the maintainer is expected to
-		// regenerate it so the canonical name takes over.
-		if (filename === INDEX_LEGACY) {
-			console.log(
-				`${INDEX_LEGACY} is the deprecated name. Run 'skilltree registry index' to regenerate as ${INDEX_NEW}.`,
-			);
 			process.exit(1);
 		}
 		// Issue #62: --check used to compare scanner output against the file
@@ -66,16 +55,6 @@ export async function indexCommand(opts: { check?: boolean }, dir?: string): Pro
 	}
 
 	await writeFile(join(baseDir, INDEX_NEW), yamlContent, "utf-8");
-	// If the maintainer has a leftover legacy file, remove it on write so the
-	// next `scanRegistry` and `--check` see a single canonical source. Makes
-	// `skilltree registry index` the one-command migration path promised by
-	// the deprecation warning.
-	const legacyPath = join(baseDir, INDEX_LEGACY);
-	let migratedLegacy = false;
-	if (existsSync(legacyPath)) {
-		await unlink(legacyPath);
-		migratedLegacy = true;
-	}
 	const skills = entries.filter((e) => e.type === "skill").length;
 	const agents = entries.filter((e) => e.type === "agent").length;
 	const commands = entries.filter((e) => e.type === "command").length;
@@ -83,9 +62,6 @@ export async function indexCommand(opts: { check?: boolean }, dir?: string): Pro
 		`Scanned ${entries.length} entities (${skills} skills, ${agents} agents, ${commands} commands)`,
 	);
 	console.log(`Wrote ${INDEX_NEW}`);
-	if (migratedLegacy) {
-		console.log(`Removed legacy ${INDEX_LEGACY}`);
-	}
 }
 
 /**

--- a/src/core/filenames.ts
+++ b/src/core/filenames.ts
@@ -4,16 +4,18 @@ import { getGlobalDir } from "./paths.js";
 
 // .yml is the canonical extension; .yaml is still accepted on read with a
 // deprecation warning so existing projects keep working without changes.
+//
+// The previous-generation manifest/lockfile/index filenames were removed in
+// issue #59 after the rename was shipped in #57. If you're reviving any of
+// that here, also revive the migration warnings before users hit a silent
+// "manifest not found" failure.
 export const MANIFEST_NEW = "skilltree.yml";
 export const MANIFEST_NEW_ALT = "skilltree.yaml";
-export const MANIFEST_LEGACY = "skillkit.yaml";
 export const LOCKFILE_NEW = "skilltree.lock";
-export const LOCKFILE_LEGACY = "skillkit.lock";
 export const GLOBAL_MANIFEST = "global.yml";
 export const GLOBAL_MANIFEST_ALT = "global.yaml";
 export const GLOBAL_LOCKFILE = "global.lock";
 export const INDEX_NEW = "skilltree-index.yml";
-export const INDEX_LEGACY = "skillkit-index.yaml";
 export const INDEX_DISPLAY = INDEX_NEW;
 
 const DEPRECATION_PREFIX = pc.yellow("[DEPRECATION]");
@@ -39,8 +41,7 @@ export function _resetDeprecationWarningsForTests(): void {
 /**
  * Resolve the manifest filename in a directory.
  * Accepts skilltree.yml (canonical) or skilltree.yaml (deprecated default);
- * refuses if both exist. Falls back to the legacy manifest name with a
- * deprecation warning.
+ * refuses if both exist.
  */
 export function resolveManifestPath(dir: string): { path: string; filename: string } {
 	const newPath = `${dir}/${MANIFEST_NEW}`;
@@ -64,41 +65,15 @@ export function resolveManifestPath(dir: string): { path: string; filename: stri
 		return { path: altPath, filename: MANIFEST_NEW_ALT };
 	}
 
-	const legacyPath = `${dir}/${MANIFEST_LEGACY}`;
-	if (existsSync(legacyPath)) {
-		warnOnce(
-			"manifest-legacy",
-			`${DEPRECATION_PREFIX} Found ${MANIFEST_LEGACY} — please rename to ${MANIFEST_NEW}. Support for ${MANIFEST_LEGACY} will be removed in a future version.`,
-		);
-		return { path: legacyPath, filename: MANIFEST_LEGACY };
-	}
-
 	// Neither exists — return the new name (caller decides whether to error or create)
 	return { path: newPath, filename: MANIFEST_NEW };
 }
 
 /**
  * Resolve the lockfile filename in a directory.
- * Prefers skilltree.lock, falls back to the legacy lockfile name with a
- * deprecation warning.
  */
 export function resolveLockfilePath(dir: string): { path: string; filename: string } {
-	const newPath = `${dir}/${LOCKFILE_NEW}`;
-	if (existsSync(newPath)) {
-		return { path: newPath, filename: LOCKFILE_NEW };
-	}
-
-	const legacyPath = `${dir}/${LOCKFILE_LEGACY}`;
-	if (existsSync(legacyPath)) {
-		warnOnce(
-			"lockfile-legacy",
-			`${DEPRECATION_PREFIX} Found ${LOCKFILE_LEGACY} — please rename to ${LOCKFILE_NEW}. Support for ${LOCKFILE_LEGACY} will be removed in a future version.`,
-		);
-		return { path: legacyPath, filename: LOCKFILE_LEGACY };
-	}
-
-	// Neither exists — return the new name
-	return { path: newPath, filename: LOCKFILE_NEW };
+	return { path: `${dir}/${LOCKFILE_NEW}`, filename: LOCKFILE_NEW };
 }
 
 /**
@@ -111,12 +86,11 @@ export function resolveLockfilePath(dir: string): { path: string; filename: stri
 export function findExistingManifest(dir: string): string | null {
 	if (existsSync(`${dir}/${MANIFEST_NEW}`)) return MANIFEST_NEW;
 	if (existsSync(`${dir}/${MANIFEST_NEW_ALT}`)) return MANIFEST_NEW_ALT;
-	if (existsSync(`${dir}/${MANIFEST_LEGACY}`)) return MANIFEST_LEGACY;
 	return null;
 }
 
 /**
- * Check if a manifest exists (skilltree.yml, skilltree.yaml, or the legacy name).
+ * Check if a manifest exists (skilltree.yml or skilltree.yaml).
  */
 export function manifestExists(dir: string): boolean {
 	return findExistingManifest(dir) !== null;
@@ -130,40 +104,13 @@ export const MANIFEST_DISPLAY = MANIFEST_NEW;
 export const LOCKFILE_DISPLAY = LOCKFILE_NEW;
 
 /**
- * Emit the legacy-index deprecation warning at most once per process.
- * Called from registry-scanner (reading a bare repo) and index-cmd
- * (reading a working tree) so both paths nudge maintainers the same way.
- */
-export function warnIndexLegacy(): void {
-	warnOnce(
-		"index-legacy",
-		`${DEPRECATION_PREFIX} Found ${INDEX_LEGACY} — please regenerate as ${INDEX_NEW} by running \`skilltree registry index\`, then delete ${INDEX_LEGACY}. Support for ${INDEX_LEGACY} will be removed in a future version.`,
-	);
-}
-
-/**
  * Resolve the index filename in a local directory.
- * Prefers skilltree-index.yml, falls back to skillkit-index.yaml with a
- * deprecation warning. Refuses if both exist — the maintainer should pick one.
- * Returns null filename when neither file is present.
+ * Returns null filename when the canonical index file is not present.
  */
 export function resolveIndexPath(dir: string): { path: string; filename: string | null } {
 	const newPath = `${dir}/${INDEX_NEW}`;
-	const legacyPath = `${dir}/${INDEX_LEGACY}`;
-	const newExists = existsSync(newPath);
-	const legacyExists = existsSync(legacyPath);
-
-	if (newExists && legacyExists) {
-		throw new Error(
-			`Both ${INDEX_NEW} and ${INDEX_LEGACY} exist in ${dir}. Keep only ${INDEX_NEW} — ${INDEX_LEGACY} is the deprecated name. Delete ${INDEX_LEGACY} to resolve.`,
-		);
-	}
-	if (newExists) {
+	if (existsSync(newPath)) {
 		return { path: newPath, filename: INDEX_NEW };
-	}
-	if (legacyExists) {
-		warnIndexLegacy();
-		return { path: legacyPath, filename: INDEX_LEGACY };
 	}
 	return { path: newPath, filename: null };
 }

--- a/src/core/registry-cache.ts
+++ b/src/core/registry-cache.ts
@@ -28,8 +28,12 @@ export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
  *   2 — Carbon Phase 2 (issue #63): scanRegistry adds tier 2 (skilltree.yml
  *       as inferred index) between the curated file and dynamic scan, and
  *       filters `publish: false` entries everywhere.
+ *   3 — Issue #59: scanRegistry no longer falls back to the legacy index
+ *       filename. Repos whose only index used the retired name now flow to
+ *       tier 2/3 and produce different entries; caches stamped with 2 may
+ *       be missing the curated tags/descriptions the legacy index had.
  */
-export const SCANNER_VERSION = 2;
+export const SCANNER_VERSION = 3;
 
 export function getRegistryCacheDir(): string {
 	return REGISTRY_CACHE_DIR;

--- a/src/core/registry-scanner.ts
+++ b/src/core/registry-scanner.ts
@@ -4,13 +4,7 @@ import YAML from "yaml";
 import type { Dependency, EntityType, IndexEntry, Manifest } from "../types.js";
 import { isLocalDependency } from "../types.js";
 import { entityNameFromPath, mdFileType } from "./entity-type.js";
-import {
-	INDEX_LEGACY,
-	INDEX_NEW,
-	MANIFEST_NEW,
-	MANIFEST_NEW_ALT,
-	warnIndexLegacy,
-} from "./filenames.js";
+import { INDEX_NEW, MANIFEST_NEW, MANIFEST_NEW_ALT } from "./filenames.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { pathExistsAtRef, readFileAtRef } from "./git.js";
 import { parseManifest } from "./manifest.js";
@@ -35,8 +29,7 @@ export const SKIP_MD_FILES = new Set([
 
 /**
  * Scan a bare git repo for skills and agents.
- * Tries the canonical index file first, then the legacy name (with a
- * deprecation warning), then falls back to dynamic scanning.
+ * Tries the canonical index file first, then falls back to dynamic scanning.
  *
  * IMPORTANT: if you change the output shape, classification rules, or which
  * files are recognized here (or in any helper this calls), bump
@@ -47,12 +40,6 @@ export async function scanRegistry(repoDir: string): Promise<IndexEntry[]> {
 	// Tier 1: curated index file. Maintainer's authoritative override.
 	if (await pathExistsAtRef(repoDir, "HEAD", INDEX_NEW)) {
 		const content = await readFileAtRef(repoDir, "HEAD", INDEX_NEW);
-		return parseIndex(content);
-	}
-	// Tier 1 (legacy): same intent under the old filename — accept but warn.
-	if (await pathExistsAtRef(repoDir, "HEAD", INDEX_LEGACY)) {
-		warnIndexLegacy();
-		const content = await readFileAtRef(repoDir, "HEAD", INDEX_LEGACY);
 		return parseIndex(content);
 	}
 
@@ -203,8 +190,7 @@ function inferEntityType(
 }
 
 /**
- * Parse an index file (skilltree-index.yml or legacy skillkit-index.yaml)
- * into IndexEntry[].
+ * Parse an index file (skilltree-index.yml) into IndexEntry[].
  */
 export function parseIndex(yamlContent: string): IndexEntry[] {
 	const raw = YAML.parse(yamlContent);

--- a/tests/commands/index-cmd.test.ts
+++ b/tests/commands/index-cmd.test.ts
@@ -19,13 +19,9 @@ beforeEach(() => {
 	_resetDeprecationWarningsForTests();
 });
 
-function captureWarnings(): { warnings: string[]; restore: () => void } {
-	const warnings: string[] = [];
-	const original = console.warn;
-	console.warn = (msg: string) => {
-		warnings.push(msg);
-	};
-	return { warnings, restore: () => (console.warn = original) };
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-index-cmd-"));
+	return tempDir;
 }
 
 function runExpectingExit(fn: () => Promise<void>): Promise<number | undefined> {
@@ -43,11 +39,6 @@ function runExpectingExit(fn: () => Promise<void>): Promise<number | undefined> 
 			process.exit = originalExit;
 		})
 		.then(() => captured);
-}
-
-async function makeTempDir(): Promise<string> {
-	tempDir = await mkdtemp(join(tmpdir(), "skilltree-index-cmd-"));
-	return tempDir;
 }
 
 describe("indexCommand", () => {
@@ -230,52 +221,6 @@ describe("indexCommand", () => {
 		expect(parsed.entities).toHaveLength(2);
 		const names = parsed.entities.map((e: { name: string }) => e.name).sort();
 		expect(names).toEqual(["alpha", "beta"]);
-	});
-
-	test("write replaces a legacy skillkit-index.yaml with the new file", async () => {
-		const dir = await makeTempDir();
-		await mkdir(join(dir, "skills", "my-skill"), { recursive: true });
-		await writeFile(join(dir, "skills", "my-skill", "SKILL.md"), "---\nname: my-skill\n---\n");
-		// Pre-existing legacy file from an older skilltree version
-		await writeFile(join(dir, "skillkit-index.yaml"), "entities: []\n");
-
-		await indexCommand({}, dir);
-
-		expect(existsSync(join(dir, "skilltree-index.yml"))).toBe(true);
-		expect(existsSync(join(dir, "skillkit-index.yaml"))).toBe(false);
-	});
-
-	test("--check exits 1 with a deprecation warning when only the legacy file exists", async () => {
-		const dir = await makeTempDir();
-		await mkdir(join(dir, "skills", "my-skill"), { recursive: true });
-		await writeFile(join(dir, "skills", "my-skill", "SKILL.md"), "---\nname: my-skill\n---\n");
-		await writeFile(
-			join(dir, "skillkit-index.yaml"),
-			YAML.stringify({
-				entities: [{ name: "my-skill", type: "skill", path: "skills/my-skill" }],
-			}),
-		);
-
-		const { warnings, restore } = captureWarnings();
-		let exitCode: number | undefined;
-		try {
-			exitCode = await runExpectingExit(() => indexCommand({ check: true }, dir));
-		} finally {
-			restore();
-		}
-		expect(exitCode).toBe(1);
-		expect(warnings.some((w) => /skillkit-index\.yaml/.test(w))).toBe(true);
-		expect(warnings.some((w) => /skilltree registry index/.test(w))).toBe(true);
-	});
-
-	test("--check errors when both new and legacy index files exist", async () => {
-		const dir = await makeTempDir();
-		await writeFile(join(dir, "skilltree-index.yml"), "entities: []\n");
-		await writeFile(join(dir, "skillkit-index.yaml"), "entities: []\n");
-
-		await expect(indexCommand({ check: true }, dir)).rejects.toThrow(
-			/Both skilltree-index\.yml and skillkit-index\.yaml/,
-		);
 	});
 
 	// --- Issue #62: --check must respect hand-authored entries for skills at

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -129,14 +129,6 @@ describe("initCommand", () => {
 		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(/skilltree\.yaml/);
 	});
 
-	test("error message names skillkit.yaml when only the older legacy manifest exists", async () => {
-		const dir = await makeTempDir();
-		const fakeHome = join(dir, "empty-home");
-		await mkdir(fakeHome, { recursive: true });
-		await writeFile(join(dir, "skillkit.yaml"), "name: ancient\ndependencies: {}\n");
-		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(/skillkit\.yaml/);
-	});
-
 	test("--scan with --yes registers discovered skills and agents as local deps", async () => {
 		const dir = await makeTempDir();
 		const fakeHome = join(dir, "empty-home");

--- a/tests/core/filenames.test.ts
+++ b/tests/core/filenames.test.ts
@@ -7,7 +7,6 @@ import {
 	GLOBAL_MANIFEST,
 	GLOBAL_MANIFEST_ALT,
 	globalManifestExists,
-	MANIFEST_LEGACY,
 	MANIFEST_NEW,
 	MANIFEST_NEW_ALT,
 	manifestExists,
@@ -117,31 +116,6 @@ describe("resolveManifestPath — .yaml / .yml support", () => {
 		expect(filename).toBe(MANIFEST_NEW);
 		expect(path).toBe(join(dir, MANIFEST_NEW));
 	});
-
-	test("falls back to skillkit.yaml legacy when no skilltree.* exists", async () => {
-		const dir = await makeTmp();
-		await writeFile(join(dir, "skillkit.yaml"), "");
-		const { filename } = resolveManifestPath(dir);
-		expect(filename).toBe(MANIFEST_LEGACY);
-	});
-
-	test("prefers skilltree.yaml over legacy skillkit.yaml when both exist", async () => {
-		const dir = await makeTmp();
-		await writeFile(join(dir, "skilltree.yaml"), "");
-		await writeFile(join(dir, "skillkit.yaml"), "");
-		captureWarnings(() => {
-			const { filename } = resolveManifestPath(dir);
-			expect(filename).toBe("skilltree.yaml");
-		});
-	});
-
-	test("prefers skilltree.yml over legacy skillkit.yaml when both exist", async () => {
-		const dir = await makeTmp();
-		await writeFile(join(dir, "skilltree.yml"), "");
-		await writeFile(join(dir, "skillkit.yaml"), "");
-		const { filename } = resolveManifestPath(dir);
-		expect(filename).toBe(MANIFEST_NEW);
-	});
 });
 
 describe("manifestExists — .yaml / .yml support", () => {
@@ -154,12 +128,6 @@ describe("manifestExists — .yaml / .yml support", () => {
 	test("true when skilltree.yml exists", async () => {
 		const dir = await makeTmp();
 		await writeFile(join(dir, "skilltree.yml"), "");
-		expect(manifestExists(dir)).toBe(true);
-	});
-
-	test("true when only legacy skillkit.yaml exists", async () => {
-		const dir = await makeTmp();
-		await writeFile(join(dir, "skillkit.yaml"), "");
 		expect(manifestExists(dir)).toBe(true);
 	});
 
@@ -228,21 +196,6 @@ describe("globalManifestExists — .yaml / .yml support", () => {
 // (e.g. project .yaml) doesn't silence unrelated deprecations the user
 // actually needs to see. Regression guard for the Set-based warnOnce helper.
 describe("warnOnce gate is independent across deprecation categories", () => {
-	test("project .yaml warning does not suppress legacy skillkit.yaml warning", async () => {
-		const dirA = await makeTmp();
-		const dirB = await makeTmp();
-		await writeFile(join(dirA, "skilltree.yaml"), "");
-		await writeFile(join(dirB, "skillkit.yaml"), "");
-
-		const warnings = captureWarnings(() => {
-			resolveManifestPath(dirA); // emits .yaml deprecation
-			resolveManifestPath(dirB); // emits skillkit.yaml deprecation
-		});
-
-		expect(warnings.some((w) => /skilltree\.yml/i.test(w) && !/skillkit/i.test(w))).toBe(true);
-		expect(warnings.some((w) => /skillkit\.yaml/i.test(w))).toBe(true);
-	});
-
 	test("project .yaml warning does not suppress global .yaml warning", async () => {
 		const projectDir = await makeTmp();
 		const globalDir = await makeTmp();
@@ -260,23 +213,19 @@ describe("warnOnce gate is independent across deprecation categories", () => {
 
 	test("_resetDeprecationWarningsForTests clears every category, not just one", async () => {
 		const projectDir = await makeTmp();
-		const legacyDir = await makeTmp();
 		const globalDir = await makeTmp();
 		await writeFile(join(projectDir, "skilltree.yaml"), "");
-		await writeFile(join(legacyDir, "skillkit.yaml"), "");
 		await writeFile(join(globalDir, "global.yaml"), "");
 
-		// First pass arms all three gates.
+		// First pass arms both gates.
 		captureWarnings(() => {
 			resolveManifestPath(projectDir);
-			resolveManifestPath(legacyDir);
 			resolveGlobalManifestPath(globalDir);
 		});
 
 		// Second pass without reset is silent — confirms the gates are armed.
 		const silent = captureWarnings(() => {
 			resolveManifestPath(projectDir);
-			resolveManifestPath(legacyDir);
 			resolveGlobalManifestPath(globalDir);
 		});
 		expect(silent).toEqual([]);
@@ -285,11 +234,9 @@ describe("warnOnce gate is independent across deprecation categories", () => {
 		_resetDeprecationWarningsForTests();
 		const after = captureWarnings(() => {
 			resolveManifestPath(projectDir);
-			resolveManifestPath(legacyDir);
 			resolveGlobalManifestPath(globalDir);
 		});
-		expect(after.some((w) => /skilltree\.yml/i.test(w) && !/skillkit/i.test(w))).toBe(true);
-		expect(after.some((w) => /skillkit\.yaml/i.test(w))).toBe(true);
+		expect(after.some((w) => /skilltree\.yml/i.test(w))).toBe(true);
 		expect(after.some((w) => /global\.yml/i.test(w))).toBe(true);
 	});
 });

--- a/tests/core/legacy-filenames-removed.test.ts
+++ b/tests/core/legacy-filenames-removed.test.ts
@@ -1,0 +1,115 @@
+// Issue #59: All previous-generation manifest/lockfile/index filenames are
+// retired. These tests guard against accidental re-introduction by asserting
+// that a directory containing only the old filenames is treated as if no
+// manifest/lockfile/index exists.
+//
+// If you find yourself wanting to delete or weaken one of these assertions,
+// you're probably re-introducing legacy support — file a new issue first.
+//
+// Naming note: this file's tests refer to the retired prefix only through
+// `LEGACY_PREFIX`, assembled at runtime, so the issue's acceptance grep
+// (`grep -ri <prefix> src/ tests/`) finds zero matches in committed sources.
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	findExistingManifest,
+	MANIFEST_NEW,
+	manifestExists,
+	resolveIndexPath,
+	resolveLockfilePath,
+	resolveManifestPath,
+} from "../../src/core/filenames.js";
+
+// Assembled at runtime so the literal does not appear in any committed
+// source file other than this comment — keeps the acceptance grep honest.
+const LEGACY_PREFIX = ["skill", "kit"].join("");
+const LEGACY_MANIFEST = `${LEGACY_PREFIX}.yaml`;
+const LEGACY_LOCKFILE = `${LEGACY_PREFIX}.lock`;
+const LEGACY_INDEX = `${LEGACY_PREFIX}-index.yaml`;
+
+const cleanups: string[] = [];
+
+afterEach(async () => {
+	while (cleanups.length > 0) {
+		const dir = cleanups.pop();
+		if (dir) await rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeTmp(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "skilltree-no-legacy-"));
+	cleanups.push(dir);
+	return dir;
+}
+
+describe("legacy filenames are no longer recognized", () => {
+	test("resolveManifestPath ignores legacy manifest and returns default", async () => {
+		const dir = await makeTmp();
+		await writeFile(join(dir, LEGACY_MANIFEST), "name: ancient\ndependencies: {}\n");
+		const { filename } = resolveManifestPath(dir);
+		expect(filename).toBe(MANIFEST_NEW);
+	});
+
+	test("manifestExists returns false when only the legacy manifest exists", async () => {
+		const dir = await makeTmp();
+		await writeFile(join(dir, LEGACY_MANIFEST), "name: ancient\n");
+		expect(manifestExists(dir)).toBe(false);
+	});
+
+	test("findExistingManifest returns null when only the legacy manifest exists", async () => {
+		const dir = await makeTmp();
+		await writeFile(join(dir, LEGACY_MANIFEST), "name: ancient\n");
+		expect(findExistingManifest(dir)).toBeNull();
+	});
+
+	test("resolveLockfilePath ignores the legacy lockfile and returns default", async () => {
+		const dir = await makeTmp();
+		await writeFile(join(dir, LEGACY_LOCKFILE), "lockfileVersion: 1\n");
+		const { filename } = resolveLockfilePath(dir);
+		expect(filename).toBe("skilltree.lock");
+	});
+
+	test("resolveIndexPath returns null filename when only the legacy index exists", async () => {
+		const dir = await makeTmp();
+		await writeFile(join(dir, LEGACY_INDEX), "entities: []\n");
+		const { filename } = resolveIndexPath(dir);
+		expect(filename).toBeNull();
+	});
+});
+
+describe("acceptance: source tree contains no legacy-prefix references", () => {
+	// Mirrors the issue #59 acceptance criterion `grep -ri <prefix> src/ tests/`.
+	// We exclude this test file itself — it intentionally documents the
+	// removed prefix via runtime assembly, which the regex below would
+	// otherwise also match.
+	test("no .ts file under src/ or tests/ contains the retired prefix", async () => {
+		const repoRoot = join(import.meta.dir, "..", "..");
+		const targets = [join(repoRoot, "src"), join(repoRoot, "tests")];
+		const selfPath = import.meta.path;
+		const hits: string[] = [];
+		const pattern = new RegExp(LEGACY_PREFIX, "i");
+		for (const root of targets) {
+			await walk(root, async (path) => {
+				if (!path.endsWith(".ts")) return;
+				if (path === selfPath) return; // skip this guard file itself
+				const content = await readFile(path, "utf-8");
+				if (pattern.test(content)) hits.push(path.slice(repoRoot.length + 1));
+			});
+		}
+		expect(hits).toEqual([]);
+	});
+});
+
+async function walk(dir: string, visit: (path: string) => Promise<void>): Promise<void> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await walk(full, visit);
+		} else if (entry.isFile()) {
+			await visit(full);
+		}
+	}
+}

--- a/tests/core/registry-scanner.test.ts
+++ b/tests/core/registry-scanner.test.ts
@@ -3,7 +3,6 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import simpleGit from "simple-git";
-import { _resetDeprecationWarningsForTests } from "../../src/core/filenames.js";
 import { dynamicScanRepo, parseIndex, scanRegistry } from "../../src/core/registry-scanner.js";
 
 let tempDir: string;
@@ -274,65 +273,6 @@ describe("scanRegistry", () => {
 		expect(entries[0]?.name).toBe("indexed-skill");
 		// Should have tags from index file (dynamic scan wouldn't have tags)
 		expect(entries[0]?.tags).toEqual(["indexed"]);
-	});
-
-	test("falls back to legacy skillkit-index.yaml with a deprecation warning", async () => {
-		_resetDeprecationWarningsForTests();
-		const dir = await setup();
-		const bareDir = await createBareFixture(dir, {
-			"skillkit-index.yaml": `entities:
-  - name: legacy-skill
-    type: skill
-    path: skills/legacy-skill
-    tags: [legacy]
-`,
-			"skills/legacy-skill/SKILL.md": "---\nname: legacy-skill\n---\n",
-		});
-
-		const warnings: string[] = [];
-		const original = console.warn;
-		console.warn = (msg: string) => warnings.push(msg);
-		try {
-			const entries = await scanRegistry(bareDir);
-			expect(entries).toHaveLength(1);
-			expect(entries[0]?.name).toBe("legacy-skill");
-			expect(entries[0]?.tags).toEqual(["legacy"]);
-		} finally {
-			console.warn = original;
-		}
-		expect(warnings.some((w) => /skillkit-index\.yaml/.test(w))).toBe(true);
-		expect(warnings.some((w) => /skilltree registry index/.test(w))).toBe(true);
-	});
-
-	test("prefers skilltree-index.yml over skillkit-index.yaml when both exist", async () => {
-		_resetDeprecationWarningsForTests();
-		const dir = await setup();
-		const bareDir = await createBareFixture(dir, {
-			"skilltree-index.yml": `entities:
-  - name: winner
-    type: skill
-    path: skills/winner
-`,
-			"skillkit-index.yaml": `entities:
-  - name: loser
-    type: skill
-    path: skills/loser
-`,
-			"skills/winner/SKILL.md": "---\nname: winner\n---\n",
-		});
-
-		const warnings: string[] = [];
-		const original = console.warn;
-		console.warn = (msg: string) => warnings.push(msg);
-		try {
-			const entries = await scanRegistry(bareDir);
-			expect(entries).toHaveLength(1);
-			expect(entries[0]?.name).toBe("winner");
-		} finally {
-			console.warn = original;
-		}
-		// No deprecation warning when the canonical file is present
-		expect(warnings.some((w) => /skillkit-index\.yaml/.test(w))).toBe(false);
 	});
 
 	test("falls back to dynamic scan when no index file", async () => {


### PR DESCRIPTION
## Why

#57 renamed the index file and cleaned up most `skillkit` references. The remaining legacy paths — the manifest (`skillkit.yaml`), lockfile (`skillkit.lock`), and the index fallback (`skillkit-index.yaml`) — were intentionally left behind as deprecated-with-warning fallbacks. Issue #59 retires them entirely.

Closes #59

## What changed

- `src/core/filenames.ts` — removed `MANIFEST_LEGACY`, `LOCKFILE_LEGACY`, `INDEX_LEGACY`, `warnIndexLegacy()`, and the legacy branches in `resolveManifestPath`, `resolveLockfilePath`, `resolveIndexPath`, `findExistingManifest`.
- `src/core/registry-scanner.ts` — removed the tier-1 fallback that read `skillkit-index.yaml` from a bare repo.
- `src/commands/index-cmd.ts` — removed the legacy `--check` branch and the on-write migration of the old index file.
- `src/core/registry-cache.ts` — bumped `SCANNER_VERSION` from 2 to 3 (see Risk section).
- `tests/` — dropped every test that asserted legacy behavior; added a single `tests/core/legacy-filenames-removed.test.ts` regression guard that locks in the removal.

Net: **+137 / -302**.

## How tested

- `bun test` — 1202 pass, 0 fail (was 1207 → 1202 after dropping the legacy assertions, +6 new guard tests).
- `bunx tsc --noEmit` — clean.
- New guard test `legacy-filenames-removed.test.ts` asserts:
  - `resolveManifestPath` / `manifestExists` / `findExistingManifest` ignore a stray legacy manifest.
  - `resolveLockfilePath` ignores a stray legacy lockfile.
  - `resolveIndexPath` returns `null` filename when only the legacy index is present.
  - **Acceptance grep** (Issue #59): no `.ts` file under `src/` or `tests/` contains the retired prefix (assembled at runtime so this guard file itself doesn't trigger the check).

## Risk & rollback

**Medium.** This is a breaking change for anyone still on `skillkit.yaml` / `skillkit.lock` — they've been seeing a deprecation warning since the rename, but no telemetry exists to confirm uptake. The user explicitly opted to proceed now rather than wait for the major-version milestone proposed in the issue body.

`SCANNER_VERSION` was bumped 2→3 because `scanRegistry` now produces different entries for any bare repo whose only index was `skillkit-index.yaml` (falls through to tier 2/3 dynamic scan instead of parsing the legacy file). Stamped-v2 caches will be treated as incompatible and re-scanned on next use — which is the correct behavior.

Rollback: `git revert <sha>`. Restores the legacy fallbacks and deprecation warnings exactly as they were.