### PR TITLE
fix(list): show pinned commit (e.g. @a56045e) for unpinned remote deps

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -54,16 +54,44 @@ interface ListRow {
 	group: string;
 	version: string;
 	source: string;
+	/** Resolved commit SHA — present for remote deps, omitted for `source: local`. */
+	commit?: string;
+}
+
+/** Short SHA convention used elsewhere in the codebase (see graph.ts install warnings). */
+const SHORT_SHA_LEN = 7;
+
+/**
+ * Display label for a lockfile entry's version column.
+ *
+ * Falls back to `@<short-sha>` for unpinned remote deps (issue #76) so users
+ * still see a meaningful identifier instead of a bare `-`. Local deps keep
+ * their `"local"` label; the literal `"-"` only appears when neither version
+ * nor commit is recorded.
+ */
+function versionLabel(entry: Lockfile["packages"][string]): string {
+	if (entry.version !== undefined) return entry.version;
+	if (entry.source === "local") return "local";
+	if (entry.commit) return `@${entry.commit.slice(0, SHORT_SHA_LEN)}`;
+	return "-";
 }
 
 function buildRows(lockfile: Lockfile): ListRow[] {
-	return Object.entries(lockfile.packages).map(([key, entry]) => ({
-		name: entry.name ?? key,
-		type: entry.type,
-		group: entry.group,
-		version: entry.version ?? (entry.source === "local" ? "local" : "-"),
-		source: entry.source === "local" ? entry.path : (entry.repo ?? "-"),
-	}));
+	return Object.entries(lockfile.packages).map(([key, entry]) => {
+		const row: ListRow = {
+			name: entry.name ?? key,
+			type: entry.type,
+			group: entry.group,
+			version: versionLabel(entry),
+			source: entry.source === "local" ? entry.path : (entry.repo ?? "-"),
+		};
+		// Surface the full commit for non-local entries so `--json` consumers
+		// can resolve unpinned deps without re-parsing the lockfile (issue #76).
+		if (entry.source !== "local" && entry.commit) {
+			row.commit = entry.commit;
+		}
+		return row;
+	});
 }
 
 function printGlobalTable(rows: ListRow[]): void {

--- a/tests/commands/list-extended.test.ts
+++ b/tests/commands/list-extended.test.ts
@@ -134,4 +134,58 @@ describe("listCommand extended", () => {
 		expect(logs.some((l) => l.includes("2.1.3"))).toBe(true);
 		expect(logs.some((l) => l.includes("github.com/org/skills"))).toBe(true);
 	});
+
+	test("unpinned remote dep shows @<short-sha> instead of '-' (issue #76)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
+		await writeFile(
+			join(tempDir, "skilltree.lock"),
+			"lockfile_version: 1\npackages:\n  unpinned-skill:\n    type: skill\n    group: prod\n    repo: github.com/org/skills\n    path: skills/unpinned-skill\n    commit: a56045e1234567890abcdef0123456789abcdef0\n    dependencies: []\n",
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir);
+		} finally {
+			restore();
+		}
+		// Should surface the commit SHA, not a literal "-"
+		expect(logs.some((l) => l.includes("@a56045e"))).toBe(true);
+		// Must NOT show the unhelpful "-" placeholder in the version column
+		const dataRows = logs.filter((l) => l.includes("unpinned-skill"));
+		expect(dataRows.some((l) => / - /.test(l))).toBe(false);
+	});
+
+	test("--json includes commit field and omits '-' version for unpinned remote dep (issue #76)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
+		await writeFile(
+			join(tempDir, "skilltree.lock"),
+			"lockfile_version: 1\npackages:\n  unpinned-skill:\n    type: skill\n    group: prod\n    repo: github.com/org/skills\n    path: skills/unpinned-skill\n    commit: a56045e1234567890abcdef0123456789abcdef0\n    dependencies: []\n  pinned-skill:\n    type: skill\n    group: prod\n    repo: github.com/org/skills\n    path: skills/pinned-skill\n    version: 2.1.3\n    commit: deadbeefcafebabe1234567890abcdef01234567\n    dependencies: []\n",
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir, { json: true });
+		} finally {
+			restore();
+		}
+
+		const json = JSON.parse(logs.join("")) as Array<{
+			name: string;
+			version?: string;
+			commit?: string;
+		}>;
+		const unpinned = json.find((r) => r.name === "unpinned-skill");
+		const pinned = json.find((r) => r.name === "pinned-skill");
+
+		// Unpinned: no literal "-" for version, commit surfaced
+		expect(unpinned).toBeDefined();
+		expect(unpinned?.version).not.toBe("-");
+		expect(unpinned?.commit).toBe("a56045e1234567890abcdef0123456789abcdef0");
+
+		// Pinned: version preserved, commit still surfaced
+		expect(pinned?.version).toBe("2.1.3");
+		expect(pinned?.commit).toBe("deadbeefcafebabe1234567890abcdef01234567");
+	});
 });


### PR DESCRIPTION
## Why

`skilltree list` printed `Version: -` for remote deps without a semver pin, even though the lockfile already records the resolved commit SHA. Issue #76 flagged this as the only inspection-layer command that quietly loses the install-time version info.

Closes #76

## What changed

- `src/commands/list.ts` — new `versionLabel()` helper. When `entry.version` is absent for a remote dep, fall back to `@<short-sha>` (7 chars, matching the convention used in `graph.ts` install warnings) instead of `-`.
- `src/commands/list.ts` — `--json` output now includes a `commit` field for every non-local entry, so machine consumers can resolve unpinned deps without re-parsing the lockfile.
- Local deps and pinned remotes are unchanged.

## How tested

- Two new tests in `tests/commands/list-extended.test.ts`:
  - Text table: unpinned remote dep shows `@a56045e`, no bare `-` in the row.
  - `--json`: unpinned entry has a `commit` field and no `version: "-"`; pinned entry keeps `version` plus `commit`.
- Full suite: `bun test` — 1227 pass / 0 fail.
- `bun run lint` and `bun run typecheck` clean.

## Risk & rollback

Low. Pure display change in one command; no install-path code touched. Revert with `git revert <sha>` if needed.