### PR TITLE
fix: scan --apply merges into existing deps key instead of writing parallel block

### DIFF
--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -1,5 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { entityNameFromPath } from "./entity-type.js";
+import { basename } from "node:path";
+import type { SkillFrontmatter } from "../types.js";
+import { entityNameFromPath, mdFileType } from "./entity-type.js";
 import { getDeclaredDeps, parseFrontmatter } from "./frontmatter.js";
 import { llmScanContent } from "./llm.js";
 
@@ -296,8 +298,43 @@ export async function scanFiles(filePaths: string[], opts?: ScanOptions): Promis
 }
 
 /**
+ * The two frontmatter keys we'll ever write deps under. `dependencies:` is the
+ * SKILL.md / command convention; `skills:` is the agent convention. Both are
+ * read by `parseFrontmatter`; only one should ever be written for any given
+ * file. Issue #68.
+ */
+type DepsKey = "dependencies" | "skills";
+
+/**
+ * Decide which frontmatter key `applyToFrontmatter` should merge into.
+ *
+ * Priority (issue #68):
+ *   1. Existing non-empty `dependencies:` list → write there.
+ *   2. Else existing non-empty `skills:` list → write there.
+ *   3. Else fall back to the convention for the file type:
+ *      - SKILL.md  → `dependencies:`
+ *      - agent .md → `skills:`
+ *      - command .md → `dependencies:` (no command-specific key today)
+ *
+ * The non-chosen key, when both happen to exist, is left untouched — the
+ * reader (`getDeclaredDeps`) already unions both, so preserving the orthogonal
+ * key keeps author intent. This is the writer-side counterpart to the
+ * reader's tolerance.
+ */
+function chooseDepsKey(filePath: string, fm: SkillFrontmatter): DepsKey {
+	if ((fm.dependencies ?? []).length > 0) return "dependencies";
+	if ((fm.skills ?? []).length > 0) return "skills";
+	if (basename(filePath) === "SKILL.md") return "dependencies";
+	return mdFileType(filePath) === "agent" ? "skills" : "dependencies";
+}
+
+/**
  * Apply detected dependencies to frontmatter.
- * Adds undeclared deps to the dependencies list.
+ *
+ * Merges into whichever existing deps key the author chose (or the file-type
+ * convention when neither is present) and writes exactly one deps block —
+ * never a parallel `dependencies:`/`skills:` pair. See `chooseDepsKey` and
+ * issue #68 for the full rules.
  */
 export async function applyToFrontmatter(filePath: string, newDeps: string[]): Promise<void> {
 	const content = await readFile(filePath, "utf-8");
@@ -305,24 +342,29 @@ export async function applyToFrontmatter(filePath: string, newDeps: string[]): P
 
 	if (!frontmatter) return;
 
-	const existing = frontmatter.dependencies ?? [];
+	const targetKey = chooseDepsKey(filePath, frontmatter);
+	const existing = frontmatter[targetKey] ?? [];
 	const merged = [...new Set([...existing, ...newDeps])].sort();
 
 	// Rebuild frontmatter
 	const depsYaml =
-		merged.length > 0 ? `dependencies:\n${merged.map((d) => `  - ${d}`).join("\n")}` : "";
+		merged.length > 0 ? `${targetKey}:\n${merged.map((d) => `  - ${d}`).join("\n")}` : "";
 
 	// Find frontmatter boundaries
 	const firstDelim = content.indexOf("---");
 	const secondDelim = content.indexOf("---", firstDelim + 3);
 	const existingFm = content.slice(firstDelim + 3, secondDelim).trim();
 
-	// Remove existing dependencies block from frontmatter
+	// Strip the existing block for the *target* key only. The other deps key,
+	// if present, is left in place — `chooseDepsKey` already preferred it if
+	// it was non-empty, so reaching here means the orthogonal key holds no
+	// dep list we'd overwrite. (Empty `dependencies: []` / `skills: []`
+	// scalars are preserved verbatim; harmless and round-trip-friendly.)
 	const fmLines = existingFm.split("\n");
 	const filteredLines: string[] = [];
 	let inDepBlock = false;
 	for (const line of fmLines) {
-		if (line.startsWith("dependencies:")) {
+		if (line.startsWith(`${targetKey}:`)) {
 			inDepBlock = true;
 			continue;
 		}

--- a/tests/core/scanner.test.ts
+++ b/tests/core/scanner.test.ts
@@ -602,3 +602,142 @@ describe("applyToFrontmatter", () => {
 		expect(content).toContain("- task-builder");
 	});
 });
+
+describe("applyToFrontmatter — merge into existing key (issue #68)", () => {
+	test("merges into existing `skills:` list and does NOT add a `dependencies:` block", async () => {
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "agent-style-skill");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			"---\nname: agent-style-skill\ndescription: A skill that uses the agent `skills:` convention\nskills:\n  - already-declared\n---\n\nUse the python-coding skill.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("- already-declared");
+		expect(content).toContain("- python-coding");
+		// Must NOT create a parallel `dependencies:` block alongside `skills:`
+		expect(content).not.toMatch(/^dependencies:/m);
+		// Original key is still present
+		expect(content).toMatch(/^skills:/m);
+		// New dep appears under the skills block
+		expect(content).toMatch(/skills:[\s\S]*- python-coding/);
+	});
+
+	test("prefers existing `dependencies:` over `skills:` when both are present", async () => {
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "both-keys");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			"---\nname: both-keys\ndependencies:\n  - dep-one\nskills:\n  - skill-one\n---\n\nUse the task-builder skill.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["task-builder"]);
+
+		const content = await readFile(filePath, "utf-8");
+		// New dep is merged into the preferred (dependencies:) key
+		expect(content).toMatch(/dependencies:[\s\S]*- task-builder/);
+		// The orthogonal `skills:` key is preserved untouched
+		expect(content).toMatch(/^skills:/m);
+		expect(content).toContain("- skill-one");
+		// dep-one is still present in the dependencies list
+		expect(content).toMatch(/dependencies:[\s\S]*- dep-one/);
+	});
+
+	test("falls back to `skills:` for agent .md files when no deps key exists", async () => {
+		const dir = await makeTempDir();
+		const agentsDir = join(dir, "agents");
+		await mkdir(agentsDir, { recursive: true });
+		const filePath = join(agentsDir, "my-agent.md");
+		await writeFile(
+			filePath,
+			"---\nname: my-agent\ndescription: An agent\n---\n\nUse the python-coding skill.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toMatch(/^skills:/m);
+		expect(content).toContain("- python-coding");
+		expect(content).not.toMatch(/^dependencies:/m);
+	});
+
+	test("falls back to `dependencies:` for command .md files when no deps key exists", async () => {
+		const dir = await makeTempDir();
+		const cmdDir = join(dir, "commands");
+		await mkdir(cmdDir, { recursive: true });
+		const filePath = join(cmdDir, "my-cmd.md");
+		await writeFile(
+			filePath,
+			"---\nname: my-cmd\ndescription: A command\n---\n\nRun /hypothesis afterwards.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["hypothesis"]);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toMatch(/^dependencies:/m);
+		expect(content).toContain("- hypothesis");
+		expect(content).not.toMatch(/^skills:/m);
+	});
+
+	test("falls back to `dependencies:` for SKILL.md when both deps keys are absent", async () => {
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "fresh");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			"---\nname: fresh\ndescription: A fresh skill\n---\n\nUse the python-coding skill.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toMatch(/^dependencies:/m);
+		expect(content).toContain("- python-coding");
+		expect(content).not.toMatch(/^skills:/m);
+	});
+
+	test("falls back to convention when both keys are present but empty (skills: [])", async () => {
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "empty-both");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			"---\nname: empty-both\ndependencies: []\nskills: []\n---\n\nUse the python-coding skill.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		// SKILL.md convention wins when both are empty
+		expect(content).toMatch(/dependencies:[\s\S]*- python-coding/);
+	});
+
+	test("merged list is sorted alphabetically", async () => {
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "sorted");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			"---\nname: sorted\nskills:\n  - zebra\n  - alpha\n---\n\nUse the mango skill.\n",
+		);
+
+		await applyToFrontmatter(filePath, ["mango"]);
+
+		const content = await readFile(filePath, "utf-8");
+		const skillsBlock = content.match(/skills:\n((?: {2}- .+\n?)+)/)?.[1] ?? "";
+		const items = skillsBlock
+			.split("\n")
+			.map((l) => l.replace(/^ {2}- /, "").trim())
+			.filter((l) => l.length > 0);
+		expect(items).toEqual(["alpha", "mango", "zebra"]);
+	});
+});


### PR DESCRIPTION
## Why

`skilltree scan --apply` always wrote a top-level `dependencies:` block to SKILL.md frontmatter, even when the author had already authored a `skills:` list (the agent convention). The result was two parallel declaration fields living side-by-side — confusing for authors, and the silent drift compounded on each run because the read side (`getDeclaredDeps`) tolerates both keys.

Closes #68.

## What changed

- `src/core/scanner.ts` — `applyToFrontmatter` now picks the target key via a new `chooseDepsKey(filePath, frontmatter)` helper:
  1. Existing non-empty `dependencies:` → write there.
  2. Else existing non-empty `skills:` → write there.
  3. Else file-type convention: `SKILL.md` → `dependencies:`, agent `.md` → `skills:`, command `.md` → `dependencies:`.
- Only the *target* key's existing block is stripped before the rewrite — the orthogonal key (if present) is preserved, since `getDeclaredDeps` already unions both and we don't want to silently consolidate author intent.
- Exactly one deps block is written; sorted, deduped.

## How tested

- Added 7 tests in `tests/core/scanner.test.ts` under `applyToFrontmatter — merge into existing key (issue #68)`:
  - Merges into existing `skills:` and does **not** add a parallel `dependencies:` block (the bug repro).
  - Prefers `dependencies:` when both keys are non-empty; leaves `skills:` untouched.
  - Falls back to `skills:` for agent `.md` files.
  - Falls back to `dependencies:` for command `.md` files.
  - Falls back to `dependencies:` for SKILL.md with no deps key.
  - Falls back to convention when both keys exist but are empty (`dependencies: [] / skills: []`).
  - Merged list is sorted alphabetically.
- All 1215 tests pass; biome + tsc clean via pre-commit.

## Risk & rollback

Low. Change is localized to one helper in `scanner.ts` (authoring path only — never runs at install time). Revert with `git revert <sha>` if needed.