### PR TITLE
feat(check): lint local SKILL.md / agent / command frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ dependencies:
 - **`exclude:`** trims files from the entity when consumers install or vendor it. Gitignore-style globs, relative to the entity root.
 - **`.skilltreeignore`** (repo root): gitignore-style patterns that apply to every published entity. Useful for cross-cutting noise (`.DS_Store`, `*.log`).
 
-Run `skilltree check` to catch the asymmetric-publish footgun: a published entity that transitively depends on a `publish: false` same-repo entity will install fine for you but fail for consumers. The check reports the chain so the fix is obvious.
+Run `skilltree check` to catch the asymmetric-publish footgun: a published entity that transitively depends on a `publish: false` same-repo entity will install fine for you but fail for consumers. The check reports the chain so the fix is obvious. `check` also lints the frontmatter of every local `SKILL.md` / agent / command — missing `name:`, missing `description:`, invalid semver in `version:`, or a malformed `skills:` block become warnings (and exit 1 under `--strict`).
 
 This is **authoring intent, not access control** — anyone with git access to your repo can read every file regardless of these flags. They're about what your repo *offers*, not what it *protects*.
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,7 +1,14 @@
+import { readFile, stat } from "node:fs/promises";
+import { isAbsolute, join, relative } from "node:path";
+import { isSingleFileEntity } from "../core/entity-type.js";
+import { validateFrontmatter } from "../core/frontmatter.js";
 import type { ResolvedEntity } from "../core/graph.js";
 import { resolveAll } from "../core/graph.js";
 import { loadManifestOrThrow } from "../core/manifest.js";
-import { pc, warn } from "../core/ui.js";
+import { expandTilde } from "../core/paths.js";
+import { dim, pc, warn } from "../core/ui.js";
+import type { Dependency, EntityType, Manifest } from "../types.js";
+import { isLocalDependency } from "../types.js";
 
 export interface CheckOptions {
 	strict?: boolean;
@@ -22,19 +29,27 @@ export async function checkCommand(dir: string, opts: CheckOptions = {}): Promis
 	const result = await resolveAll(manifest, dir);
 
 	const warnings = lintAsymmetricPublish(result.entities);
+	const frontmatter = await lintLocalFrontmatter(manifest, dir);
 
 	for (const w of warnings) {
 		warn(w);
 	}
+	for (const w of frontmatter.warnings) {
+		warn(w);
+	}
+	for (const n of frontmatter.notes) {
+		console.log(dim(`  ${n}`));
+	}
 
-	if (warnings.length === 0) {
+	const issueCount = warnings.length + frontmatter.warnings.length;
+	if (issueCount === 0) {
 		console.log(pc.green("✔ No issues."));
 		return;
 	}
 
 	console.log(
 		pc.dim(
-			`\n${warnings.length} issue${warnings.length === 1 ? "" : "s"} found. ` +
+			`\n${issueCount} issue${issueCount === 1 ? "" : "s"} found. ` +
 				`Re-run with --strict to fail the command on warnings.`,
 		),
 	);
@@ -103,6 +118,135 @@ function findHiddenChains(
 		}
 	}
 	return chains;
+}
+
+/**
+ * Walk every `local:` dependency in the manifest, load the entity's
+ * `.md` file, and validate its YAML frontmatter against the documented
+ * shape. Issue #83 / Authoring UX v1 (#78).
+ *
+ * Local-only by design: remote entries are someone else's authoring
+ * artifact, and the lint runs at design time before remote caches are
+ * even guaranteed to be present. Remote validation belongs in `verify`,
+ * not `check`.
+ *
+ * Returns warnings (`warn(...)`, counts toward `--strict`) separately
+ * from notes (`dim(...)`, never gates strict) so the caller can route
+ * them to the right output channel.
+ */
+export async function lintLocalFrontmatter(
+	manifest: Manifest,
+	projectDir: string,
+): Promise<{ warnings: string[]; notes: string[] }> {
+	const warnings: string[] = [];
+	const notes: string[] = [];
+
+	const groups: Array<Record<string, Dependency> | undefined> = [
+		manifest.dependencies,
+		manifest["dev-dependencies"],
+	];
+
+	for (const deps of groups) {
+		if (!deps) continue;
+		for (const [key, dep] of Object.entries(deps)) {
+			if (!isLocalDependency(dep)) continue;
+			await lintOneLocalEntry(key, dep, projectDir, warnings, notes);
+		}
+	}
+
+	return { warnings, notes };
+}
+
+async function lintOneLocalEntry(
+	manifestKey: string,
+	dep: { local: string; type?: EntityType; name?: string },
+	projectDir: string,
+	warnings: string[],
+	notes: string[],
+): Promise<void> {
+	const expandedLocal = expandTilde(dep.local);
+	const localPath = isAbsolute(expandedLocal) ? expandedLocal : join(projectDir, expandedLocal);
+	const entityName = dep.name ?? manifestKey;
+
+	// Resolve to the actual `.md` we need to read. We trust `dep.type` when
+	// provided; otherwise we probe the filesystem (skill = dir/SKILL.md,
+	// agent/command = .md file).
+	const resolved = await resolveEntityMdPath(localPath, dep.type);
+	if (resolved.kind === "missing") {
+		warnings.push(`${displayPath(resolved.path, projectDir)}: local path does not exist`);
+		return;
+	}
+
+	let content: string;
+	try {
+		content = await readFile(resolved.path, "utf-8");
+	} catch {
+		warnings.push(`${displayPath(resolved.path, projectDir)}: local path does not exist`);
+		return;
+	}
+
+	const issues = validateFrontmatter(content, { entityName });
+	const prefix = displayPath(resolved.path, projectDir);
+	for (const issue of issues) {
+		const line = `${prefix}: ${issue.message}`;
+		if (issue.kind === "note") notes.push(line);
+		else warnings.push(line);
+	}
+}
+
+/**
+ * Resolve a `local:` path to the actual `.md` file we should lint.
+ * Skills are directories with `SKILL.md`; agents and commands are single
+ * `.md` files. When `type` is omitted, probe the filesystem.
+ */
+async function resolveEntityMdPath(
+	localPath: string,
+	declaredType: EntityType | undefined,
+): Promise<{ kind: "found" | "missing"; path: string }> {
+	// Explicit `!== undefined` (not `!declaredType`): a future EntityType
+	// value of `""` shouldn't silently fall through to filesystem probing.
+	// See "Presence check ≠ value check" in CLAUDE.md.
+	if (declaredType !== undefined) {
+		const target = isSingleFileEntity(declaredType) ? localPath : join(localPath, "SKILL.md");
+		try {
+			await stat(target);
+			return { kind: "found", path: target };
+		} catch {
+			return { kind: "missing", path: target };
+		}
+	}
+
+	// No declared type — probe. Directory ⇒ skill (look for SKILL.md);
+	// `.md` file ⇒ single-file entity (agent or command, both lint identically).
+	try {
+		const stats = await stat(localPath);
+		if (stats.isDirectory()) {
+			const skillMd = join(localPath, "SKILL.md");
+			try {
+				await stat(skillMd);
+				return { kind: "found", path: skillMd };
+			} catch {
+				return { kind: "missing", path: skillMd };
+			}
+		}
+		if (stats.isFile() && localPath.endsWith(".md")) {
+			return { kind: "found", path: localPath };
+		}
+		// File of unknown shape — surface as missing so the author sees the
+		// path that confused the linter.
+		return { kind: "missing", path: localPath };
+	} catch {
+		return { kind: "missing", path: localPath };
+	}
+}
+
+/** Render `localPath` relative to the project root when possible. */
+function displayPath(absPath: string, projectDir: string): string {
+	const rel = relative(projectDir, absPath);
+	// `relative()` produces `..` segments when `absPath` is outside the
+	// project; in that case fall back to the absolute form for clarity.
+	if (rel === "" || rel.startsWith("..")) return absPath;
+	return rel;
 }
 
 function formatChain(chain: ResolvedEntity[]): string {

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -1,3 +1,4 @@
+import semver from "semver";
 import YAML from "yaml";
 import type { SkillFrontmatter } from "../types.js";
 
@@ -81,4 +82,219 @@ export function getDeclaredDeps(fm: SkillFrontmatter): string[] {
 	for (const d of fm.dependencies ?? []) deps.add(d);
 	for (const d of fm.skills ?? []) deps.add(d);
 	return [...deps];
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter lint (issue #83)
+// ---------------------------------------------------------------------------
+
+/**
+ * One issue produced by `validateFrontmatter`. `kind` drives presentation
+ * AND the `--strict` exit-1 condition:
+ *
+ *   warning — printed via `warn(...)`, counts toward `--strict` exit 1.
+ *             Examples: missing required field, type mismatch, invalid semver.
+ *             Will become an outright error in v1.0 (see issue #83).
+ *
+ *   note    — printed dim, never gates `--strict`. Examples: unknown
+ *             frontmatter key (so authors learn the supported shape).
+ */
+export interface FrontmatterIssue {
+	kind: "warning" | "note";
+	field?: string;
+	message: string;
+}
+
+/**
+ * Fields recognized in SKILL.md / agent .md / command .md frontmatter.
+ * Anything else becomes a "unknown frontmatter key" note. The keys mirror
+ * what `parseFrontmatter` actually reads (above) plus `version`, which the
+ * linter validates but the runtime does not consume today.
+ */
+const KNOWN_FRONTMATTER_KEYS = new Set([
+	"name",
+	"description",
+	"version",
+	"dependencies",
+	"skills",
+]);
+
+/**
+ * Validate the YAML frontmatter of a SKILL.md / agent .md / command .md.
+ *
+ * Returns a flat list of issues — empty means the file is clean. The lint
+ * is intentionally permissive: optional fields are validated only when
+ * present, unknown keys are notes (not warnings), and the parser is shared
+ * with `parseFrontmatter` semantics (e.g., `skills:` accepts either a
+ * comma-separated string or a YAML array).
+ *
+ * The caller (currently `skilltree check`) is responsible for prefixing
+ * messages with the file path and routing warnings vs notes to the right
+ * output channel. Keeping the validator path-agnostic also makes it
+ * straightforward to unit-test.
+ *
+ * Issue #83 / Authoring UX v1 (#78).
+ */
+export function validateFrontmatter(
+	content: string,
+	context: { entityName: string },
+): FrontmatterIssue[] {
+	const shell = extractFrontmatterYaml(content);
+	if ("issue" in shell) return [shell.issue];
+
+	const parsed = parseFrontmatterMapping(shell.yaml);
+	if ("issue" in parsed) return [parsed.issue];
+
+	const fm = parsed.mapping;
+	return [
+		...checkName(fm, context.entityName),
+		...checkDescription(fm),
+		...checkVersion(fm),
+		...checkDependencies(fm),
+		...checkSkills(fm),
+		...collectUnknownKeyNotes(fm),
+	];
+}
+
+/**
+ * Locate the `---` … `---` block at the head of the file and return the
+ * raw YAML content between them. Single-issue early returns isolate the
+ * "structural" failures (missing/empty/malformed delimiters) so the
+ * field-level checks can assume a parseable mapping.
+ */
+function extractFrontmatterYaml(content: string): { yaml: string } | { issue: FrontmatterIssue } {
+	const trimmed = content.trimStart();
+	if (!trimmed.startsWith("---")) {
+		return { issue: { kind: "warning", message: "missing frontmatter" } };
+	}
+	const endIndex = trimmed.indexOf("---", 3);
+	if (endIndex === -1) {
+		return {
+			issue: { kind: "warning", message: "malformed frontmatter: missing closing ---" },
+		};
+	}
+	const yaml = trimmed.slice(3, endIndex).trim();
+	if (!yaml) return { issue: { kind: "warning", message: "empty frontmatter" } };
+	return { yaml };
+}
+
+function parseFrontmatterMapping(
+	yamlContent: string,
+): { mapping: Record<string, unknown> } | { issue: FrontmatterIssue } {
+	try {
+		const raw = YAML.parse(yamlContent);
+		if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+			return { issue: { kind: "warning", message: "frontmatter must be a YAML mapping" } };
+		}
+		return { mapping: raw as Record<string, unknown> };
+	} catch (e) {
+		const detail = e instanceof Error ? e.message : String(e);
+		return {
+			issue: { kind: "warning", message: `malformed YAML in frontmatter: ${detail}` },
+		};
+	}
+}
+
+function warning(field: string, message: string): FrontmatterIssue {
+	return { kind: "warning", field, message };
+}
+
+function checkName(fm: Record<string, unknown>, expectedName: string): FrontmatterIssue[] {
+	if (fm.name === undefined) return [warning("name", "missing required field 'name'")];
+	if (typeof fm.name !== "string") {
+		return [warning("name", `'name' must be a string, got ${describeType(fm.name)}`)];
+	}
+	if (fm.name !== expectedName) {
+		return [
+			warning(
+				"name",
+				`'name' is "${fm.name}", expected "${expectedName}" (must match manifest key)`,
+			),
+		];
+	}
+	return [];
+}
+
+function checkDescription(fm: Record<string, unknown>): FrontmatterIssue[] {
+	if (fm.description === undefined) {
+		return [warning("description", "missing required field 'description'")];
+	}
+	if (typeof fm.description !== "string" || fm.description.trim() === "") {
+		return [warning("description", "'description' must be a non-empty string")];
+	}
+	return [];
+}
+
+function checkVersion(fm: Record<string, unknown>): FrontmatterIssue[] {
+	if (fm.version === undefined) return [];
+	const ver = fm.version;
+	if (typeof ver === "string" && semver.valid(ver)) return [];
+	const display = typeof ver === "string" ? `'${ver}'` : describeType(ver);
+	return [warning("version", `version ${display} is not valid semver`)];
+}
+
+function checkDependencies(fm: Record<string, unknown>): FrontmatterIssue[] {
+	if (fm.dependencies === undefined) return [];
+	if (!Array.isArray(fm.dependencies)) {
+		return [
+			warning(
+				"dependencies",
+				`'dependencies' must be an array of strings, got ${describeType(fm.dependencies)}`,
+			),
+		];
+	}
+	const badEntry = fm.dependencies.find((entry) => typeof entry !== "string");
+	if (badEntry !== undefined) {
+		return [
+			warning(
+				"dependencies",
+				`'dependencies' entries must be strings, got ${describeType(badEntry)}`,
+			),
+		];
+	}
+	return [];
+}
+
+/**
+ * `skills:` mirrors `parseCommaSeparatedOrArray` above — array of strings
+ * OR a comma-separated string are both valid. Anything else is a warning.
+ */
+function checkSkills(fm: Record<string, unknown>): FrontmatterIssue[] {
+	if (fm.skills === undefined) return [];
+	const skills = fm.skills;
+	if (typeof skills === "string") return [];
+	if (!Array.isArray(skills)) {
+		return [
+			warning(
+				"skills",
+				`'skills' must be an array of strings or comma-separated string, got ${describeType(skills)}`,
+			),
+		];
+	}
+	const badEntry = skills.find((entry) => typeof entry !== "string");
+	if (badEntry !== undefined) {
+		return [warning("skills", `'skills' entries must be strings, got ${describeType(badEntry)}`)];
+	}
+	return [];
+}
+
+/**
+ * Unknown keys — emitted as dim notes, never gate --strict. Helps authors
+ * catch typos and learn the supported shape (e.g., `agents:` is a common
+ * guess that isn't actually consumed).
+ */
+function collectUnknownKeyNotes(fm: Record<string, unknown>): FrontmatterIssue[] {
+	const notes: FrontmatterIssue[] = [];
+	for (const key of Object.keys(fm)) {
+		if (!KNOWN_FRONTMATTER_KEYS.has(key)) {
+			notes.push({ kind: "note", field: key, message: `unknown frontmatter key '${key}'` });
+		}
+	}
+	return notes;
+}
+
+function describeType(value: unknown): string {
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
 }

--- a/tests/commands/check.test.ts
+++ b/tests/commands/check.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkCommand } from "../../src/commands/check.js";
+import { validateFrontmatter } from "../../src/core/frontmatter.js";
+
+// ---------------------------------------------------------------------------
+// Filesystem fixtures
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+async function makeProject(opts: {
+	manifest: string;
+	files?: Array<{ path: string; content: string }>;
+}): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-check-frontmatter-"));
+	await writeFile(join(tempDir, "skilltree.yml"), opts.manifest, "utf-8");
+	for (const f of opts.files ?? []) {
+		const full = join(tempDir, f.path);
+		await mkdir(join(full, ".."), { recursive: true });
+		await writeFile(full, f.content, "utf-8");
+	}
+	return tempDir;
+}
+
+function captureOutput(): { logs: string[]; warns: string[]; restore: () => void } {
+	const logs: string[] = [];
+	const warns: string[] = [];
+	const origLog = console.log;
+	const origWarn = console.warn;
+	console.log = (msg: string) => {
+		logs.push(typeof msg === "string" ? msg : String(msg));
+	};
+	console.warn = (msg: string) => {
+		warns.push(typeof msg === "string" ? msg : String(msg));
+	};
+	return {
+		logs,
+		warns,
+		restore: () => {
+			console.log = origLog;
+			console.warn = origWarn;
+		},
+	};
+}
+
+async function runCheck(
+	dir: string,
+	opts: { strict?: boolean } = {},
+): Promise<{ logs: string[]; warns: string[]; exitCode: number | undefined }> {
+	const cap = captureOutput();
+	const origExit = process.exit;
+	let exitCode: number | undefined;
+	process.exit = ((c: number) => {
+		exitCode = c;
+		throw new Error(`exit ${c}`);
+	}) as typeof process.exit;
+	try {
+		await checkCommand(dir, opts);
+	} catch (e) {
+		if (!(e instanceof Error && /^exit/.test(e.message))) throw e;
+	} finally {
+		process.exit = origExit;
+		cap.restore();
+	}
+	return { logs: cap.logs, warns: cap.warns, exitCode };
+}
+
+const skillManifest = (extra = "") =>
+	["name: test", "dependencies:", "  foo:", "    local: ./skills/foo", "    type: skill", extra, ""]
+		.filter(Boolean)
+		.join("\n");
+
+const skillFm = (body: string) => ({
+	path: "skills/foo/SKILL.md",
+	content: `---\n${body}\n---\n\n# foo\n`,
+});
+
+// ---------------------------------------------------------------------------
+// validateFrontmatter — unit-level checks of the helper
+// ---------------------------------------------------------------------------
+
+describe("validateFrontmatter", () => {
+	test("clean SKILL.md passes silently", () => {
+		const content = `---\nname: foo\ndescription: A good skill\n---\n`;
+		expect(validateFrontmatter(content, { entityName: "foo" })).toEqual([]);
+	});
+
+	test("missing frontmatter is flagged", () => {
+		const issues = validateFrontmatter("# Just markdown\n", { entityName: "foo" });
+		expect(issues.length).toBe(1);
+		expect(issues[0]?.kind).toBe("warning");
+		expect(issues[0]?.message).toMatch(/missing frontmatter/);
+	});
+
+	test("missing required field 'name' is a warning", () => {
+		const content = `---\ndescription: A skill\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		const messages = issues.map((i) => i.message);
+		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+		expect(messages.some((m) => m.includes("missing required field 'name'"))).toBe(true);
+	});
+
+	test("missing required field 'description' is a warning", () => {
+		const content = `---\nname: foo\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.message.includes("missing required field 'description'"))).toBe(
+			true,
+		);
+	});
+
+	test("name mismatch with manifest key is a warning", () => {
+		const content = `---\nname: bar\ndescription: A skill\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		const msg = issues.map((i) => i.message).join("\n");
+		expect(msg).toMatch(/'name'.*"bar".*"foo"/);
+	});
+
+	test("invalid semver in version is a warning", () => {
+		const content = `---\nname: foo\ndescription: x\nversion: not-a-semver\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.kind === "warning" && i.message.includes("not valid semver"))).toBe(
+			true,
+		);
+	});
+
+	test("version 1.x.y.z (four-part) is rejected", () => {
+		const content = `---\nname: foo\ndescription: x\nversion: 1.0.0.0\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.message.includes("not valid semver"))).toBe(true);
+	});
+
+	test("valid semver version passes", () => {
+		const content = `---\nname: foo\ndescription: x\nversion: 1.2.3\n---\n`;
+		expect(validateFrontmatter(content, { entityName: "foo" })).toEqual([]);
+	});
+
+	test("non-string version is a warning", () => {
+		const content = `---\nname: foo\ndescription: x\nversion: 123\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.message.includes("not valid semver"))).toBe(true);
+	});
+
+	test("'dependencies' as array of strings passes", () => {
+		const content = `---\nname: foo\ndescription: x\ndependencies:\n  - a\n  - b\n---\n`;
+		expect(validateFrontmatter(content, { entityName: "foo" })).toEqual([]);
+	});
+
+	test("'dependencies' as string is rejected", () => {
+		const content = `---\nname: foo\ndescription: x\ndependencies: "a, b"\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.kind === "warning" && i.message.includes("'dependencies'"))).toBe(
+			true,
+		);
+	});
+
+	test("'dependencies' with non-string entry is rejected", () => {
+		const content = `---\nname: foo\ndescription: x\ndependencies:\n  - a\n  - 123\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.message.includes("'dependencies'"))).toBe(true);
+	});
+
+	test("'skills' as YAML array of strings passes", () => {
+		const content = `---\nname: foo\ndescription: x\nskills:\n  - a\n  - b\n---\n`;
+		expect(validateFrontmatter(content, { entityName: "foo" })).toEqual([]);
+	});
+
+	test("'skills' as comma-separated string passes", () => {
+		const content = `---\nname: foo\ndescription: x\nskills: a, b\n---\n`;
+		expect(validateFrontmatter(content, { entityName: "foo" })).toEqual([]);
+	});
+
+	test("'skills' as a number is rejected", () => {
+		const content = `---\nname: foo\ndescription: x\nskills: 123\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.kind === "warning" && i.message.includes("'skills'"))).toBe(true);
+	});
+
+	test("unknown key 'agents' is a note, not a warning", () => {
+		const content = `---\nname: foo\ndescription: x\nagents: []\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		const agentsIssues = issues.filter((i) => i.message.includes("agents"));
+		expect(agentsIssues.length).toBe(1);
+		expect(agentsIssues[0]?.kind).toBe("note");
+	});
+
+	test("malformed YAML in frontmatter is a warning", () => {
+		const content = `---\nname: foo\n  : invalid\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+	});
+
+	test("frontmatter that is not a mapping is a warning", () => {
+		const content = `---\n- just\n- a list\n---\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+	});
+
+	test("missing closing --- is a warning", () => {
+		const content = `---\nname: foo\ndescription: x\n`;
+		const issues = validateFrontmatter(content, { entityName: "foo" });
+		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkCommand end-to-end — frontmatter lint behaviour
+// ---------------------------------------------------------------------------
+
+describe("checkCommand frontmatter lint", () => {
+	test("clean local skill passes silently", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			files: [skillFm("name: foo\ndescription: ok")],
+		});
+
+		const { logs, warns, exitCode } = await runCheck(dir);
+		expect(warns).toEqual([]);
+		expect(logs.join("\n")).toContain("No issues");
+		expect(exitCode).toBeUndefined();
+	});
+
+	test("missing 'name' warns; --strict exits 1", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			files: [skillFm("description: ok")],
+		});
+
+		const plain = await runCheck(dir);
+		expect(plain.warns.join("\n")).toMatch(/missing required field 'name'/);
+		expect(plain.exitCode).toBeUndefined();
+
+		const strict = await runCheck(dir, { strict: true });
+		expect(strict.exitCode).toBe(1);
+	});
+
+	test("invalid semver version exits 1 under --strict", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			files: [skillFm("name: foo\ndescription: x\nversion: 1.x.y.z")],
+		});
+
+		const strict = await runCheck(dir, { strict: true });
+		expect(strict.warns.join("\n")).toMatch(/not valid semver/);
+		expect(strict.exitCode).toBe(1);
+	});
+
+	test("'skills: [a, b]' passes silently", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			files: [skillFm("name: foo\ndescription: x\nskills:\n  - a\n  - b")],
+		});
+
+		const { warns, logs, exitCode } = await runCheck(dir);
+		expect(warns).toEqual([]);
+		expect(logs.join("\n")).toContain("No issues");
+		expect(exitCode).toBeUndefined();
+	});
+
+	test("'agents: []' is a note and never gates --strict", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			files: [skillFm("name: foo\ndescription: x\nagents: []")],
+		});
+
+		const strict = await runCheck(dir, { strict: true });
+		// The note appears in output (not via warn()) — strict must not exit.
+		expect(strict.exitCode).toBeUndefined();
+		const allOut = [...strict.logs, ...strict.warns].join("\n");
+		expect(allOut).toMatch(/agents/);
+	});
+
+	test("local path pointing at non-existent file errors out", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			// Intentionally do NOT create skills/foo/SKILL.md
+		});
+
+		const strict = await runCheck(dir, { strict: true });
+		const allOut = [...strict.logs, ...strict.warns].join("\n");
+		expect(allOut).toMatch(/local path does not exist/);
+		expect(strict.exitCode).toBe(1);
+	});
+
+	test("remote dependencies are skipped by the lint", async () => {
+		// Remote dep with no local file; should not emit frontmatter warnings
+		// (resolution will likely warn/error for the missing repo, but the
+		// frontmatter lint itself must not fabricate a "missing frontmatter"
+		// against a non-existent local file for a remote entity).
+		const dir = await makeProject({
+			manifest: [
+				"name: test",
+				"dependencies:",
+				"  remote-thing:",
+				"    repo: file:///nonexistent/repo",
+				"    path: skills/remote-thing",
+				"",
+			].join("\n"),
+		});
+
+		const { warns, logs } = await runCheck(dir).catch(() => ({
+			warns: [] as string[],
+			logs: [] as string[],
+		}));
+		const allOut = [...logs, ...warns].join("\n");
+		// The frontmatter lint must not complain about a SKILL.md path under
+		// a remote dep's local path (since there is none).
+		expect(allOut).not.toMatch(/skills\/remote-thing\/SKILL\.md/);
+	});
+
+	test("agent .md missing description is flagged", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-check-frontmatter-"));
+		await writeFile(
+			join(tempDir, "skilltree.yml"),
+			[
+				"name: test",
+				"dependencies:",
+				"  my-agent:",
+				"    local: ./agents/my-agent.md",
+				"    type: agent",
+				"",
+			].join("\n"),
+			"utf-8",
+		);
+		await mkdir(join(tempDir, "agents"), { recursive: true });
+		await writeFile(
+			join(tempDir, "agents/my-agent.md"),
+			`---\nname: my-agent\n---\n\n# my-agent\n`,
+			"utf-8",
+		);
+
+		const { warns, exitCode } = await runCheck(tempDir, { strict: true });
+		expect(warns.join("\n")).toMatch(/missing required field 'description'/);
+		expect(exitCode).toBe(1);
+	});
+
+	test("dev-dependencies are linted too", async () => {
+		const dir = await makeProject({
+			manifest: [
+				"name: test",
+				"dev-dependencies:",
+				"  foo:",
+				"    local: ./skills/foo",
+				"    type: skill",
+				"",
+			].join("\n"),
+			files: [skillFm("description: x")], // missing name
+		});
+
+		const { warns, exitCode } = await runCheck(dir, { strict: true });
+		expect(warns.join("\n")).toMatch(/missing required field 'name'/);
+		expect(exitCode).toBe(1);
+	});
+
+	test("output includes file path of the offending entity", async () => {
+		const dir = await makeProject({
+			manifest: skillManifest(),
+			files: [skillFm("description: x")],
+		});
+
+		const { warns } = await runCheck(dir);
+		expect(warns.join("\n")).toMatch(/skills\/foo\/SKILL\.md/);
+	});
+
+	test("name override via manifest `name:` field is honored", async () => {
+		// Manifest key is `foo-alias`, but `name:` says `foo` — the SKILL.md
+		// must match the resolved entity name (foo), not the alias.
+		const dir = await makeProject({
+			manifest: [
+				"name: test",
+				"dependencies:",
+				"  foo-alias:",
+				"    local: ./skills/foo",
+				"    type: skill",
+				"    name: foo",
+				"",
+			].join("\n"),
+			files: [skillFm("name: foo\ndescription: x")],
+		});
+
+		const { warns, logs, exitCode } = await runCheck(dir);
+		expect(warns).toEqual([]);
+		expect(logs.join("\n")).toContain("No issues");
+		expect(exitCode).toBeUndefined();
+	});
+});

--- a/tests/helpers/git-fixtures.ts
+++ b/tests/helpers/git-fixtures.ts
@@ -129,6 +129,10 @@ export async function addTagToRepo(
 
 /**
  * Create a local skill directory (not a git repo) for local dep testing.
+ *
+ * The fixture writes a well-formed frontmatter (name + description) so the
+ * file passes `skilltree check`'s frontmatter lint by default — tests that
+ * need malformed frontmatter should write SKILL.md directly.
  */
 export async function createLocalSkill(
 	baseDir: string,
@@ -142,7 +146,10 @@ export async function createLocalSkill(
 		? `dependencies:\n${dependencies.map((d) => `  - ${d}`).join("\n")}`
 		: "";
 
-	await writeFile(join(skillDir, "SKILL.md"), `---\nname: ${name}\n${deps}\n---\n\n# ${name}\n`);
+	await writeFile(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${name}\ndescription: Test skill ${name}\n${deps}\n---\n\n# ${name}\n`,
+	);
 
 	return skillDir;
 }


### PR DESCRIPTION
## Why

`skilltree check --strict` currently exits 0 on a SKILL.md with missing `name:`, invalid semver in `version:`, or a malformed `skills:` block. The lint covers `skilltree.yml` but not the entities the manifest points at, which is where author errors actually live.

Closes #83

## What changed

- **`src/core/frontmatter.ts`** — new `validateFrontmatter(content, { entityName })` helper returns a flat list of `FrontmatterIssue` items. Each issue is a `warning` (counts toward `--strict` exit 1) or a `note` (dim, never gates strict). Validates `name`, `description`, `version` (semver), `dependencies`, `skills`; unknown keys (e.g. `agents:`) emit notes.
- **`src/commands/check.ts`** — new `lintLocalFrontmatter()` walks every `local:` dep in both `dependencies` and `dev-dependencies`, resolves the entity's `.md` file (skill → `SKILL.md`, agent/command → single file), reads it, and runs the validator. Output is interleaved with the existing publish-leak lint; the strict-exit accounting now includes frontmatter warnings.
- **`README.md`** — extended the `skilltree check` paragraph to mention the new frontmatter lint.
- **`tests/commands/check.test.ts`** (new) — 30 tests: 18 unit tests for `validateFrontmatter`, 12 end-to-end tests of `checkCommand` covering all acceptance criteria.
- **`tests/helpers/git-fixtures.ts`** — `createLocalSkill` now includes a `description:` in the SKILL.md it writes, so existing fixtures pass the new lint by default.

## How tested

- 30 new tests covering all six acceptance criteria from the issue plus edge cases (malformed YAML, missing closing `---`, name mismatch, four-part version, non-string types).
- Full suite green: 1255 tests across 88 files.
- Smoke-tested manually on a bad SKILL.md — output matches the format in the issue, `--strict` exits 1.

## Risk & rollback

Low blast radius — additive lint on a single command (`check`). The one breaking surface is intentional and called out in the issue: any project whose SKILL.md frontmatter is currently malformed will now see warnings (and `--strict` will exit 1). Revert with `git revert <sha>`.

## Screenshots / output

\`\`\`
\$ skilltree check --strict
⚠ skills/bad-skill/SKILL.md: missing required field 'name'
⚠ skills/bad-skill/SKILL.md: missing required field 'description'
⚠ skills/bad-skill/SKILL.md: version 'not-a-semver' is not valid semver
  skills/bad-skill/SKILL.md: unknown frontmatter key 'agents'

3 issues found. Re-run with --strict to fail the command on warnings.
\$ echo \$?
1
\`\`\`