### PR TITLE
fix: update --dry-run no longer mutates skilltree.lock

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -42,16 +42,19 @@ async function updateAll(
 ): Promise<void> {
 	console.log(`Updating all ${isGlobal ? "global " : ""}dependencies...`);
 
-	// Delete lockfile to force full re-resolution
-	try {
-		if (isGlobal) {
-			const { path } = resolveGlobalLockfilePath(globalDir);
-			await rm(path);
-		} else {
-			await rm(`${dir}/skilltree.lock`);
+	// Delete lockfile to force full re-resolution.
+	// Skipped under --dry-run so we don't mutate state during a preview.
+	if (!dryRun) {
+		try {
+			if (isGlobal) {
+				const { path } = resolveGlobalLockfilePath(globalDir);
+				await rm(path);
+			} else {
+				await rm(`${dir}/skilltree.lock`);
+			}
+		} catch {
+			// No lockfile
 		}
-	} catch {
-		// No lockfile
 	}
 
 	await installCommand(dir, {
@@ -89,22 +92,32 @@ async function selectiveUpdate(
 		throw new Error(`"${name}" is not in ${isGlobal ? GLOBAL_MANIFEST : MANIFEST_NEW}.`);
 	}
 
-	// Clear lockfile entries for this dep (and same-repo siblings)
+	// Clear lockfile entries for this dep (and same-repo siblings).
+	// Under --dry-run we only count what would be cleared; we do not mutate
+	// the in-memory lockfile or write it back.
 	const targetRepo = isRemoteDependency(dep) ? dep.repo : undefined;
 	let removedCount = 0;
 	for (const [key, entry] of Object.entries(lockfile.packages)) {
 		if (key === name || (targetRepo && entry.repo === targetRepo)) {
-			delete lockfile.packages[key];
+			if (!dryRun) {
+				delete lockfile.packages[key];
+			}
 			removedCount++;
 		}
 	}
 
-	if (isGlobal) {
-		await writeGlobalLockfile(lockfile, globalDir);
-	} else {
-		await writeLockfile(dir, lockfile);
+	if (!dryRun) {
+		if (isGlobal) {
+			await writeGlobalLockfile(lockfile, globalDir);
+		} else {
+			await writeLockfile(dir, lockfile);
+		}
 	}
-	console.log(dim(`Cleared ${removedCount} lockfile entries for re-resolution.`));
+	console.log(
+		dim(
+			`${dryRun ? "Would clear" : "Cleared"} ${removedCount} lockfile entries for re-resolution.`,
+		),
+	);
 
 	await installCommand(dir, {
 		dryRun,

--- a/tests/commands/update-extended.test.ts
+++ b/tests/commands/update-extended.test.ts
@@ -89,4 +89,42 @@ describe("updateCommand extended", () => {
 		const lockfile = parseLockfile(lockContent);
 		expect(lockfile.packages["my-skill"]).toBeDefined();
 	});
+
+	test("update --dry-run (all) does not delete the lockfile", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
+		);
+		await installCommand(dir, {});
+
+		const before = await readFile(join(dir, "skilltree.lock"), "utf-8");
+
+		// Bare update --dry-run should preview without touching the lockfile
+		await updateCommand(dir, undefined, { dryRun: true });
+
+		const after = await readFile(join(dir, "skilltree.lock"), "utf-8");
+		expect(after).toBe(before);
+	});
+
+	test("update <name> --dry-run does not clear lockfile entries", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			"dependencies:\n  my-skill:\n    local: ./skills/my-skill\n",
+		);
+		await installCommand(dir, {});
+
+		const before = await readFile(join(dir, "skilltree.lock"), "utf-8");
+		const beforeParsed = parseLockfile(before);
+		expect(beforeParsed.packages["my-skill"]).toBeDefined();
+
+		// Selective update --dry-run must not clear the entry
+		await updateCommand(dir, "my-skill", { dryRun: true });
+
+		const after = await readFile(join(dir, "skilltree.lock"), "utf-8");
+		expect(after).toBe(before);
+	});
 });


### PR DESCRIPTION
## Why
`skilltree update --dry-run` is documented as a preview, but both code paths in `src/commands/update.ts` were mutating (and in the bare case, deleting) `skilltree.lock` *before* the `dryRun` flag was consulted. Result: the command users naturally reached for as the "safe preview" caused silent data loss. P0 per the issue.

Closes #67

## What changed
- `src/commands/update.ts`
  - `updateAll`: the `rm(skilltree.lock)` block (both project and global paths) is now guarded by `if (!dryRun)`. Under `--dry-run`, the lockfile is left untouched and we delegate to `installCommand` which has its own `dryRun` handling.
  - `selectiveUpdate`: the per-entry `delete lockfile.packages[key]` and the subsequent `writeLockfile` / `writeGlobalLockfile` are both gated on `!dryRun`. The match-counting loop still runs so the preview can report how many entries *would* be cleared.
  - Console message switches between "Cleared N lockfile entries for re-resolution." and "Would clear N lockfile entries for re-resolution." based on `dryRun`.
- `tests/commands/update-extended.test.ts`: two new tests verify byte-equality of `skilltree.lock` before/after `updateCommand(..., { dryRun: true })` for both the bare-update and selective-update code paths.

## How tested
- New tests in `tests/commands/update-extended.test.ts` cover both code paths and assert the lockfile contents are unchanged.
- Full suite: 1210 pass / 0 fail.
- `bun run lint` and `bun run typecheck` clean.

## Risk & rollback
Low. Behavior change is strictly additive: paths that previously mutated under `dryRun` now no-op, matching the documented contract. Non-dry-run behavior is unchanged. Rollback: `git revert <sha>`.