### PR TITLE
fix(info): fall through to lockfile/manifest for installed deps

### DIFF
--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -253,17 +253,23 @@ skilltree search python --json
 
 ## `skilltree info <name>`
 
-Show detailed information about a skill or agent from registries.
+Show detailed information about a skill or agent. Looks across three layers in order:
+
+1. **`skilltree.lock`** — most authoritative (installed state: source, version, commit, integrity)
+2. **`skilltree.yml`** — manifest declaration (may not yet be installed)
+3. **Registries** — catalog of available skills
+
+If the name is found in multiple layers, each is shown as its own `[lockfile]` / `[manifest]` / `[registry: <name>]` section. Lockfile and manifest layers work even with no registries configured, so introspecting your own installed deps never asks you to set up a registry first.
 
 ```bash
 skilltree info python-coding
 skilltree info python-coding --json
 ```
 
-Shows entity type, registry, path, description, tags, available versions, and a copy-pasteable `add` command.
+Exit code is `0` when found in any layer, `1` only when the name is absent from lockfile, manifest, **and** all configured registries.
 
 **Flags:**
-- `--json` — Machine-readable JSON output
+- `--json` — Machine-readable JSON output (array of layer-tagged objects)
 
 ## `skilltree registry index`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -315,7 +315,7 @@ export function buildProgram(): Command {
 		.description("Show detailed information about a skill, agent, or command")
 		.option("--json", "Output results as JSON")
 		.action(async (name: string, opts) => {
-			await infoCommand(name, { json: opts.json });
+			await infoCommand(name, { json: opts.json, dir: process.cwd() });
 		});
 
 	program

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,57 +1,100 @@
 import semver from "semver";
+import { manifestExists } from "../core/filenames.js";
 import { listTags } from "../core/git.js";
+import { readLockfile } from "../core/lockfile.js";
+import { expandSources, readManifest } from "../core/manifest.js";
 import { getRegistryRepoDir, loadFreshRegistryIndex } from "../core/registry-cache.js";
 import { listRegistries } from "../core/registry-config.js";
 import { dim, label, pc } from "../core/ui.js";
-import type { IndexEntry } from "../types.js";
+import type { Dependency, IndexEntry, LockfileEntry, Manifest } from "../types.js";
+import { isLocalDependency, isRemoteDependency, isSourceDependency } from "../types.js";
 
-interface InfoMatch {
-	entity: IndexEntry;
-	registry: string;
-	repo: string;
+interface LockfileMatch {
+	layer: "lockfile";
+	name: string;
+	entry: LockfileEntry;
 }
 
-interface FindMatchesResult {
-	matches: InfoMatch[];
+interface ManifestMatch {
+	layer: "manifest";
+	name: string;
+	dep: Dependency;
+	group: "prod" | "dev";
+}
+
+interface RegistryMatch {
+	layer: "registry";
+	registry: string;
+	repo: string;
+	entity: IndexEntry;
+}
+
+type Match = LockfileMatch | ManifestMatch | RegistryMatch;
+
+interface FindInRegistriesResult {
+	matches: RegistryMatch[];
 	/**
 	 * True iff at least one registry's cache loaded successfully. Distinguishes
 	 * "no usable indexes" (issue #25 — caches missing or fingerprint-stale)
-	 * from "indexes loaded but the entity isn't there" so the error message can
-	 * point the user at the right remediation.
+	 * from "indexes loaded but the entity isn't there" so the error message
+	 * can point the user at the right remediation.
 	 */
 	anyIndexLoaded: boolean;
 }
 
+export interface InfoCommandOptions {
+	json?: boolean;
+	/**
+	 * Project directory holding `skilltree.yml` / `skilltree.lock`. Defaults
+	 * to `process.cwd()`. Tests pass an isolated tempDir so they don't pick up
+	 * the surrounding project's manifest.
+	 */
+	dir?: string;
+}
+
+/**
+ * `skilltree info <name>` — layered lookup across the three places a dep can
+ * live (issue #75). Order matters and is intentional:
+ *
+ *   1. lockfile  (most authoritative — exact installed state)
+ *   2. manifest  (declared but maybe not yet installed)
+ *   3. registries (catalog of available skills)
+ *
+ * A locally-resolvable dep must never error out because registries aren't
+ * configured or their caches are stale — those concerns belong only to the
+ * registry layer. Exit code is 0 if found in any layer; 1 only when truly
+ * absent from all three.
+ */
 export async function infoCommand(
 	name: string,
-	opts?: { json?: boolean },
+	opts?: InfoCommandOptions,
 	configPath?: string,
 	cacheDir?: string,
 ): Promise<void> {
+	const dir = opts?.dir ?? process.cwd();
+
+	const lockfileMatch = await findInLockfile(name, dir);
+	const manifestMatch = await findInManifest(name, dir);
+
 	const registries = await listRegistries(configPath);
+	const { matches: registryMatches, anyIndexLoaded } = await findInRegistries(
+		name,
+		registries,
+		cacheDir,
+	);
 
-	if (registries.length === 0) {
-		throw new Error("No registries configured. Run 'skilltree registry add <url>' to add one.");
-	}
-
-	const { matches, anyIndexLoaded } = await findMatches(name, registries, cacheDir);
-
-	// Distinguish "no caches usable" (issue #25) from "entity truly absent" so
-	// the user — or a scripted JSON consumer — gets the right next step
-	// instead of bouncing through search or treating the empty result as
-	// definitive. Setup failures throw regardless of --json (matches search.ts).
-	if (!anyIndexLoaded) {
-		throw new Error("No registry indexes available. Run 'skilltree registry update' first.");
-	}
+	const matches: Match[] = [];
+	if (lockfileMatch) matches.push(lockfileMatch);
+	if (manifestMatch) matches.push(manifestMatch);
+	matches.push(...registryMatches);
 
 	if (matches.length === 0) {
-		if (opts?.json) {
-			console.log("[]");
-			return;
-		}
-		throw new Error(
-			`"${name}" not found in any registry.\nRun 'skilltree search <query>' to find available skills.`,
-		);
+		// Nothing found anywhere — pick the most actionable error.
+		// Registry setup failures (no registries / stale caches) only surface
+		// when the dep wasn't locally resolvable either; otherwise users got
+		// sent to "add a registry" when their lockfile already had the answer.
+		handleNoMatches(name, registries.length, anyIndexLoaded, opts?.json);
+		return;
 	}
 
 	if (opts?.json) {
@@ -59,19 +102,61 @@ export async function infoCommand(
 		return;
 	}
 
-	if (matches.length === 1) {
-		await printSingleMatch(matches[0] as InfoMatch, name, cacheDir);
-	} else {
-		printMultipleMatches(matches, name);
-	}
+	await printTextInfo(matches, name, cacheDir);
 }
 
-async function findMatches(
+// --- Layer 1: lockfile ---
+
+async function findInLockfile(name: string, dir: string): Promise<LockfileMatch | null> {
+	// readLockfile returns null on ENOENT; parse errors (corruption,
+	// unsupported version, cycles) propagate by design (see lockfile.ts).
+	// Letting them surface here is better than silently falling through
+	// to "not found in any registry" — the user needs to know.
+	const lockfile = await readLockfile(dir);
+	if (!lockfile) return null;
+
+	for (const [key, entry] of Object.entries(lockfile.packages)) {
+		const entryName = entry.name ?? key;
+		if (entryName === name) {
+			return { layer: "lockfile", name: entryName, entry };
+		}
+	}
+	return null;
+}
+
+// --- Layer 2: manifest ---
+
+async function findInManifest(name: string, dir: string): Promise<ManifestMatch | null> {
+	// No manifest is a normal state for `info` (e.g., user runs it outside
+	// a project root). Check existence explicitly so a real read/parse
+	// error still surfaces — same rationale as findInLockfile.
+	if (!manifestExists(dir)) return null;
+	const manifest: Manifest = await readManifest(dir);
+	const expanded = expandSources(manifest);
+
+	const prod = expanded.dependencies ?? {};
+	for (const [key, dep] of Object.entries(prod)) {
+		if ((dep.name ?? key) === name) {
+			return { layer: "manifest", name, dep, group: "prod" };
+		}
+	}
+	const dev = expanded["dev-dependencies"] ?? {};
+	for (const [key, dep] of Object.entries(dev)) {
+		if ((dep.name ?? key) === name) {
+			return { layer: "manifest", name, dep, group: "dev" };
+		}
+	}
+	return null;
+}
+
+// --- Layer 3: registries ---
+
+async function findInRegistries(
 	name: string,
 	registries: Array<{ name: string; repo: string }>,
 	cacheDir?: string,
-): Promise<FindMatchesResult> {
-	const matches: InfoMatch[] = [];
+): Promise<FindInRegistriesResult> {
+	const matches: RegistryMatch[] = [];
 	let anyIndexLoaded = false;
 	for (const reg of registries) {
 		// loadFreshRegistryIndex skips fingerprint-incompatible caches (issue #25).
@@ -80,11 +165,189 @@ async function findMatches(
 		anyIndexLoaded = true;
 		for (const entity of index.entities) {
 			if (entity.name === name) {
-				matches.push({ entity, registry: reg.name, repo: reg.repo });
+				matches.push({ layer: "registry", registry: reg.name, repo: reg.repo, entity });
 			}
 		}
 	}
 	return { matches, anyIndexLoaded };
+}
+
+// --- "nothing found" routing ---
+
+function handleNoMatches(
+	name: string,
+	registryCount: number,
+	anyIndexLoaded: boolean,
+	json: boolean | undefined,
+): void {
+	// Setup failures must propagate regardless of --json (matches search.ts):
+	// a scripted consumer otherwise sees `[]` and treats it as definitively
+	// absent. Issue #25.
+	if (registryCount > 0 && !anyIndexLoaded) {
+		throw new Error("No registry indexes available. Run 'skilltree registry update' first.");
+	}
+	if (json) {
+		console.log("[]");
+		return;
+	}
+	if (registryCount === 0) {
+		throw new Error(
+			`"${name}" not found in lockfile, manifest, or any registry. No registries configured — run 'skilltree registry add <url>' to broaden the search.`,
+		);
+	}
+	throw new Error(
+		`"${name}" not found in lockfile, manifest, or any registry.\nRun 'skilltree search <query>' to find available skills.`,
+	);
+}
+
+// --- Rendering: JSON ---
+
+async function printJsonInfo(matches: Match[], cacheDir?: string): Promise<void> {
+	const out = await Promise.all(matches.map((m) => matchToJson(m, cacheDir)));
+	console.log(JSON.stringify(out, null, 2));
+}
+
+async function matchToJson(m: Match, cacheDir?: string): Promise<Record<string, unknown>> {
+	if (m.layer === "lockfile") {
+		const e = m.entry;
+		const result: Record<string, unknown> = {
+			layer: "lockfile",
+			name: m.name,
+			type: e.type,
+			group: e.group,
+			path: e.path,
+			commit: e.commit,
+			dependencies: e.dependencies,
+		};
+		if (e.repo !== undefined) result.repo = e.repo;
+		if (e.source !== undefined) result.source = e.source;
+		if (e.version !== undefined) result.version = e.version;
+		if (e.integrity !== undefined) result.integrity = e.integrity;
+		return result;
+	}
+	if (m.layer === "manifest") {
+		return {
+			layer: "manifest",
+			name: m.name,
+			group: m.group,
+			...depToJson(m.dep),
+		};
+	}
+	// registry
+	const result: Record<string, unknown> = {
+		layer: "registry",
+		registry: m.registry,
+		repo: m.repo,
+		...m.entity,
+	};
+	const versions = await fetchVersions(m.registry, cacheDir);
+	if (versions.length > 0) {
+		result.versions = versions;
+		result.latest = versions[0];
+	}
+	return result;
+}
+
+function depToJson(dep: Dependency): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	if (isRemoteDependency(dep)) {
+		out.repo = dep.repo;
+		if (dep.path !== undefined) out.path = dep.path;
+		if (dep.version !== undefined) out.version = dep.version;
+		if (dep.type !== undefined) out.type = dep.type;
+		return out;
+	}
+	if (isSourceDependency(dep)) {
+		out.source = dep.source;
+		if (dep.path !== undefined) out.path = dep.path;
+		if (dep.version !== undefined) out.version = dep.version;
+		if (dep.type !== undefined) out.type = dep.type;
+		return out;
+	}
+	if (isLocalDependency(dep)) {
+		out.local = dep.local;
+		if (dep.type !== undefined) out.type = dep.type;
+		return out;
+	}
+	return out;
+}
+
+// --- Rendering: text ---
+
+async function printTextInfo(matches: Match[], name: string, cacheDir?: string): Promise<void> {
+	for (let i = 0; i < matches.length; i++) {
+		const m = matches[i] as Match;
+		if (i > 0) console.log();
+		if (m.layer === "lockfile") {
+			printLockfileSection(m);
+		} else if (m.layer === "manifest") {
+			printManifestSection(m);
+		} else {
+			await printRegistrySection(m, name, cacheDir);
+		}
+	}
+}
+
+function printLockfileSection(m: LockfileMatch): void {
+	const e = m.entry;
+	console.log(`  ${pc.bold("[lockfile]")} ${pc.bold(m.name)} ${dim(`(${e.type})`)}`);
+	console.log(`  ${label("Group:")}        ${e.group}`);
+	const source = e.source === "local" ? "local" : (e.repo ?? "-");
+	console.log(`  ${label("Source:")}       ${source}`);
+	console.log(`  ${label("Path:")}         ${e.path}`);
+	if (e.version) {
+		console.log(`  ${label("Version:")}      ${pc.green(e.version)}`);
+	}
+	console.log(`  ${label("Commit:")}       ${e.commit}`);
+	if (e.integrity) {
+		console.log(`  ${label("Integrity:")}    ${dim(e.integrity)}`);
+	}
+	if (e.dependencies.length > 0) {
+		console.log(`  ${label("Dependencies:")} ${e.dependencies.join(", ")}`);
+	}
+}
+
+function printManifestSection(m: ManifestMatch): void {
+	console.log(`  ${pc.bold("[manifest]")} ${pc.bold(m.name)} ${dim(`(${m.group})`)}`);
+	const d = m.dep;
+	if (isRemoteDependency(d)) {
+		console.log(`  ${label("Source:")}       ${d.repo}`);
+		if (d.path) console.log(`  ${label("Path:")}         ${d.path}`);
+		if (d.version) console.log(`  ${label("Version:")}      ${d.version}`);
+	} else if (isSourceDependency(d)) {
+		console.log(`  ${label("Source:")}       ${d.source}`);
+		if (d.path) console.log(`  ${label("Path:")}         ${d.path}`);
+		if (d.version) console.log(`  ${label("Version:")}      ${d.version}`);
+	} else if (isLocalDependency(d)) {
+		console.log(`  ${label("Source:")}       local`);
+		console.log(`  ${label("Path:")}         ${d.local}`);
+	}
+	if (d.type) console.log(`  ${label("Type:")}         ${d.type}`);
+}
+
+async function printRegistrySection(
+	m: RegistryMatch,
+	name: string,
+	cacheDir?: string,
+): Promise<void> {
+	console.log(
+		`  ${pc.bold(`[registry: ${m.registry}]`)} ${pc.bold(m.entity.name)} ${dim(`(${m.entity.type})`)}`,
+	);
+	console.log(`  ${label("Repo:")}         ${m.repo}`);
+	console.log(`  ${label("Path:")}         ${m.entity.path}`);
+	if (m.entity.description) {
+		console.log(`  ${label("Description:")}  ${m.entity.description}`);
+	}
+	if (m.entity.tags?.length) {
+		console.log(`  ${label("Tags:")}         ${m.entity.tags.join(", ")}`);
+	}
+	const versions = await fetchVersions(m.registry, cacheDir);
+	if (versions.length > 0) {
+		console.log(`  ${label("Versions:")}     ${versions.slice(0, 10).join(", ")}`);
+		console.log(`  ${label("Latest:")}       ${pc.green(versions[0] ?? "")}`);
+	}
+	console.log();
+	console.log(`  ${pc.cyan(`→ skilltree add ${name} --repo ${m.repo} --path ${m.entity.path}`)}`);
 }
 
 async function fetchVersions(registry: string, cacheDir?: string): Promise<string[]> {
@@ -97,59 +360,5 @@ async function fetchVersions(registry: string, cacheDir?: string): Promise<strin
 			.sort((a, b) => semver.rcompare(a, b));
 	} catch {
 		return [];
-	}
-}
-
-async function printJsonInfo(matches: InfoMatch[], cacheDir?: string): Promise<void> {
-	const jsonResults = await Promise.all(
-		matches.map(async (m) => {
-			const result: Record<string, unknown> = { ...m.entity, registry: m.registry, repo: m.repo };
-			const versions = await fetchVersions(m.registry, cacheDir);
-			if (versions.length > 0) {
-				result.versions = versions;
-				result.latest = versions[0];
-			}
-			return result;
-		}),
-	);
-	console.log(JSON.stringify(jsonResults, null, 2));
-}
-
-async function printSingleMatch(m: InfoMatch, name: string, cacheDir?: string): Promise<void> {
-	console.log(`  ${pc.bold(m.entity.name)} ${dim(`(${m.entity.type})`)}`);
-	console.log(`  ${label("Registry:")}     ${m.registry} ${dim(`(${m.repo})`)}`);
-	console.log(`  ${label("Path:")}         ${m.entity.path}`);
-	if (m.entity.description) {
-		console.log(`  ${label("Description:")}  ${m.entity.description}`);
-	}
-	if (m.entity.tags?.length) {
-		console.log(`  ${label("Tags:")}         ${m.entity.tags.join(", ")}`);
-	}
-
-	const versions = await fetchVersions(m.registry, cacheDir);
-	if (versions.length > 0) {
-		console.log(`  ${label("Versions:")}     ${versions.slice(0, 10).join(", ")}`);
-		console.log(`  ${label("Latest:")}       ${pc.green(versions[0] ?? "")}`);
-	}
-
-	console.log();
-	console.log(`  ${pc.cyan(`→ skilltree add ${name} --repo ${m.repo} --path ${m.entity.path}`)}`);
-}
-
-function printMultipleMatches(matches: InfoMatch[], name: string): void {
-	console.log(`  Found in ${pc.bold(String(matches.length))} registries:\n`);
-	for (let i = 0; i < matches.length; i++) {
-		const m = matches[i] as InfoMatch;
-		console.log(
-			`  ${pc.bold(`[${i + 1}]`)} ${pc.bold(m.entity.name)} ${dim(`(${m.entity.type})`)} — ${m.registry}`,
-		);
-		console.log(`      ${dim(`${m.repo} :: ${m.entity.path}`)}`);
-		if (m.entity.description) {
-			console.log(`      ${m.entity.description}`);
-		}
-		console.log(
-			`      ${pc.cyan(`→ skilltree add ${name} --repo ${m.repo} --path ${m.entity.path}`)}`,
-		);
-		console.log();
 	}
 }

--- a/tests/commands/info-layered.test.ts
+++ b/tests/commands/info-layered.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for #75: `skilltree info` should fall through to lockfile/manifest for
+ * installed deps before consulting registries.
+ *
+ * Resolution order:
+ *   1. lockfile (most authoritative — installed, with commit + integrity)
+ *   2. manifest (declared but maybe not yet installed)
+ *   3. configured registries
+ *
+ * The "No registries configured" precondition is no longer top-of-function;
+ * it only fires when the dep also isn't locally resolvable.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { infoCommand } from "../../src/commands/info.js";
+import { writeLockfile } from "../../src/core/lockfile.js";
+import { writeManifest } from "../../src/core/manifest.js";
+import { writeRegistryIndex } from "../../src/core/registry-cache.js";
+import { writeConfig } from "../../src/core/registry-config.js";
+import type { Lockfile, Manifest, RegistryIndex } from "../../src/types.js";
+
+let tempDir: string;
+
+async function setup(): Promise<string> {
+	tempDir = join(tmpdir(), `skilltree-info75-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	await mkdir(tempDir, { recursive: true });
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+function captureLogs(): { logs: string[]; restore: () => void } {
+	const logs: string[] = [];
+	const orig = console.log;
+	console.log = (...args: unknown[]) => logs.push(args.join(" "));
+	return {
+		logs,
+		restore: () => {
+			console.log = orig;
+		},
+	};
+}
+
+async function writeProjectManifest(dir: string, manifest: Manifest): Promise<void> {
+	await writeManifest(dir, manifest);
+}
+
+async function writeProjectLockfile(dir: string, lockfile: Lockfile): Promise<void> {
+	await writeLockfile(dir, lockfile);
+}
+
+describe("#75: info falls through to lockfile/manifest", () => {
+	test("installed dep with NO registries configured succeeds with [lockfile] block", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+
+		// No registries configured at all
+		await writeConfig({ registries: [] }, configPath);
+
+		// But the dep IS installed (lockfile + manifest)
+		await writeProjectManifest(dir, {
+			dependencies: {
+				"skill-creator": {
+					repo: "github.com/anthropics/skills",
+					path: "skills/skill-creator",
+				},
+			},
+		});
+		await writeProjectLockfile(dir, {
+			lockfile_version: 1,
+			packages: {
+				"skill-creator": {
+					type: "skill",
+					group: "prod",
+					repo: "github.com/anthropics/skills",
+					path: "skills/skill-creator",
+					commit: "abc1234",
+					integrity: "sha256-deadbeef",
+					dependencies: [],
+				},
+			},
+		});
+
+		const cap = captureLogs();
+		try {
+			// Must NOT throw — old behavior threw "No registries configured"
+			await infoCommand("skill-creator", { dir }, configPath, cacheDir);
+		} finally {
+			cap.restore();
+		}
+		const output = cap.logs.join("\n");
+		expect(output).toContain("[lockfile]");
+		expect(output).toContain("skill-creator");
+		expect(output).toContain("abc1234");
+	});
+
+	test("--json on installed dep with no registries returns lockfile-tagged entry", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [] }, configPath);
+
+		await writeProjectLockfile(dir, {
+			lockfile_version: 1,
+			packages: {
+				"skill-creator": {
+					type: "skill",
+					group: "prod",
+					repo: "github.com/anthropics/skills",
+					path: "skills/skill-creator",
+					commit: "abc1234",
+					version: "1.2.3",
+					integrity: "sha256-deadbeef",
+					dependencies: [],
+				},
+			},
+		});
+
+		const cap = captureLogs();
+		try {
+			await infoCommand("skill-creator", { json: true, dir }, configPath, cacheDir);
+		} finally {
+			cap.restore();
+		}
+		const parsed = JSON.parse(cap.logs.join("\n")) as Array<Record<string, unknown>>;
+		expect(Array.isArray(parsed)).toBe(true);
+		expect(parsed.length).toBe(1);
+		expect(parsed[0]?.layer).toBe("lockfile");
+		expect(parsed[0]?.name).toBe("skill-creator");
+		expect(parsed[0]?.version).toBe("1.2.3");
+		expect(parsed[0]?.commit).toBe("abc1234");
+	});
+
+	test("dep declared in manifest but not yet installed shows [manifest] block", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [] }, configPath);
+
+		// Manifest declares it, but no lockfile yet
+		await writeProjectManifest(dir, {
+			dependencies: {
+				"some-skill": {
+					repo: "github.com/x/y",
+					path: "skills/some-skill",
+					version: "^2.0.0",
+				},
+			},
+		});
+
+		const cap = captureLogs();
+		try {
+			await infoCommand("some-skill", { dir }, configPath, cacheDir);
+		} finally {
+			cap.restore();
+		}
+		const output = cap.logs.join("\n");
+		expect(output).toContain("[manifest]");
+		expect(output).toContain("some-skill");
+		expect(output).toContain("^2.0.0");
+		// No lockfile section — it isn't installed
+		expect(output).not.toContain("[lockfile]");
+	});
+
+	test("dep in lockfile AND registry shows both sections", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [{ name: "main", repo: "github.com/x/y" }] }, configPath);
+
+		const index: RegistryIndex = {
+			registry: "main",
+			repo: "github.com/x/y",
+			updated_at: new Date().toISOString(),
+			scanner_version: 1,
+			entities: [
+				{
+					name: "skill-creator",
+					type: "skill",
+					path: "skills/skill-creator",
+					description: "Generates SKILL.md scaffolds",
+				},
+			],
+		};
+		await writeRegistryIndex(index, cacheDir);
+
+		await writeProjectLockfile(dir, {
+			lockfile_version: 1,
+			packages: {
+				"skill-creator": {
+					type: "skill",
+					group: "prod",
+					repo: "github.com/anthropics/skills",
+					path: "skills/skill-creator",
+					commit: "abc1234",
+					dependencies: [],
+				},
+			},
+		});
+
+		const cap = captureLogs();
+		try {
+			await infoCommand("skill-creator", { dir }, configPath, cacheDir);
+		} finally {
+			cap.restore();
+		}
+		const output = cap.logs.join("\n");
+		expect(output).toContain("[lockfile]");
+		expect(output).toContain("[registry: main]");
+		// Lockfile section comes first (most authoritative)
+		const lockIdx = output.indexOf("[lockfile]");
+		const regIdx = output.indexOf("[registry: main]");
+		expect(lockIdx).toBeLessThan(regIdx);
+	});
+
+	test("found nowhere throws unified error mentioning all three layers", async () => {
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [{ name: "r", repo: "x" }] }, configPath);
+		const index: RegistryIndex = {
+			registry: "r",
+			repo: "x",
+			updated_at: new Date().toISOString(),
+			scanner_version: 1,
+			entities: [],
+		};
+		await writeRegistryIndex(index, cacheDir);
+
+		await expect(infoCommand("nonexistent", { dir }, configPath, cacheDir)).rejects.toThrow(
+			/not found.*lockfile.*manifest.*registr/i,
+		);
+	});
+
+	test("--json with installed-only dep does NOT throw 'No registries configured'", async () => {
+		// Belt-and-suspenders: the round-3 spec explicitly calls out that the
+		// line-33 precondition must move to after the local check.
+		const dir = await setup();
+		const configPath = join(dir, "config.yaml");
+		const cacheDir = join(dir, "cache");
+		await writeConfig({ registries: [] }, configPath);
+		await writeProjectLockfile(dir, {
+			lockfile_version: 1,
+			packages: {
+				"skill-creator": {
+					type: "skill",
+					group: "prod",
+					repo: "github.com/anthropics/skills",
+					path: "skills/skill-creator",
+					commit: "abc1234",
+					dependencies: [],
+				},
+			},
+		});
+		const cap = captureLogs();
+		try {
+			await infoCommand("skill-creator", { json: true, dir }, configPath, cacheDir);
+		} finally {
+			cap.restore();
+		}
+		// Should have output, not thrown
+		expect(cap.logs.join("\n")).toContain("lockfile");
+	});
+});

--- a/tests/commands/ux-fixes.test.ts
+++ b/tests/commands/ux-fixes.test.ts
@@ -116,7 +116,9 @@ describe("Fix #6: search/info exit codes", () => {
 		};
 		await writeRegistryIndex(index, cacheDir);
 
-		await expect(infoCommand("nonexistent", {}, configPath, cacheDir)).rejects.toThrow("not found");
+		await expect(infoCommand("nonexistent", { dir }, configPath, cacheDir)).rejects.toThrow(
+			"not found",
+		);
 	});
 
 	test("infoCommand directs user to 'registry update' when every cache is outdated (issue #25)", async () => {
@@ -144,7 +146,7 @@ describe("Fix #6: search/info exit codes", () => {
 			"utf-8",
 		);
 
-		await expect(infoCommand("python-coding", {}, configPath, cacheDir)).rejects.toThrow(
+		await expect(infoCommand("python-coding", { dir }, configPath, cacheDir)).rejects.toThrow(
 			"registry update",
 		);
 	});
@@ -172,7 +174,7 @@ describe("Fix #6: search/info exit codes", () => {
 		);
 
 		await expect(
-			infoCommand("python-coding", { json: true }, configPath, cacheDir),
+			infoCommand("python-coding", { json: true, dir }, configPath, cacheDir),
 		).rejects.toThrow("registry update");
 	});
 });


### PR DESCRIPTION
Closes #75.

`skilltree info <name>` previously only consulted registries, so running it on a dep already in the project's `skilltree.lock` errored with "no registries configured" (or "not found in any registry"). The user was sent to add a registry when the answer was already local. Now `info` resolves layered — lockfile → manifest → registries — and renders each hit as its own `[lockfile]` / `[manifest]` / `[registry: <name>]` section. Registry-setup errors (no registries, stale caches) only surface when the dep also wasn't locally resolvable. Exit code is 0 if found in any layer, 1 only when absent from all three. `--json` output becomes an array of layer-tagged objects (backward-incompatible, acceptable pre-v1.0 per the issue body).

**Risk:** Low. Confined to one command's read path. Revert with `git revert <sha>`.