### PR TITLE
feat(outdated): add read-only outdated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 | `skilltree add <name>` | Add a dependency (remote, local, or dev) |
 | `skilltree install` | Resolve dependencies and install |
 | `skilltree update [name]` | Update to latest versions |
+| `skilltree outdated [name]` | Preview which deps have newer versions (read-only) |
 | `skilltree remove <name>` | Remove a dependency |
 | `skilltree verify` | Check installed files against lockfile |
 | `skilltree list` | List installed dependencies |

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -90,6 +90,25 @@ skilltree update --global         # Update global deps
 - `-n, --dry-run` — Preview version bumps without applying
 - `-g, --global` — Update global dependencies
 
+## `skilltree outdated [name]`
+
+Read-only preview of dependency drift. Reports which deps have newer semver tags available upstream without modifying the lockfile or manifest. Counterpart to `skilltree update`.
+
+```bash
+skilltree outdated                 # Show all deps with drift status
+skilltree outdated python-coding   # Filter to one dep
+skilltree outdated --json          # Machine-readable output
+skilltree outdated --check         # Exit 1 if any drift exists (CI gate)
+skilltree outdated --global        # Inspect global deps
+```
+
+**Flags:**
+- `--json` — Output results as JSON
+- `--check` — Exit 1 if any drift exists (CI-friendly)
+- `-g, --global` — Show global deps
+
+**Output columns:** `Name`, `Current` (semver pin / `@<short-sha>` / `local`), `Latest` (latest semver tag on the resolved repo), `Bump` (`major` / `minor` / `patch` / `—`). Local deps and unresolved deps show `—`; a network/cache failure for a remote shows `error` in the Bump column.
+
 ## `skilltree remove <name>`
 
 Remove a dependency from manifest, lockfile, and installed files.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { infoCommand } from "./commands/info.js";
 import { initCommand } from "./commands/init.js";
 import { installCommand } from "./commands/install.js";
 import { listCommand } from "./commands/list.js";
+import { outdatedCommand } from "./commands/outdated.js";
 import {
 	registryAddCommand,
 	registryInitCommand,
@@ -115,6 +116,20 @@ export function buildProgram(): Command {
 		.action(async (name: string | undefined, opts) => {
 			await updateCommand(process.cwd(), name, {
 				dryRun: opts.dryRun,
+				global: opts.global,
+			});
+		});
+
+	program
+		.command("outdated [name]")
+		.description("Preview which deps have newer versions available (read-only)")
+		.option("--json", "Output results as JSON")
+		.option("--check", "Exit 1 if any drift exists (CI-friendly)")
+		.option("-g, --global", "Show global deps")
+		.action(async (name: string | undefined, opts) => {
+			await outdatedCommand(process.cwd(), name, {
+				json: opts.json,
+				check: opts.check,
 				global: opts.global,
 			});
 		});

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -106,6 +106,16 @@ const COMMANDS: CmdDef[] = [
 		],
 	},
 	{
+		name: "outdated",
+		description: "Preview which deps have newer versions available (read-only)",
+		positionalComplete: "deps",
+		flags: [
+			{ long: "--json", description: "Output results as JSON" },
+			{ long: "--check", description: "Exit 1 if any drift exists" },
+			{ long: "--global", short: "-g", description: "Show global deps" },
+		],
+	},
+	{
 		name: "remove",
 		description: "Remove a dependency",
 		positionalComplete: "deps",

--- a/src/commands/outdated.ts
+++ b/src/commands/outdated.ts
@@ -1,0 +1,217 @@
+import semver from "semver";
+import { MANIFEST_NEW, manifestExists } from "../core/filenames.js";
+import { ensureCached, listTags } from "../core/git.js";
+import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
+import { getGlobalDir } from "../core/paths.js";
+import { filterSemverTags } from "../core/resolver.js";
+import { dim, pc } from "../core/ui.js";
+import type { EntityType, LockfileEntry } from "../types.js";
+
+export interface OutdatedOptions {
+	json?: boolean;
+	check?: boolean;
+	global?: boolean;
+	/** Test override — defaults to `getGlobalDir()`. */
+	globalDir?: string;
+}
+
+export type BumpKind = "major" | "minor" | "patch" | "error" | null;
+
+export interface OutdatedRow {
+	name: string;
+	type: EntityType;
+	/** Display form: semver string, `@<short-sha>`, or `local`. */
+	current: string;
+	/** The resolved commit SHA, or null for local deps. */
+	currentCommit: string | null;
+	/** Latest semver tag on the resolved repo, or null when unknown. */
+	latest: string | null;
+	/** Upgrade magnitude. null for local/up-to-date/commit-only. "error" on network failure. */
+	bump: BumpKind;
+	/** The repo URL, or null for local deps. */
+	repo: string | null;
+}
+
+/**
+ * `skilltree outdated` — read-only preview of dependency drift.
+ *
+ * Reads manifest + lockfile and reports which deps have newer semver tags
+ * available upstream. Never writes the lockfile or manifest; the registry
+ * cache may still be fetched (that's not project state). Mirrors the
+ * affordance pattern of `npm outdated` / `cargo outdated`. See issue #79.
+ */
+export async function outdatedCommand(
+	dir: string,
+	name?: string,
+	opts?: OutdatedOptions,
+): Promise<void> {
+	const isGlobal = !!opts?.global;
+	const globalDir = opts?.globalDir ?? getGlobalDir();
+
+	if (!isGlobal && !manifestExists(dir)) {
+		throw new Error(`No ${MANIFEST_NEW} found. Run \`skilltree init\` first.`);
+	}
+
+	const lockfile = isGlobal ? await readGlobalLockfile(globalDir) : await readLockfile(dir);
+
+	if (!lockfile || Object.keys(lockfile.packages).length === 0) {
+		if (opts?.json) {
+			console.log("[]");
+			return;
+		}
+		console.log(
+			isGlobal
+				? "No global dependencies installed. Run `skilltree install --global`."
+				: "No dependencies installed. Run `skilltree install`.",
+		);
+		return;
+	}
+
+	let entries = Object.entries(lockfile.packages);
+	if (name) {
+		const filtered = entries.filter(([key, entry]) => (entry.name ?? key) === name);
+		if (filtered.length === 0) {
+			throw new Error(`"${name}" is not in the lockfile.`);
+		}
+		entries = filtered;
+	}
+
+	// Resolve rows in parallel — each row hits a different repo cache, and
+	// the network roundtrip dominates per-row work.
+	const rows = await Promise.all(entries.map(([key, entry]) => buildRow(key, entry)));
+
+	if (opts?.json) {
+		console.log(JSON.stringify(rows, null, 2));
+	} else {
+		printTable(rows);
+	}
+
+	if (opts?.check && rows.some((r) => r.bump !== null)) {
+		// Setting process.exitCode (rather than calling process.exit) lets the
+		// process flush stdout/stderr naturally before exiting — important
+		// since we just printed the table or JSON the user wants to see.
+		process.exitCode = 1;
+	}
+}
+
+async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow> {
+	const name = entry.name ?? key;
+	const type = entry.type;
+
+	if (entry.source === "local") {
+		return {
+			name,
+			type,
+			current: "local",
+			currentCommit: null,
+			latest: null,
+			bump: null,
+			repo: null,
+		};
+	}
+
+	const repo = entry.repo ?? null;
+	// Treat "" and null/undefined as "no commit" — empty-string-vs-undefined
+	// has bitten this codebase before (see CLAUDE.md hardening pattern #2).
+	const commit = entry.commit ? entry.commit : null;
+	const current = entry.version ?? (commit ? `@${commit.slice(0, 7)}` : "-");
+	const currentCommit = commit;
+
+	if (!repo) {
+		// Defensive: a non-local entry without a repo URL is malformed but
+		// shouldn't crash a read-only command — report and move on.
+		return { name, type, current, currentCommit, latest: null, bump: null, repo: null };
+	}
+
+	let tags: string[];
+	try {
+		const cachePath = await ensureCached(repo);
+		tags = await listTags(cachePath);
+	} catch {
+		return { name, type, current, currentCommit, latest: null, bump: "error", repo };
+	}
+
+	const semverTags = filterSemverTags(tags);
+	// filterSemverTags returns rcompare-sorted, so [0] is the highest version.
+	// Empty array → no tags at all → no upstream signal.
+	const latest = semverTags[0]?.version;
+	if (!latest) {
+		return { name, type, current, currentCommit, latest: null, bump: null, repo };
+	}
+
+	const currentSemver = entry.version;
+	if (!currentSemver) {
+		// Commit-only resolution: we can surface the latest tag for context
+		// but can't compute a bump kind without a semver anchor on the
+		// current side. Matches the example in the issue body where
+		// `task-builder @a56045e | 2.0.0 | —` shows "—".
+		return { name, type, current, currentCommit, latest, bump: null, repo };
+	}
+
+	if (semver.eq(currentSemver, latest)) {
+		return { name, type, current, currentCommit, latest, bump: null, repo };
+	}
+
+	const bump = classifyBump(currentSemver, latest);
+	return { name, type, current, currentCommit, latest, bump, repo };
+}
+
+/**
+ * Reduce semver.diff's seven-way output (major, premajor, minor, preminor,
+ * patch, prepatch, prerelease) to the three buckets the UI reports.
+ *
+ * Returns null when semver.diff can't classify the change (e.g.
+ * build-metadata-only differences). That's read-only-safe: it keeps the
+ * row visible but does NOT trigger `--check` exit-1, since we have no
+ * meaningful upgrade to recommend.
+ */
+function classifyBump(current: string, latest: string): "major" | "minor" | "patch" | null {
+	const diff = semver.diff(current, latest);
+	if (!diff) return null;
+	if (diff === "major" || diff === "premajor") return "major";
+	if (diff === "minor" || diff === "preminor") return "minor";
+	return "patch";
+}
+
+function printTable(rows: OutdatedRow[]): void {
+	const display = rows.map((r) => ({
+		name: r.name,
+		current: r.current,
+		latest: r.latest ?? "—",
+		bump: r.bump ?? "—",
+	}));
+
+	const widths = {
+		name: Math.max(4, ...display.map((r) => r.name.length)),
+		current: Math.max(7, ...display.map((r) => r.current.length)),
+		latest: Math.max(6, ...display.map((r) => r.latest.length)),
+		bump: Math.max(4, ...display.map((r) => r.bump.length)),
+	};
+
+	console.log(
+		pc.bold(
+			`${"Name".padEnd(widths.name)}  ${"Current".padEnd(widths.current)}  ${"Latest".padEnd(widths.latest)}  Bump`,
+		),
+	);
+	console.log(dim("-".repeat(widths.name + widths.current + widths.latest + widths.bump + 6)));
+	for (const row of display) {
+		console.log(
+			`${pc.cyan(row.name.padEnd(widths.name))}  ${row.current.padEnd(widths.current)}  ${pc.green(row.latest.padEnd(widths.latest))}  ${colorBump(row.bump)}`,
+		);
+	}
+}
+
+function colorBump(bump: string): string {
+	switch (bump) {
+		case "major":
+			return pc.red(bump);
+		case "minor":
+			return pc.yellow(bump);
+		case "patch":
+			return pc.green(bump);
+		case "error":
+			return pc.red(bump);
+		default:
+			return dim(bump);
+	}
+}

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -18,6 +18,8 @@ Commands:
   add [options] <name>          Add a dependency
   install [options]             Resolve and install dependencies
   update [options] [name]       Update dependencies to latest versions
+  outdated [options] [name]     Preview which deps have newer versions available
+                                (read-only)
   remove [options] <name>       Remove a dependency
   verify [options]              Verify installed dependencies against lockfile
   check [options]               Lint the project's skilltree.yml for design-time
@@ -107,6 +109,19 @@ Options:
   -n, --dry-run  Preview version bumps without applying
   -g, --global   Update global dependencies
   -h, --help     display help for command
+"
+`;
+
+exports[`CLI help snapshots \`outdated --help\` is stable 1`] = `
+"Usage: skilltree outdated [options] [name]
+
+Preview which deps have newer versions available (read-only)
+
+Options:
+  --json        Output results as JSON
+  --check       Exit 1 if any drift exists (CI-friendly)
+  -g, --global  Show global deps
+  -h, --help    display help for command
 "
 `;
 

--- a/tests/commands/outdated.test.ts
+++ b/tests/commands/outdated.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit from "simple-git";
+import { installCommand } from "../../src/commands/install.js";
+import { outdatedCommand } from "../../src/commands/outdated.js";
+import { addTagToRepo, createLocalSkill, createTestRepo } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-outdated-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+async function writeManifest(dir: string, content: string): Promise<void> {
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
+}
+
+async function makeBareClone(repoDir: string, baseDir: string, name: string): Promise<string> {
+	const bareDir = join(baseDir, `${name}.git`);
+	await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+	return bareDir;
+}
+
+function captureConsole(): { logs: string[]; restore: () => void } {
+	const logs: string[] = [];
+	const originalLog = console.log;
+	console.log = (...args: unknown[]) => logs.push(args.join(" "));
+	return { logs, restore: () => (console.log = originalLog) };
+}
+
+// Reset exitCode between tests so `--check` leakage doesn't fail unrelated cases
+let savedExitCode: typeof process.exitCode;
+beforeEach(() => {
+	savedExitCode = process.exitCode;
+	process.exitCode = 0;
+});
+afterEach(() => {
+	process.exitCode = savedExitCode;
+});
+
+describe("outdatedCommand", () => {
+	test("empty lockfile prints empty array under --json", async () => {
+		const dir = await makeTempDir();
+		await writeManifest(dir, "name: test\n");
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		expect(logs.join("").trim()).toBe("[]");
+	});
+
+	test("empty lockfile prints informational message in table mode", async () => {
+		const dir = await makeTempDir();
+		await writeManifest(dir, "name: test\n");
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, {});
+		} finally {
+			restore();
+		}
+
+		expect(logs.some((l) => l.includes("No dependencies"))).toBe(true);
+	});
+
+	test("local dep shows current=local and bump=null", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, "dependencies:\n  my-skill:\n    local: ./skills/my-skill\n");
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		const row = rows.find((r) => r.name === "my-skill");
+		expect(row).toBeDefined();
+		expect(row?.current).toBe("local");
+		expect(row?.latest).toBeNull();
+		expect(row?.bump).toBeNull();
+	});
+
+	test("remote dep at v1.0.0 with v2.0.0 available shows bump=major", async () => {
+		const dir = await makeTempDir();
+
+		const repoDir = await createTestRepo(
+			dir,
+			"repo",
+			[{ path: "skills/my-skill", name: "my-skill" }],
+			"v1.0.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  my-skill:\n    repo: "file://${bareDir}"\n    path: skills/my-skill\n    version: "1.0.0"\n`,
+		);
+		await installCommand(dir, {});
+
+		// Add v2.0.0 to the upstream but do NOT update lockfile (outdated must be read-only)
+		await addTagToRepo(repoDir, bareDir, "v2.0.0", [{ path: "skills/my-skill", name: "my-skill" }]);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		const row = rows.find((r) => r.name === "my-skill");
+		expect(row).toBeDefined();
+		expect(row?.current).toBe("1.0.0");
+		expect(row?.latest).toBe("2.0.0");
+		expect(row?.bump).toBe("major");
+	});
+
+	test("remote dep on latest version shows bump=null", async () => {
+		const dir = await makeTempDir();
+
+		const repoDir = await createTestRepo(
+			dir,
+			"repo",
+			[{ path: "skills/my-skill", name: "my-skill" }],
+			"v1.0.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  my-skill:\n    repo: "file://${bareDir}"\n    path: skills/my-skill\n    version: "*"\n`,
+		);
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		const row = rows.find((r) => r.name === "my-skill");
+		expect(row).toBeDefined();
+		expect(row?.bump).toBeNull();
+	});
+
+	test("--check exits with code 1 when drift exists", async () => {
+		const dir = await makeTempDir();
+
+		const repoDir = await createTestRepo(
+			dir,
+			"repo",
+			[{ path: "skills/my-skill", name: "my-skill" }],
+			"v1.0.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  my-skill:\n    repo: "file://${bareDir}"\n    path: skills/my-skill\n    version: "1.0.0"\n`,
+		);
+		await installCommand(dir, {});
+		await addTagToRepo(repoDir, bareDir, "v2.0.0", [{ path: "skills/my-skill", name: "my-skill" }]);
+
+		const { restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true, check: true });
+		} finally {
+			restore();
+		}
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	test("--check exits 0 when no drift (only local deps)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, "dependencies:\n  my-skill:\n    local: ./skills/my-skill\n");
+		await installCommand(dir, {});
+
+		const { restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true, check: true });
+		} finally {
+			restore();
+		}
+
+		expect(process.exitCode).toBeFalsy(); // 0 or undefined
+	});
+
+	test("positional name filters to one dep", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "skill-a");
+		await createLocalSkill(join(dir, "skills"), "skill-b");
+		await writeManifest(
+			dir,
+			"dependencies:\n  skill-a:\n    local: ./skills/skill-a\n  skill-b:\n    local: ./skills/skill-b\n",
+		);
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, "skill-a", { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.name).toBe("skill-a");
+	});
+
+	test("positional name that doesn't exist errors", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "real");
+		await writeManifest(dir, "dependencies:\n  real:\n    local: ./skills/real\n");
+		await installCommand(dir, {});
+
+		await expect(outdatedCommand(dir, "nonexistent", {})).rejects.toThrow();
+	});
+
+	test("does NOT write or modify the lockfile (snapshot test)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"repo",
+			[{ path: "skills/my-skill", name: "my-skill" }],
+			"v1.0.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  my-skill:\n    repo: "file://${bareDir}"\n    path: skills/my-skill\n    version: "1.0.0"\n`,
+		);
+		await installCommand(dir, {});
+
+		await addTagToRepo(repoDir, bareDir, "v2.0.0", [{ path: "skills/my-skill", name: "my-skill" }]);
+
+		const lockPath = join(dir, "skilltree.lock");
+		const manifestPath = join(dir, "skilltree.yml");
+
+		const lockBefore = await readFile(lockPath, "utf-8");
+		const manifestBefore = await readFile(manifestPath, "utf-8");
+		const lockMtimeBefore = (await stat(lockPath)).mtimeMs;
+		const manifestMtimeBefore = (await stat(manifestPath)).mtimeMs;
+
+		const { restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const lockAfter = await readFile(lockPath, "utf-8");
+		const manifestAfter = await readFile(manifestPath, "utf-8");
+		const lockMtimeAfter = (await stat(lockPath)).mtimeMs;
+		const manifestMtimeAfter = (await stat(manifestPath)).mtimeMs;
+
+		expect(lockAfter).toBe(lockBefore);
+		expect(manifestAfter).toBe(manifestBefore);
+		expect(lockMtimeAfter).toBe(lockMtimeBefore);
+		expect(manifestMtimeAfter).toBe(manifestMtimeBefore);
+	});
+
+	test("commit-only resolved (no semver tags) shows latest=null, bump=null", async () => {
+		const dir = await makeTempDir();
+		// Repo without any semver tags
+		const repoDir = await createTestRepo(dir, "repo", [
+			{ path: "skills/my-skill", name: "my-skill" },
+		]);
+		const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  my-skill:\n    repo: "file://${bareDir}"\n    path: skills/my-skill\n`,
+		);
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		const row = rows.find((r) => r.name === "my-skill");
+		expect(row).toBeDefined();
+		expect(row?.current).toMatch(/^@[0-9a-f]+$/); // @<short-sha>
+		expect(row?.latest).toBeNull();
+		expect(row?.bump).toBeNull();
+	});
+
+	test("missing remote (bad repo URL) shows bump='error'", async () => {
+		const dir = await makeTempDir();
+		// Write a synthetic lockfile pointing at a nonexistent file:// URL.
+		await writeManifest(dir, "name: test\n");
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			`lockfile_version: 1
+packages:
+  ghost-skill:
+    type: skill
+    group: prod
+    repo: "file://${dir}/does-not-exist.git"
+    path: skills/ghost
+    version: 1.0.0
+    commit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+    dependencies: []
+`,
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		const row = rows.find((r) => r.name === "ghost-skill");
+		expect(row).toBeDefined();
+		expect(row?.bump).toBe("error");
+		expect(row?.latest).toBeNull();
+	});
+
+	test("table output includes Name, Current, Latest, Bump columns", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "my-skill");
+		await writeManifest(dir, "dependencies:\n  my-skill:\n    local: ./skills/my-skill\n");
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, {});
+		} finally {
+			restore();
+		}
+
+		const out = logs.join("\n");
+		expect(out).toContain("Name");
+		expect(out).toContain("Current");
+		expect(out).toContain("Latest");
+		expect(out).toContain("Bump");
+		expect(out).toContain("my-skill");
+		expect(out).toContain("local");
+	});
+
+	test("bare command (no name) lists all deps", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "skill-a");
+		await createLocalSkill(join(dir, "skills"), "skill-b");
+		await writeManifest(
+			dir,
+			"dependencies:\n  skill-a:\n    local: ./skills/skill-a\n  skill-b:\n    local: ./skills/skill-b\n",
+		);
+		await installCommand(dir, {});
+
+		const { logs, restore } = captureConsole();
+		try {
+			await outdatedCommand(dir, undefined, { json: true });
+		} finally {
+			restore();
+		}
+
+		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+		expect(rows.length).toBe(2);
+	});
+});


### PR DESCRIPTION
## Why
`skilltree outdated` is the read-only preview counterpart to `skilltree update`. Today the only way to learn what an upgrade would change is to actually run `update` — and even `update --dry-run` mutates state in subtle ways (see #67). Three independent UX evaluations flagged this gap. This command is also part of the read-only inspection layer tracked in #77.

Closes #79

## What changed
- **`src/commands/outdated.ts`** — new command. Walks the lockfile; for each remote dep calls `ensureCached` + `listTags`, picks the latest semver tag via `filterSemverTags`, and classifies the upgrade as `major`/`minor`/`patch` (or `null` for up-to-date / local / commit-only / unclassifiable). Surfaces network failures as `bump: "error"` rather than crashing.
- **`src/cli.ts`** — registers `outdated [name]` with `--json`, `--check`, `--global` flags. `--check` sets `process.exitCode = 1` if any row has drift, leaving output intact for CI.
- **`src/commands/completion.ts`** — adds the entry so bash/zsh tab-completion covers the new command. Drift-detected by the completion freshness test.
- **`skills/skilltree/references/commands.md` + `README.md`** — user-facing docs.
- **`tests/commands/outdated.test.ts`** — 14 tests covering empty lockfile, local dep, semver drift (major bump), up-to-date, `--check` exit codes, positional filtering, unknown-name error, snapshot test asserting **no lockfile/manifest mutation** (per the acceptance criteria), commit-only resolution, and network-error rows.
- **`tests/cli/__snapshots__/help-snapshot.test.ts.snap`** — auto-updated to include the new command in `--help` output.

## How tested
- 14 new tests in `outdated.test.ts`, all green
- Full suite: **1240 pass / 0 fail** (`bun test`)
- Lint clean (`biome check`), typecheck clean (`tsc --noEmit`)
- Snapshot test asserts mtime + byte-identical content for `skilltree.yml` and `skilltree.lock` before and after the command

## Risk & rollback
Low — purely additive new command, no shared-path changes. Read-only by design (the only side effect is fetching the bare cache under `~/.skilltree/cache`, same as `info` and `search`). Rollback: `git revert <sha>`.