### PR TITLE
fix(init): stop silently enrolling every detected agent (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,11 +260,14 @@ install_targets:
 ```
 
 ```bash
-skilltree install              # installs to both .claude/ and .codex/
-skilltree targets list          # see detected and configured agents
-skilltree targets add cursor    # add another agent
-skilltree targets detect        # auto-detect installed agents
+skilltree install                       # installs to both .claude/ and .codex/
+skilltree targets list                  # see detected and configured agents
+skilltree targets add cursor            # add another agent (then `skilltree install`)
+skilltree targets detect                # auto-detect installed agents
+skilltree init --target claude --target codex   # opt in at init time, skip detection
 ```
+
+By default `init` enrols only Claude Code if multiple agents are detected — interactive runs get a prompt to include the rest; CI/non-interactive runs stay on the safe `[claude]` default. Use `--target` (repeatable) or `--yes` to enrol others up front, or `skilltree targets add <agent>` / `skilltree targets detect` later.
 
 Migrating from `dev_install_path`? Run `skilltree targets migrate`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,12 +61,21 @@ export function buildProgram(): Command {
 			"--scan",
 			"Scan the repo for existing skills, agents, and commands and register them as local deps",
 		)
-		.option("-y, --yes", "With --scan, include all discovered entries without prompting")
+		.option(
+			"-y, --yes",
+			"Skip prompts: include all discovered scan entries and enrol all detected agents",
+		)
+		.option(
+			"--target <name>",
+			"Explicit install target (skips detection). Repeat for multiple, e.g. --target claude --target codex",
+			(value: string, prev: string[] = []) => prev.concat(value),
+		)
 		.action(async (opts) => {
 			await initCommand(process.cwd(), {
 				global: opts.global,
 				scan: opts.scan,
 				yes: opts.yes,
+				targets: opts.target,
 			});
 		});
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { createInterface } from "node:readline/promises";
-import { detectInstalledAgents } from "../core/agents.js";
+import { detectInstalledAgents, resolveTarget } from "../core/agents.js";
 import {
 	findExistingGlobalManifest,
 	findExistingManifest,
@@ -37,6 +37,12 @@ export interface InitOptions {
 	globalDir?: string; // Override global manifest dir (testing + --global flow)
 	scan?: boolean;
 	yes?: boolean;
+	/**
+	 * Explicit install targets (from repeatable `--target` flag). When set,
+	 * detection is bypassed entirely — the user has already told us what they want.
+	 * Issue #74.
+	 */
+	targets?: string[];
 	/** Test override: pick which discovered entries to include, bypassing interactive prompt. */
 	selectFn?: (entries: LocalEntry[]) => Promise<LocalEntry[]>;
 	/** Test override: canned answer for the interactive prompt — exercises the prompt pipeline without readline. */
@@ -55,20 +61,22 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 	// Guard: refuse to overwrite existing manifest. Report the actual on-disk
 	// name so a project on the legacy .yaml extension doesn't get a misleading
 	// "skilltree.yml already exists" — they don't have one.
+	//
+	// The hint points at the *right* next-step commands. The previous "remove it
+	// or edit it directly" hint sent users to do manual YAML surgery when they
+	// actually wanted `targets add` or `targets detect`. Issue #74 (Friction A).
 	const existing = findExistingManifest(dir);
 	if (existing) {
-		throw new Error(`${existing} already exists. Remove it first or edit it directly.`);
+		throw new Error(
+			`${existing} already exists.\n` +
+				`  To add a coding agent to this project, run:\n` +
+				`    skilltree targets add <agent>      (e.g. claude, codex)\n` +
+				`    skilltree targets detect           (auto-add any newly-installed agents)\n` +
+				`  To start fresh, remove ${existing} first.`,
+		);
 	}
 
-	// Auto-detect installed agents
-	const detected = await detectInstalledAgents(options?.homeDir);
-	const installTargets = detected.length > 0 ? detected : ["claude"];
-
-	if (detected.length > 0) {
-		console.log(dim(`Detected agents: ${detected.join(", ")}`));
-	} else {
-		console.log(dim("No agents detected — defaulting to claude"));
-	}
+	const installTargets = await selectInstallTargets(options);
 
 	// Optional repo scan for in-tree skills and agents.
 	const dependencies: Record<string, Dependency> = {};
@@ -131,6 +139,122 @@ async function initGlobal(globalDirOverride?: string): Promise<void> {
 
 	await writeGlobalManifest(manifest, globalDir);
 	success(`Created ${globalDir}/${GLOBAL_MANIFEST}`);
+}
+
+/**
+ * Decide which agents to enrol as install_targets. Resolution order — designed
+ * so detection is treated as a *suggestion*, not an enrolment (issue #74):
+ *
+ *  1. `--target <name>` (one or more) → caller knows exactly what they want;
+ *     skip detection entirely.
+ *  2. None detected → safe default `[claude]`.
+ *  3. Exactly one detected → enrol it silently. The obvious thing is correct.
+ *  4. Multiple detected + `--yes` → enrol all. Preserves the pre-#74 behaviour
+ *     as an opt-in.
+ *  5. Multiple detected + interactive (TTY or `askFn`) → prompt
+ *     "Include all? [Y/n/1,3,5]".
+ *  6. Multiple detected + non-interactive (CI / pipe) → default to `[claude]`.
+ *     Reversible with `skilltree targets detect` later.
+ *
+ * Returns at least one target — install_targets cannot be empty.
+ */
+async function selectInstallTargets(options?: InitOptions): Promise<string[]> {
+	// 1. Explicit --target wins. Validate each up front (resolveTarget throws on
+	// unknown bare words) and dedupe so `--target claude --target claude` yields
+	// a sensible manifest. Same validation that `targets add` already enforces.
+	if (options?.targets && options.targets.length > 0) {
+		const seen = new Set<string>();
+		const uniq: string[] = [];
+		for (const t of options.targets) {
+			resolveTarget(t); // throws for unknown bare words; literal paths pass through
+			if (!seen.has(t)) {
+				seen.add(t);
+				uniq.push(t);
+			}
+		}
+		console.log(dim(`Using --target: ${uniq.join(", ")}`));
+		return uniq;
+	}
+
+	const detected = await detectInstalledAgents(options?.homeDir);
+
+	// 2. Nothing detected → safe default.
+	if (detected.length === 0) {
+		console.log(dim("No agents detected — defaulting to claude"));
+		return ["claude"];
+	}
+
+	// 3. Single detection is unambiguous — never prompt.
+	if (detected.length === 1) {
+		console.log(dim(`Detected agent: ${detected[0]}`));
+		return [...detected];
+	}
+
+	console.log(dim(`Detected agents: ${detected.join(", ")}`));
+
+	// 4. --yes preserves the pre-#74 behaviour as an opt-in.
+	if (options?.yes) return [...detected];
+
+	// 5 & 6. Prompt if we can; otherwise CI-safe default.
+	const interactive = options?.isInteractive ?? Boolean(process.stdout.isTTY);
+	const ask = options?.askFn ?? (interactive ? readlineAsk : null);
+	if (!ask) {
+		console.log(
+			dim(
+				"Non-interactive context — enrolling claude only. " +
+					"Run `skilltree targets detect` (or `skilltree targets add <agent>`) to enrol others.",
+			),
+		);
+		return ["claude"];
+	}
+
+	const picked = await promptForTargetSelection(detected, ask);
+	// "n" / empty selection → fall back to [claude] rather than producing an
+	// invalid empty install_targets.
+	if (picked.length === 0) {
+		console.log(dim("No agents selected — defaulting to claude."));
+		return ["claude"];
+	}
+	return picked;
+}
+
+async function promptForTargetSelection(agents: string[], ask: AskFn): Promise<string[]> {
+	console.log("\nEnrol detected agents as install targets?\n");
+	let idx = 1;
+	for (const a of agents) {
+		console.log(`  [${idx}] ${a}`);
+		idx++;
+	}
+	console.log("");
+	const answer = (await ask("Include all? [Y/n/1,3,5] ")).trim();
+	return parseAgentSelectionAnswer(answer, agents);
+}
+
+/**
+ * Same grammar as `parseSelectionAnswer` (empty / y → all, n → none, comma
+ * indices → subset), but operating on a plain string list. Kept as its own
+ * function rather than generalising because the caller's empty-result
+ * handling differs (we fall back to [claude] instead of accepting empty).
+ */
+export function parseAgentSelectionAnswer(answer: string, agents: string[]): string[] {
+	const trimmed = answer.trim();
+	if (trimmed === "" || trimmed.toLowerCase() === "y") return [...agents];
+	if (trimmed.toLowerCase() === "n") return [];
+
+	const indices = trimmed
+		.split(",")
+		.map((s) => Number.parseInt(s.trim(), 10))
+		.filter((n) => Number.isInteger(n) && n >= 1 && n <= agents.length);
+
+	const selected: string[] = [];
+	const seen = new Set<number>();
+	for (const i of indices) {
+		if (seen.has(i)) continue;
+		seen.add(i);
+		const agent = agents[i - 1];
+		if (agent) selected.push(agent);
+	}
+	return selected;
 }
 
 /**

--- a/src/commands/targets.ts
+++ b/src/commands/targets.ts
@@ -10,7 +10,7 @@ import {
 	removeGitignoreEntries,
 } from "../core/gitignore.js";
 import { loadManifestOrThrow, writeManifest } from "../core/manifest.js";
-import { success, warn } from "../core/ui.js";
+import { dim, success, warn } from "../core/ui.js";
 import type { Manifest } from "../types.js";
 
 interface TargetsOpts {
@@ -131,6 +131,10 @@ export async function targetsAddCommand(
 	if (added.length > 0) {
 		success(`Updated .gitignore (added ${added.join(", ")})`);
 	}
+	// Parity with `add` (issue #74, Friction B): the new target's install dir is
+	// empty until `install` runs. Make that step explicit so users aren't left
+	// wondering why `.<target>/skills/` is blank.
+	console.log(dim("  Run `skilltree install` to populate the new target."));
 }
 
 export async function targetsRemoveCommand(
@@ -197,6 +201,9 @@ export async function targetsDetectCommand(dir: string, opts?: TargetsOpts): Pro
 		if (addedToIgnore.length > 0) {
 			success(`Updated .gitignore (added ${addedToIgnore.join(", ")})`);
 		}
+		// Parity with `targets add` (issue #74, Friction B): new dirs are empty
+		// until `install` runs.
+		console.log(dim("  Run `skilltree install` to populate the new target(s)."));
 	} else {
 		console.log("All detected agents already in install_targets.");
 	}

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -54,11 +54,14 @@ Related:
   targets detect  — auto-discover installed coding agents on this machine
 
 Options:
-  -g, --global  Initialize global dependencies
-  --scan        Scan the repo for existing skills, agents, and commands and
-                register them as local deps
-  -y, --yes     With --scan, include all discovered entries without prompting
-  -h, --help    display help for command
+  -g, --global     Initialize global dependencies
+  --scan           Scan the repo for existing skills, agents, and commands and
+                   register them as local deps
+  -y, --yes        Skip prompts: include all discovered scan entries and enrol
+                   all detected agents
+  --target <name>  Explicit install target (skips detection). Repeat for
+                   multiple, e.g. --target claude --target codex
+  -h, --help       display help for command
 "
 `;
 

--- a/tests/commands/init-agents.test.ts
+++ b/tests/commands/init-agents.test.ts
@@ -12,34 +12,197 @@ async function makeTempDir(): Promise<string> {
 	return tempDir;
 }
 
+async function makeHomeWith(dir: string, agents: string[]): Promise<string> {
+	const fakeHome = join(dir, `home-${agents.join("-") || "empty"}`);
+	await mkdir(fakeHome, { recursive: true });
+	for (const a of agents) {
+		// detectDir for codex/copilot differs from the dir we install into.
+		const detectDir = a === "codex" ? ".codex" : a === "copilot" ? ".copilot" : `.${a}`;
+		await mkdir(join(fakeHome, detectDir), { recursive: true });
+	}
+	return fakeHome;
+}
+
 afterEach(async () => {
 	if (tempDir) await rm(tempDir, { recursive: true, force: true });
 });
 
 describe("init auto-detection", () => {
-	test("auto-detects agents and populates install_targets", async () => {
+	test("single detected agent: enrolled without prompting (no askFn called)", async () => {
+		// Single-agent case is unambiguous — never bother the user. Spec issue #74.
 		const dir = await makeTempDir();
-		const fakeHome = join(dir, "home");
-		await mkdir(join(fakeHome, ".claude"), { recursive: true });
-		await mkdir(join(fakeHome, ".codex"), { recursive: true });
+		const fakeHome = await makeHomeWith(dir, ["claude"]);
 
-		await initCommand(dir, { homeDir: fakeHome });
+		let promptCalls = 0;
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			askFn: async () => {
+				promptCalls++;
+				return "y";
+			},
+			isInteractive: true,
+		});
+
+		expect(promptCalls).toBe(0);
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toEqual(["claude"]);
+	});
+
+	test("multiple detected agents + --yes: includes all (opt-in current behaviour)", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, ["claude", "codex"]);
+
+		await initCommand(dir, { homeDir: fakeHome, yes: true });
 
 		const manifest = await readManifest(dir);
 		expect(manifest.install_targets).toContain("claude");
 		expect(manifest.install_targets).toContain("codex");
-		expect(manifest.dev_install_path).toBeUndefined();
+	});
+
+	test("multiple detected agents, non-interactive, no --yes: defaults to [claude] only", async () => {
+		// CI-safe default. Issue #74: detection must not equal enrolment.
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, ["claude", "codex", "cursor"]);
+
+		await initCommand(dir, { homeDir: fakeHome, isInteractive: false });
+
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toEqual(["claude"]);
+	});
+
+	test("multiple detected agents + askFn 'y': includes all", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, ["claude", "codex"]);
+
+		let question = "";
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			isInteractive: true,
+			askFn: async (q) => {
+				question = q;
+				return "y";
+			},
+		});
+
+		expect(question).toContain("Include all?");
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toContain("claude");
+		expect(manifest.install_targets).toContain("codex");
+	});
+
+	test("multiple detected agents + askFn picks subset by index", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, ["claude", "codex", "cursor"]);
+
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			isInteractive: true,
+			// Detected list is sorted; assume "claude, codex, cursor" → pick 1,3
+			askFn: async () => "1,3",
+		});
+
+		const manifest = await readManifest(dir);
+		// Pick #1 (claude) and #3 (cursor); codex (#2) excluded.
+		expect(manifest.install_targets).toContain("claude");
+		expect(manifest.install_targets).toContain("cursor");
+		expect(manifest.install_targets).not.toContain("codex");
+	});
+
+	test("multiple detected agents + askFn 'n': falls back to [claude]", async () => {
+		// "None" is meaningless for install_targets (must have at least one). Falls
+		// back to the safe default rather than producing an unusable empty list.
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, ["claude", "codex"]);
+
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			isInteractive: true,
+			askFn: async () => "n",
+		});
+
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toEqual(["claude"]);
+	});
+
+	test("--target bypasses detection entirely (single)", async () => {
+		const dir = await makeTempDir();
+		// Home has claude+codex; --target should override and pick only what was asked.
+		const fakeHome = await makeHomeWith(dir, ["claude", "codex"]);
+
+		let promptCalls = 0;
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			targets: ["codex"],
+			isInteractive: true,
+			askFn: async () => {
+				promptCalls++;
+				return "y";
+			},
+		});
+
+		expect(promptCalls).toBe(0);
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toEqual(["codex"]);
+	});
+
+	test("--target rejects unknown bare words (parity with `targets add`)", async () => {
+		// Fail fast — otherwise garbage lands in install_targets and breaks at install time.
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, []);
+
+		await expect(initCommand(dir, { homeDir: fakeHome, targets: ["bogus-agent"] })).rejects.toThrow(
+			/unknown agent/,
+		);
+	});
+
+	test("--target dedupes repeated values", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, []);
+
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			targets: ["claude", "codex", "claude"],
+		});
+
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toEqual(["claude", "codex"]);
+	});
+
+	test("--target bypasses detection entirely (multiple)", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, []);
+
+		await initCommand(dir, {
+			homeDir: fakeHome,
+			targets: ["claude", "codex"],
+			isInteractive: false,
+		});
+
+		const manifest = await readManifest(dir);
+		expect(manifest.install_targets).toEqual(["claude", "codex"]);
 	});
 
 	test("falls back to [claude] when no agents detected", async () => {
 		const dir = await makeTempDir();
-		const fakeHome = join(dir, "empty-home");
-		await mkdir(fakeHome, { recursive: true });
+		const fakeHome = await makeHomeWith(dir, []);
 
 		await initCommand(dir, { homeDir: fakeHome });
 
 		const manifest = await readManifest(dir);
 		expect(manifest.install_targets).toEqual(["claude"]);
 		expect(manifest.dev_install_path).toBeUndefined();
+	});
+
+	test("re-run on existing project: error message suggests `targets add` / `targets detect`", async () => {
+		// Friction A from issue #74: the old "Remove it first or edit it directly"
+		// hint was wrong — the actual right commands are targets add / targets detect.
+		const dir = await makeTempDir();
+		const fakeHome = await makeHomeWith(dir, []);
+		await initCommand(dir, { homeDir: fakeHome });
+
+		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(/skilltree targets add/);
+		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(
+			/skilltree targets detect/,
+		);
 	});
 });

--- a/tests/commands/targets.test.ts
+++ b/tests/commands/targets.test.ts
@@ -26,6 +26,18 @@ afterEach(async () => {
 	if (tempDir) await rm(tempDir, { recursive: true, force: true });
 });
 
+async function captureSuccessLines(fn: () => Promise<void>): Promise<string[]> {
+	const lines: string[] = [];
+	const originalLog = console.log;
+	console.log = (...args: unknown[]) => lines.push(args.map(String).join(" "));
+	try {
+		await fn();
+	} finally {
+		console.log = originalLog;
+	}
+	return lines;
+}
+
 describe("targetsAddCommand", () => {
 	test("adds known agent to install_targets", async () => {
 		const dir = await makeTempDir();
@@ -78,6 +90,18 @@ describe("targetsAddCommand", () => {
 		const manifest = await readManifest(dir);
 		expect(manifest.install_targets).toContain("claude");
 		expect(manifest.install_targets).toContain("codex");
+	});
+
+	test("success output reminds the user to run `skilltree install` (issue #74)", async () => {
+		// Friction B: after `targets add` the new target's dir is empty until the
+		// user runs `skilltree install`. Output must prompt that next step.
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+
+		const lines = await captureSuccessLines(() => targetsAddCommand("codex", dir));
+
+		const joined = lines.join("\n");
+		expect(joined).toMatch(/skilltree install/);
 	});
 });
 
@@ -150,6 +174,21 @@ describe("targetsDetectCommand", () => {
 		await writeManifestFile(dir, "dev_install_path: .claude\ndependencies: {}\n");
 
 		await expect(targetsDetectCommand(dir)).rejects.toThrow("targets migrate");
+	});
+
+	test("success output reminds the user to run `skilltree install` (issue #74)", async () => {
+		// Friction B: same reasoning as targets add — newly enrolled targets are
+		// empty on disk until install runs.
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\ndependencies: {}\n");
+		const fakeHome = join(dir, "fake-home");
+		await mkdir(join(fakeHome, ".claude"), { recursive: true });
+		await mkdir(join(fakeHome, ".codex"), { recursive: true });
+
+		const lines = await captureSuccessLines(() => targetsDetectCommand(dir, { homeDir: fakeHome }));
+
+		const joined = lines.join("\n");
+		expect(joined).toMatch(/skilltree install/);
 	});
 });
 


### PR DESCRIPTION
## Why

`skilltree init` was auto-enrolling **every** detected coding agent into `install_targets` without confirmation. A solo Claude user on a machine that also had codex / cursor / gemini installed ended up with all four baked into a `skilltree.yml` that teammates inherited — and `install` would then fan out every skill into four parallel `.<agent>/` directories. All three independent UX reviews flagged this as the first thing they hit.

Closes #74

## What changed

- **`init` resolution order** (`src/commands/init.ts`): detection is now a suggestion, not enrolment.
  1. `--target <name>` (repeatable) → explicit user choice, skips detection.
  2. No agents detected → safe default `[claude]`.
  3. Exactly one detected → enrol silently (the obvious thing).
  4. Multiple detected + `--yes` → enrol all (pre-fix behaviour, now opt-in).
  5. Multiple detected + interactive (TTY or `askFn`) → prompt `Include all? [Y/n/1,3,5]`.
  6. Multiple detected + non-interactive (CI / pipe) → default to `[claude]`. Reversible via `skilltree targets detect`.
- **New `--target` flag** wired in `src/cli.ts` (repeatable). Validated through the same `resolveTarget()` path that `targets add` uses, so unknown bare words fail fast; duplicates are deduped.
- **Friction A — `init` re-run error message** (`src/commands/init.ts`): replaced "Remove it first or edit it directly" with concrete next-step commands (`skilltree targets add`, `skilltree targets detect`).
- **Friction B — install hint** (`src/commands/targets.ts`): `targets add` and `targets detect` now print `Run \`skilltree install\` to populate the new target(s)` so users aren't left wondering why `.<agent>/skills/` is empty.
- **README** updated with the new `--target` example and the changed default behaviour.

## How tested

All TDD red→green. New tests in `tests/commands/init-agents.test.ts` and `tests/commands/targets.test.ts`:

- Single detected agent → no prompt fired (verifies `askFn` is not called).
- Multiple detected + `--yes` → all enrolled.
- Multiple detected + `isInteractive: false` → `[claude]` only.
- Multiple detected + `askFn` returns `y` / `1,3` / `n` (empty → safe `[claude]` fallback).
- `--target` bypasses detection (single & multiple), rejects unknown bare words, dedupes repeats.
- `init` re-run error message names `targets add` and `targets detect`.
- `targets add` and `targets detect` success output contains `skilltree install`.

Help snapshot regenerated for the new `--target` flag. Full suite: **1237 pass / 0 fail**, biome and tsc clean.

## Risk & rollback

Low. The interactive prompt is gated behind TTY + `askFn`, so CI and scripted flows take the deterministic `[claude]` default. `--yes` restores the prior all-detected behaviour for anyone who actually wants it. Revert with `git revert <sha>` — no schema or lockfile changes.