### PR TITLE
Delete empty .gitignore after removing entries

### DIFF
--- a/src/core/gitignore.ts
+++ b/src/core/gitignore.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { resolveTarget } from "./agents.js";
 
@@ -49,7 +49,11 @@ export async function removeGitignoreEntries(dir: string, entries: string[]): Pr
 	const removed = entries.filter((e) => lines.some((l) => l.trim() === e));
 
 	if (removed.length > 0) {
-		await writeFile(gitignorePath, filtered.join("\n"), "utf-8");
+		if (filtered.every((line) => line.trim() === "" || line.trim().startsWith("#"))) {
+			await unlink(gitignorePath);
+		} else {
+			await writeFile(gitignorePath, filtered.join("\n"), "utf-8");
+		}
 	}
 
 	return removed;

--- a/tests/core/gitignore.test.ts
+++ b/tests/core/gitignore.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AGENT_REGISTRY } from "../../src/core/agents.js";
 import {
 	getSkillAgentIgnoreEntries,
 	getSkillAgentIgnoreEntriesForTarget,
+	removeGitignoreEntries,
 } from "../../src/core/gitignore.js";
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+	const dir = await mkdtemp(join(tmpdir(), "skilltree-gitignore-"));
+	try {
+		await fn(dir);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+}
 
 describe("getSkillAgentIgnoreEntries", () => {
 	test("strips trailing slash and emits skills/agents/commands entries", () => {
@@ -67,5 +81,47 @@ describe("getSkillAgentIgnoreEntriesForTarget", () => {
 				expect(ig.startsWith(`${entry.dir}/`)).toBe(true);
 			}
 		}
+	});
+});
+
+describe("removeGitignoreEntries", () => {
+	test("deletes .gitignore when removing the last meaningful entry", async () => {
+		await withTempDir(async (dir) => {
+			await writeFile(
+				join(dir, ".gitignore"),
+				".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+				"utf-8",
+			);
+
+			const removed = await removeGitignoreEntries(dir, [
+				".claude/skills/",
+				".claude/agents/",
+				".claude/commands/",
+			]);
+
+			expect(removed).toEqual([".claude/skills/", ".claude/agents/", ".claude/commands/"]);
+			expect(existsSync(join(dir, ".gitignore"))).toBe(false);
+		});
+	});
+
+	test("deletes .gitignore when only comments and blanks remain", async () => {
+		await withTempDir(async (dir) => {
+			await writeFile(join(dir, ".gitignore"), "# skilltree entries\n\n.claude/skills/\n", "utf-8");
+
+			await removeGitignoreEntries(dir, [".claude/skills/"]);
+
+			expect(existsSync(join(dir, ".gitignore"))).toBe(false);
+		});
+	});
+
+	test("keeps unrelated entries after removing managed entries", async () => {
+		await withTempDir(async (dir) => {
+			await writeFile(join(dir, ".gitignore"), "node_modules/\n.claude/skills/\n", "utf-8");
+
+			const removed = await removeGitignoreEntries(dir, [".claude/skills/"]);
+
+			expect(removed).toEqual([".claude/skills/"]);
+			expect(await readFile(join(dir, ".gitignore"), "utf-8")).toBe("node_modules/\n");
+		});
 	});
 });

--- a/tests/e2e/vendor-e2e.test.ts
+++ b/tests/e2e/vendor-e2e.test.ts
@@ -89,9 +89,7 @@ describe("vendor e2e", () => {
 
 		await vendorCommand(dir, {});
 
-		const gitignore = await readFile(join(dir, ".gitignore"), "utf-8");
-		expect(gitignore).not.toContain(".claude/skills/");
-		expect(gitignore).not.toContain(".claude/agents/");
+		expect(existsSync(join(dir, ".gitignore"))).toBe(false);
 	});
 
 	test("vendor --dry-run makes no changes", async () => {
@@ -159,7 +157,10 @@ describe("vendor e2e", () => {
 
 		const skillPath = join(dir, ".claude", "skills", "my-skill");
 		expect(existsSync(skillPath)).toBe(true);
-		const gitignoreBefore = await readFile(join(dir, ".gitignore"), "utf-8");
+		const gitignorePath = join(dir, ".gitignore");
+		const gitignoreBefore = existsSync(gitignorePath)
+			? await readFile(gitignorePath, "utf-8")
+			: null;
 
 		// Capture stdout so we can assert dry-run advertised itself
 		const logs: string[] = [];
@@ -179,7 +180,9 @@ describe("vendor e2e", () => {
 		expect(manifest.vendor).toBe(true);
 
 		// .gitignore unchanged
-		const gitignoreAfter = await readFile(join(dir, ".gitignore"), "utf-8");
+		const gitignoreAfter = existsSync(gitignorePath)
+			? await readFile(gitignorePath, "utf-8")
+			: null;
 		expect(gitignoreAfter).toBe(gitignoreBefore);
 
 		const output = logs.join("\n");


### PR DESCRIPTION
## Summary

- delete `.gitignore` when `removeGitignoreEntries()` removes the last meaningful entry
- treat comments and blank lines as non-meaningful for this cleanup
- keep `.gitignore` when unrelated entries remain

Fixes #73.

## Validation

- `bun test tests/core/gitignore.test.ts tests/e2e/vendor-e2e.test.ts`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact`

## Notes

Full `bun test` was not used as the final gate because it currently fails in existing local git fixture coverage on this host with `fatal: options '--bare' and '--origin origin' cannot be used together`. The focused gitignore and vendor tests above pass.
