### PR TITLE
fix(vendor): register & forward --target, fix error vocabulary

### DIFF
--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -296,14 +296,16 @@ skilltree registry index --check   # Exit 1 if stale (CI mode)
 Copy all dependencies as real files (no symlinks) for git commit. Enables distribution without upstream repo access.
 
 ```bash
-skilltree vendor              # Copy all deps, set vendor: true
-skilltree vendor --frozen     # Use lockfile only
-skilltree vendor --dry-run    # Show plan without making changes
+skilltree vendor                # Copy all deps, set vendor: true
+skilltree vendor --frozen       # Use lockfile only
+skilltree vendor --dry-run      # Show plan without making changes
+skilltree vendor --target codex # Pick a target when install_targets has 2+ entries
 ```
 
 **Flags:**
 - `--frozen` — Use lockfile only, error if out of sync
 - `-n, --dry-run` — Show plan without writing files
+- `--target <name>` — Select an install target by its raw `install_targets` entry (e.g. `claude`, `codex`). Required when the manifest has multiple targets configured; rejected on legacy `dev_install_path` manifests.
 
 Sets `vendor: true` in `skilltree.yml` and removes `.claude/skills/` and `.claude/agents/` from `.gitignore`.
 
@@ -312,12 +314,14 @@ Sets `vendor: true` in `skilltree.yml` and removes `.claude/skills/` and `.claud
 Exit vendor mode. Deletes vendored files and restores `.gitignore`.
 
 ```bash
-skilltree unvendor           # Errors if vendored files were modified
-skilltree unvendor --force   # Discard modifications and unvendor
+skilltree unvendor                # Errors if vendored files were modified
+skilltree unvendor --force        # Discard modifications and unvendor
+skilltree unvendor --target codex # Pick a target when install_targets has 2+ entries
 ```
 
 **Flags:**
 - `-f, --force` — Discard modified vendored files without error
+- `--target <name>` — Select an install target by its raw `install_targets` entry. Required when the manifest has multiple targets configured.
 
 Checks integrity of vendored files before deleting. If any were modified, errors with a list of changed files. Use `--force` to discard changes, or `skilltree vendor` to overwrite with fresh copies first.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,10 +193,15 @@ export function buildProgram(): Command {
 		.description("Copy all deps as real files for git commit (distribution mode)")
 		.option("--frozen", "Use lockfile only, error if out of sync")
 		.option("-n, --dry-run", "Show plan without making changes")
+		.option(
+			"--target <name>",
+			"Select install target by raw install_targets entry (e.g. claude, codex). Required when multiple targets are configured.",
+		)
 		.action(async (opts) => {
 			await vendorCommand(process.cwd(), {
 				frozen: opts.frozen,
 				dryRun: opts.dryRun,
+				target: opts.target,
 			});
 		});
 
@@ -205,8 +210,16 @@ export function buildProgram(): Command {
 		.description("Exit vendor mode, restore normal symlinked installs")
 		.option("-f, --force", "Discard modified vendored files")
 		.option("-n, --dry-run", "Show what would happen without making changes")
+		.option(
+			"--target <name>",
+			"Select install target by raw install_targets entry (e.g. claude, codex). Required when multiple targets are configured.",
+		)
 		.action(async (opts) => {
-			await unvendorCommand(process.cwd(), { force: opts.force, dryRun: opts.dryRun });
+			await unvendorCommand(process.cwd(), {
+				force: opts.force,
+				dryRun: opts.dryRun,
+				target: opts.target,
+			});
 		});
 
 	const deps = program.command("deps").description("Dependency graph commands");

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -1,5 +1,6 @@
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
+import { resolveTarget } from "../core/agents.js";
 import { MANIFEST_NEW } from "../core/filenames.js";
 import {
 	addGitignoreEntries,
@@ -17,7 +18,6 @@ import {
 } from "../core/lockfile.js";
 import {
 	getDevInstallPath,
-	getInstallTargets,
 	loadManifestOrThrow,
 	validateManifestOrThrow,
 	warnLegacyInstallPath,
@@ -32,7 +32,7 @@ import {
 	throwOnResolutionErrors,
 	warn,
 } from "../core/ui.js";
-import type { Lockfile } from "../types.js";
+import type { Lockfile, Manifest } from "../types.js";
 
 export interface VendorOptions {
 	frozen?: boolean;
@@ -40,19 +40,87 @@ export interface VendorOptions {
 	target?: string;
 }
 
+/**
+ * Resolve which install target a vendor/unvendor invocation should act on.
+ *
+ * The contract — same for both commands so users don't have to relearn:
+ *
+ *   - Multi-target manifest (`install_targets` has 2+ entries):
+ *       `--target <name>` is REQUIRED. Without it, error lists the raw
+ *       entries the user can pass (e.g. "claude, codex") — NOT the
+ *       resolved filesystem paths (".claude", ".agents"), which would
+ *       mislead them into typing the wrong thing back at us. (See #69.)
+ *
+ *   - Single `install_targets` entry: `--target` is optional; if provided
+ *       it must match the configured entry.
+ *
+ *   - Legacy manifest (no `install_targets`, uses `dev_install_path` or
+ *       defaults): `--target` is rejected — there are no named targets
+ *       to pick from. Falls back to `getDevInstallPath()`.
+ *
+ * Returns the resolved on-disk path relative to the project root (e.g.
+ * ".claude"). Throws a user-facing `Error` for any contract violation.
+ */
+function resolveVendorTarget(
+	manifest: Manifest,
+	cmd: "vendor" | "unvendor",
+	target: string | undefined,
+): string {
+	const rawTargets = manifest.install_targets;
+
+	if (!rawTargets || rawTargets.length === 0) {
+		// Legacy manifest — no named targets exist
+		if (target !== undefined) {
+			throw new Error(
+				`${cmd}: --target is only valid when install_targets is configured. This manifest uses the legacy dev_install_path — drop --target or migrate with \`skilltree targets migrate\`.`,
+			);
+		}
+		return getDevInstallPath(manifest);
+	}
+
+	if (rawTargets.length > 1 && target === undefined) {
+		throw new Error(
+			`${cmd} requires --target <name> when multiple install targets are configured.\nConfigured targets: ${rawTargets.join(", ")}`,
+		);
+	}
+
+	const selected = target ?? rawTargets[0];
+	if (selected === undefined) {
+		// Unreachable: rawTargets.length >= 1 by the empty-check above, and
+		// target is a defined string when taken. Defensive throw keeps the
+		// type narrow without leaning on a non-null assertion.
+		throw new Error(`${cmd}: no install target available (internal invariant)`);
+	}
+	assertKnownTarget(cmd, selected, rawTargets);
+	return resolveTarget(selected);
+}
+
+/**
+ * Hard-error if `target` isn't one of the manifest's raw `install_targets`
+ * entries. Case-sensitive, exact match — matches how the rest of the codebase
+ * compares target names (e.g. `resolveTarget` does a strict object lookup).
+ *
+ * The error message uses raw entries, never resolved paths, so the user can
+ * copy-paste a name straight back into `--target`.
+ */
+function assertKnownTarget(
+	cmd: "vendor" | "unvendor",
+	target: string,
+	rawTargets: readonly string[],
+): void {
+	if (!rawTargets.includes(target)) {
+		throw new Error(
+			`${cmd}: unknown target '${target}'. Configured targets: ${rawTargets.join(", ")}`,
+		);
+	}
+}
+
 export async function vendorCommand(dir: string, options: VendorOptions): Promise<void> {
 	const manifest = await loadManifestOrThrow(dir);
 	validateManifestOrThrow(manifest);
 	warnLegacyInstallPath(manifest);
 
-	// Resolve vendor target — single target only
-	const targets = getInstallTargets(manifest);
-	if (targets.length > 1 && !options.target) {
-		throw new Error(
-			`vendor requires --target <name> when multiple install targets are configured.\nTargets: ${targets.join(", ")}`,
-		);
-	}
-	const devInstallPath = options.target ?? targets[0] ?? getDevInstallPath(manifest);
+	const devInstallPath = resolveVendorTarget(manifest, "vendor", options.target);
 	const installBase = join(dir, devInstallPath);
 
 	const existingLockfile = await readLockfile(dir);
@@ -141,6 +209,7 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 export interface UnvendorOptions {
 	force?: boolean;
 	dryRun?: boolean;
+	target?: string;
 }
 
 export async function unvendorCommand(dir: string, options?: UnvendorOptions): Promise<void> {
@@ -151,7 +220,7 @@ export async function unvendorCommand(dir: string, options?: UnvendorOptions): P
 		return;
 	}
 
-	const devInstallPath = getDevInstallPath(manifest);
+	const devInstallPath = resolveVendorTarget(manifest, "unvendor", options?.target);
 	const installBase = join(dir, devInstallPath);
 	const lockfile = await readLockfile(dir);
 

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -191,9 +191,12 @@ exports[`CLI help snapshots \`vendor --help\` is stable 1`] = `
 Copy all deps as real files for git commit (distribution mode)
 
 Options:
-  --frozen       Use lockfile only, error if out of sync
-  -n, --dry-run  Show plan without making changes
-  -h, --help     display help for command
+  --frozen         Use lockfile only, error if out of sync
+  -n, --dry-run    Show plan without making changes
+  --target <name>  Select install target by raw install_targets entry (e.g.
+                   claude, codex). Required when multiple targets are
+                   configured.
+  -h, --help       display help for command
 "
 `;
 
@@ -203,9 +206,12 @@ exports[`CLI help snapshots \`unvendor --help\` is stable 1`] = `
 Exit vendor mode, restore normal symlinked installs
 
 Options:
-  -f, --force    Discard modified vendored files
-  -n, --dry-run  Show what would happen without making changes
-  -h, --help     display help for command
+  -f, --force      Discard modified vendored files
+  -n, --dry-run    Show what would happen without making changes
+  --target <name>  Select install target by raw install_targets entry (e.g.
+                   claude, codex). Required when multiple targets are
+                   configured.
+  -h, --help       display help for command
 "
 `;
 

--- a/tests/commands/vendor-target.test.ts
+++ b/tests/commands/vendor-target.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildProgram } from "../../src/cli.js";
+import { unvendorCommand, vendorCommand } from "../../src/commands/vendor.js";
+import { createLocalSkill } from "../helpers/git-fixtures.js";
+
+/**
+ * Regression coverage for issue #69:
+ *   "vendor: error message advertises --target flag that is neither
+ *    registered nor forwarded"
+ *
+ * Three coupled bugs:
+ *   1. `--target` not registered on `vendor` / `unvendor` commands
+ *   2. Action wrapper drops `opts.target` instead of forwarding it
+ *   3. Multi-target error message lists *resolved paths* (.claude, .agents)
+ *      instead of *raw install_targets entries* (claude, codex) — so even
+ *      when --target lands, users learn the wrong vocabulary
+ */
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-vendor-target-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+async function setupMultiTargetProject(): Promise<string> {
+	const dir = await makeTempDir();
+	await writeFile(
+		join(dir, "skilltree.yml"),
+		`name: test
+install_targets:
+  - claude
+  - codex
+dependencies:
+  foo:
+    local: ./skills/foo
+`,
+	);
+	await writeFile(
+		join(dir, ".gitignore"),
+		".claude/skills/\n.claude/agents/\n.agents/skills/\n.agents/agents/\n",
+	);
+	await createLocalSkill(join(dir, "skills"), "foo");
+	return dir;
+}
+
+describe("vendor --target (issue #69)", () => {
+	describe("CLI registration", () => {
+		test("`vendor` registers --target <name>", () => {
+			const program = buildProgram();
+			const vendor = program.commands.find((c) => c.name() === "vendor");
+			expect(vendor).toBeDefined();
+			const opt = vendor?.options.find((o) => o.long === "--target");
+			expect(opt, "vendor must register --target").toBeDefined();
+			// Must require a value — bare flag is meaningless
+			expect(opt?.required).toBe(true);
+		});
+
+		test("`unvendor` registers --target <name>", () => {
+			const program = buildProgram();
+			const unvendor = program.commands.find((c) => c.name() === "unvendor");
+			expect(unvendor).toBeDefined();
+			const opt = unvendor?.options.find((o) => o.long === "--target");
+			expect(opt, "unvendor must register --target").toBeDefined();
+			expect(opt?.required).toBe(true);
+		});
+	});
+
+	describe("error message vocabulary (raw install_targets, not resolved paths)", () => {
+		test("multi-target without --target lists raw entries (`claude, codex`)", async () => {
+			const dir = await setupMultiTargetProject();
+			let caught: Error | undefined;
+			try {
+				await vendorCommand(dir, {});
+			} catch (e) {
+				caught = e as Error;
+			}
+			expect(caught).toBeDefined();
+			const msg = caught?.message ?? "";
+			// Raw names appear
+			expect(msg).toContain("claude");
+			expect(msg).toContain("codex");
+			// Resolved paths must NOT appear — they mislead the user about what
+			// to type after --target
+			expect(msg).not.toContain(".claude");
+			expect(msg).not.toContain(".agents");
+			// Mentions the flag affordance
+			expect(msg).toContain("--target");
+		});
+	});
+
+	describe("--target selects which install target to vendor", () => {
+		test("--target claude vendors into .claude/", async () => {
+			const dir = await setupMultiTargetProject();
+			await vendorCommand(dir, { target: "claude" });
+			expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+			expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(false);
+		});
+
+		test("--target codex vendors into .agents/ (codex's registry dir)", async () => {
+			const dir = await setupMultiTargetProject();
+			await vendorCommand(dir, { target: "codex" });
+			expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(true);
+			expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(false);
+		});
+	});
+
+	describe("--target validation", () => {
+		test("unknown --target produces a hard error listing configured targets", async () => {
+			const dir = await setupMultiTargetProject();
+			let caught: Error | undefined;
+			try {
+				await vendorCommand(dir, { target: "bogus" });
+			} catch (e) {
+				caught = e as Error;
+			}
+			expect(caught).toBeDefined();
+			const msg = caught?.message ?? "";
+			expect(msg).toContain("bogus");
+			expect(msg).toContain("claude");
+			expect(msg).toContain("codex");
+			// Don't leak resolved paths into the validation error either
+			expect(msg).not.toContain(".claude");
+			expect(msg).not.toContain(".agents");
+		});
+
+		test("--target is rejected on a single-target manifest (no choice to make)", async () => {
+			const dir = await makeTempDir();
+			await writeFile(
+				join(dir, "skilltree.yml"),
+				`name: test
+install_targets:
+  - claude
+dependencies:
+  foo:
+    local: ./skills/foo
+`,
+			);
+			await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+			await createLocalSkill(join(dir, "skills"), "foo");
+
+			// claude is configured — passes
+			await vendorCommand(dir, { target: "claude" });
+			expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+
+			// codex isn't configured — must hard-error, not silently vendor there
+			let caught: Error | undefined;
+			try {
+				await vendorCommand(dir, { target: "codex" });
+			} catch (e) {
+				caught = e as Error;
+			}
+			expect(caught).toBeDefined();
+			expect(caught?.message).toContain("codex");
+		});
+	});
+
+	describe("backward compatibility", () => {
+		test("single install_target manifest still vendors without --target", async () => {
+			const dir = await makeTempDir();
+			await writeFile(
+				join(dir, "skilltree.yml"),
+				`name: test
+install_targets:
+  - claude
+dependencies:
+  foo:
+    local: ./skills/foo
+`,
+			);
+			await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+			await createLocalSkill(join(dir, "skills"), "foo");
+			await vendorCommand(dir, {});
+			expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+		});
+
+		test("legacy dev_install_path manifest still vendors without --target", async () => {
+			const dir = await makeTempDir();
+			await writeFile(
+				join(dir, "skilltree.yml"),
+				`name: test
+dev_install_path: .claude
+dependencies:
+  foo:
+    local: ./skills/foo
+`,
+			);
+			await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+			await createLocalSkill(join(dir, "skills"), "foo");
+			await vendorCommand(dir, {});
+			expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+		});
+	});
+});
+
+describe("unvendor --target (issue #69, symmetric)", () => {
+	test("unvendor --target codex undoes a vendor --target codex", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "codex" });
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(true);
+
+		// manifest now has vendor: true
+		const before = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(before).toContain("vendor: true");
+
+		await unvendorCommand(dir, { target: "codex" });
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(false);
+
+		const after = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(after).not.toContain("vendor: true");
+	});
+
+	test("unvendor on multi-target without --target errors with raw entries", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "claude" });
+
+		let caught: Error | undefined;
+		try {
+			await unvendorCommand(dir, {});
+		} catch (e) {
+			caught = e as Error;
+		}
+		expect(caught).toBeDefined();
+		const msg = caught?.message ?? "";
+		expect(msg).toContain("--target");
+		expect(msg).toContain("claude");
+		expect(msg).toContain("codex");
+		expect(msg).not.toContain(".claude");
+		expect(msg).not.toContain(".agents");
+	});
+
+	test("unvendor --target rejects unknown target", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "claude" });
+
+		let caught: Error | undefined;
+		try {
+			await unvendorCommand(dir, { target: "bogus" });
+		} catch (e) {
+			caught = e as Error;
+		}
+		expect(caught).toBeDefined();
+		expect(caught?.message).toContain("bogus");
+	});
+});


### PR DESCRIPTION
## Why

Three coupled bugs in `skilltree vendor` and `unvendor` left users with no command-line path to a multi-target vendor, and the error message they hit pointed them at flag values that did not work:

```
$ skilltree vendor
✘ vendor requires --target <name> when multiple install targets are configured.
Targets: .claude, .agents

$ skilltree vendor --target claude
error: unknown option '--target'
```

Both errors lie: `--target` was never registered, and even if it had been, `.claude` and `.agents` are resolved paths — not values you can pass to `--target`. Configured targets are the raw `install_targets` entries (`claude`, `codex`).

Closes #69.

## What changed

- `src/cli.ts` — Register `--target <name>` on both `vendor` and `unvendor`, and forward `opts.target` through the action wrapper into the command function.
- `src/commands/vendor.ts` — Extract a shared `resolveVendorTarget` helper used by both commands. It (a) gates multi-target manifests behind `--target`, (b) validates `--target` against raw `install_targets` entries via a new `assertKnownTarget` helper, (c) lists raw entries (not resolved paths) in every error message, (d) rejects `--target` on legacy `dev_install_path` manifests where no named targets exist.
- `skills/skilltree/references/commands.md` — Document the new flag under both `vendor` and `unvendor`.
- `tests/commands/vendor-target.test.ts` — New regression suite covering CLI registration, multi-target error vocabulary, target selection, unknown-target validation, single-target backward compat, and the symmetric `unvendor` flow.
- `tests/cli/__snapshots__/help-snapshot.test.ts.snap` — Refreshed for the new `--target` lines on `vendor --help` and `unvendor --help`.

## How tested

- Added 12-test regression suite in `tests/commands/vendor-target.test.ts` covering all three bugs explicitly.
- Full repo suite: `bun test` → 1220 pass / 0 fail, 33 snapshots.
- `bun run lint` and `bun run typecheck` both clean.
- Manual repro from the issue verified: `bun run src/cli.ts vendor --help` now lists `--target`.

Edge cases covered: multi-target without `--target` (raw entries in error), multi-target with `--target codex` (vendors into `.agents/`), unknown `--target bogus` (hard error), single-`install_targets` manifest with and without `--target`, legacy `dev_install_path` manifest (still works without `--target`), and the symmetric `unvendor --target` flow.

## Risk & rollback

Low blast radius — change is confined to the vendor/unvendor commands and a small CLI option registration. One small behavior change: `--target` is now explicitly rejected on legacy `dev_install_path` manifests (previously the flag was silently dropped because it was never registered). Rollback: `git revert <sha>`.