### PR TITLE
feat(why): add `skilltree why <name>` reverse-lookup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 | `skilltree verify` | Check installed files against lockfile |
 | `skilltree list` | List installed dependencies |
 | `skilltree deps tree` | Show dependency tree |
+| `skilltree why <name>` | Reverse-lookup which top-level dep pulled in `<name>` |
 | `skilltree scan <paths...>` | Detect undeclared deps in skill body text |
 | `skilltree vendor` | Enter vendor mode (copy deps, commit to git) |
 | `skilltree unvendor` | Exit vendor mode (restore symlinks + gitignore) |
@@ -338,7 +339,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 
 | Flag | Commands | Description |
 |------|----------|-------------|
-| `--global` | init, add, install, update, remove, list, verify, deps tree | Operate on global deps (`~/.skilltree/global.yaml` → `~/.claude/`) |
+| `--global` | init, add, install, update, remove, list, verify, deps tree, why | Operate on global deps (`~/.skilltree/global.yaml` → `~/.claude/`) |
 | `--prod` | install | Skip dev-dependencies |
 | `--frozen` | install, vendor | Lockfile-only, error if out of sync (CI mode) |
 | `--force` | install, remove | Overwrite modified files / skip confirmation |

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -162,6 +162,22 @@ skilltree deps tree --global
 **Flags:**
 - `-g, --global` — Show global dependency tree
 
+## `skilltree why <name>`
+
+Reverse-lookup which top-level dependency pulled in `<name>`. Reads the lockfile only and walks the resolved graph backwards from the target to every reachable top-level dep. Mirrors the `npm why` / `cargo why` mental model — useful when you spot something installed and want to know who's responsible for it.
+
+```bash
+skilltree why python-coding
+skilltree why foo --type agent      # disambiguate a name shared by skill+agent
+skilltree why something --json      # machine-readable
+skilltree why bar --global          # inspect global lockfile
+```
+
+**Flags:**
+- `-t, --type <type>` — Disambiguate when `<name>` matches multiple entity types (`skill`, `agent`, `command`)
+- `--json` — Output paths as JSON
+- `-g, --global` — Inspect the global lockfile
+
 ## `skilltree scan <paths...>`
 
 Detect undeclared dependencies in skill body text using regex patterns.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ import { teachCommand } from "./commands/teach.js";
 import { updateCommand } from "./commands/update.js";
 import { unvendorCommand, vendorCommand } from "./commands/vendor.js";
 import { verifyCommand } from "./commands/verify.js";
+import { whyCommand } from "./commands/why.js";
 import { pc } from "./core/ui.js";
 
 /**
@@ -238,6 +239,23 @@ export function buildProgram(): Command {
 				global: opts.global,
 				json: opts.json,
 				dedupe: opts.dedupe,
+			});
+		});
+
+	program
+		.command("why <name>")
+		.description(
+			"Show which top-level dependency pulled in <name>\n\nWalks the resolved graph backwards from <name> to every reachable top-level dep declared in skilltree.yml. Mirrors `npm why`.",
+		)
+		.option("-t, --type <type>", "Disambiguate when <name> matches multiple entity types")
+		.option("--json", "Output paths as JSON")
+		.option("-g, --global", "Inspect the global lockfile")
+		.action(async (name: string, opts) => {
+			await whyCommand(name, {
+				dir: process.cwd(),
+				global: opts.global,
+				type: opts.type,
+				json: opts.json,
 			});
 		});
 

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -199,6 +199,20 @@ const COMMANDS: CmdDef[] = [
 		],
 	},
 	{
+		name: "why",
+		description: "Show which top-level dependency pulled in <name>",
+		flags: [
+			{
+				long: "--type",
+				short: "-t",
+				description: "Disambiguate when <name> matches multiple entity types",
+				takesArg: true,
+			},
+			{ long: "--json", description: "Output paths as JSON" },
+			{ long: "--global", short: "-g", description: "Inspect the global lockfile" },
+		],
+	},
+	{
 		name: "registry",
 		description: "Registry management commands",
 		subcommands: [

--- a/src/commands/why.ts
+++ b/src/commands/why.ts
@@ -1,0 +1,238 @@
+import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
+import { readGlobalManifest, readManifest } from "../core/manifest.js";
+import { getGlobalDir } from "../core/paths.js";
+import { dim, pc } from "../core/ui.js";
+import type { EntityType, Lockfile, LockfileEntry } from "../types.js";
+
+/**
+ * `skilltree why <name>` — reverse-lookup which top-level dependency pulled in
+ * a given entity. Reads `skilltree.lock` only; never writes. Mirrors the
+ * `npm why` / `cargo why` mental model. Tracks issue #80.
+ */
+export interface WhyOptions {
+	/** Project directory containing `skilltree.yml` + `skilltree.lock`. */
+	dir?: string;
+	/** Read the global manifest/lockfile under `~/.skilltree`. */
+	global?: boolean;
+	/** Test override for the global dir. */
+	globalDir?: string;
+	/** Disambiguate when the name resolves to multiple entity types. */
+	type?: EntityType;
+	/** Emit JSON instead of human-readable text. */
+	json?: boolean;
+}
+
+type Group = "dependencies" | "dev-dependencies";
+
+interface JsonHop {
+	name: string;
+	/** Non-null only on the root hop (the top-level dep that started the path). */
+	group: Group | null;
+}
+
+interface JsonOutput {
+	name: string;
+	type: EntityType;
+	/** Empty array when the target is itself a top-level dep. */
+	paths: JsonHop[][];
+	/** Set when the target is a top-level dep; identifies which group. */
+	top_level?: Group;
+}
+
+export async function whyCommand(target: string, opts?: WhyOptions): Promise<void> {
+	const dir = opts?.dir ?? process.cwd();
+	const isGlobal = !!opts?.global;
+	const globalDir = opts?.globalDir ?? getGlobalDir();
+
+	const manifest = isGlobal ? await readGlobalManifest(globalDir) : await readManifest(dir);
+	const lockfile = isGlobal ? await readGlobalLockfile(globalDir) : await readLockfile(dir);
+
+	if (!lockfile) {
+		const cmd = isGlobal ? "skilltree install --global" : "skilltree install";
+		throw new Error(`No lockfile found. Run \`${cmd}\` first.`);
+	}
+
+	// 1. Find all packages matching `target` (by YAML key or by `name` field).
+	//    The lockfile is keyed by the YAML alias; when an entry was authored
+	//    with `name: foo` under a different key, that needs to match too.
+	const matches = findMatches(lockfile, target, opts?.type);
+
+	if (matches.length === 0) {
+		throw new Error(
+			`"${target}" is not in skilltree.lock. Did you mean to run \`skilltree install\` first?`,
+		);
+	}
+
+	if (matches.length > 1) {
+		const qualified = matches.map((m) => `${m.key} (${m.entry.type})`).join(", ");
+		throw new Error(
+			`"${target}" matches multiple entries: ${qualified}.\nRe-run with --type <skill|agent|command> to disambiguate.`,
+		);
+	}
+
+	// Exactly one match remains (the 0 and >1 branches above returned).
+	// Destructure via guard to satisfy TS noUncheckedIndexedAccess.
+	const [sole] = matches;
+	if (!sole) throw new Error(`Internal: unreachable — match length invariant violated`);
+	const { key: targetKey, entry: targetEntry } = sole;
+
+	// 2. Catalogue top-level deps and their groups.
+	const topProd = new Set(Object.keys(manifest.dependencies ?? {}));
+	const topDev = new Set(Object.keys(manifest["dev-dependencies"] ?? {}));
+	const groupOf = (k: string): Group | undefined => {
+		if (topProd.has(k)) return "dependencies";
+		if (topDev.has(k)) return "dev-dependencies";
+		return undefined;
+	};
+
+	// 3. Build reverse adjacency: child name → set of parent keys.
+	//    Mirrors `deps tree`: entries' `dependencies` lists are looked up
+	//    directly against `lockfile.packages` (works when YAML key == name,
+	//    the common case).
+	const parentsOf = buildReverseAdjacency(lockfile);
+
+	// 4. Walk upward from the target, recording every path that ends at a
+	//    top-level dep. The target itself is omitted from each path.
+	const rootSet = new Set<string>([...topProd, ...topDev]);
+	const paths = collectPathsToRoots(targetKey, parentsOf, rootSet);
+
+	// 5. Render.
+	if (opts?.json) {
+		const out: JsonOutput = {
+			name: target,
+			type: targetEntry.type,
+			paths: paths.map((p) =>
+				p.map((name, i) => ({
+					name,
+					group: i === 0 ? (groupOf(name) ?? null) : null,
+				})),
+			),
+		};
+		const topGroup = groupOf(targetKey);
+		if (topGroup) out.top_level = topGroup;
+		console.log(JSON.stringify(out, null, 2));
+		return;
+	}
+
+	renderText(target, targetEntry, targetKey, paths, groupOf);
+}
+
+function findMatches(
+	lockfile: Lockfile,
+	target: string,
+	typeFilter: EntityType | undefined,
+): Array<{ key: string; entry: LockfileEntry }> {
+	const out: Array<{ key: string; entry: LockfileEntry }> = [];
+	for (const [key, entry] of Object.entries(lockfile.packages)) {
+		const nameMatches = key === target || entry.name === target;
+		if (!nameMatches) continue;
+		if (typeFilter && entry.type !== typeFilter) continue;
+		out.push({ key, entry });
+	}
+	return out;
+}
+
+function buildReverseAdjacency(lockfile: Lockfile): Map<string, Set<string>> {
+	const parentsOf = new Map<string, Set<string>>();
+	for (const [parentKey, entry] of Object.entries(lockfile.packages)) {
+		for (const childName of entry.dependencies) {
+			// childName references either a YAML key or a name. We index by the
+			// raw string used in the dependencies array — the reverse lookup
+			// will match what callers ask for (their target key).
+			let parents = parentsOf.get(childName);
+			if (!parents) {
+				parents = new Set();
+				parentsOf.set(childName, parents);
+			}
+			parents.add(parentKey);
+		}
+	}
+	return parentsOf;
+}
+
+function collectPathsToRoots(
+	targetKey: string,
+	parentsOf: Map<string, Set<string>>,
+	roots: Set<string>,
+): string[][] {
+	const paths: string[][] = [];
+
+	// DFS upward. `currentPath` is the chain *below* `node`, ordered from
+	// the immediate parent down to the original target (target last).
+	// When `node` is a root, we record [node, ...currentPath].
+	const walk = (node: string, currentPath: string[], visited: Set<string>): void => {
+		if (roots.has(node)) {
+			paths.push([node, ...currentPath]);
+			// Don't stop here — a root could itself be transitively pulled in
+			// by another root (e.g., target is also a top-level). Continue
+			// exploring upward so longer chains are also surfaced.
+		}
+		const parents = parentsOf.get(node);
+		if (!parents) return;
+		for (const parent of parents) {
+			if (visited.has(parent)) continue; // cycle protection
+			const nextVisited = new Set(visited);
+			nextVisited.add(parent);
+			walk(parent, [node, ...currentPath], nextVisited);
+		}
+	};
+
+	const seed = new Set<string>([targetKey]);
+	const parents = parentsOf.get(targetKey);
+	if (parents) {
+		for (const parent of parents) {
+			if (seed.has(parent)) continue;
+			const nextVisited = new Set(seed);
+			nextVisited.add(parent);
+			walk(parent, [targetKey], nextVisited);
+		}
+	}
+
+	// Drop the target itself from each path — callers expect each path to
+	// list only the chain *to* the target, not including it.
+	return paths.map((p) => p.slice(0, -1));
+}
+
+function renderText(
+	target: string,
+	targetEntry: LockfileEntry,
+	targetKey: string,
+	paths: string[][],
+	groupOf: (k: string) => Group | undefined,
+): void {
+	const topGroup = groupOf(targetKey);
+
+	// Header always names the target with its type.
+	console.log(`${pc.cyan(target)} ${dim(`(${targetEntry.type})`)} ${pc.dim("←")}`);
+
+	if (paths.length === 0) {
+		// Either it's a top-level dep with no upstream, or it's somehow
+		// orphaned (in lockfile but no top-level reaches it — shouldn't
+		// happen after a clean install but report it cleanly).
+		if (topGroup) {
+			console.log(`  ${dim(`(top-level: ${topGroup})`)}`);
+		} else {
+			console.log(`  ${dim("(no top-level dependency transitively depends on this entry)")}`);
+		}
+		return;
+	}
+
+	// If the target is *also* a top-level dep, lead with that line so the
+	// user sees the direct declaration before the transitive chains.
+	if (topGroup) {
+		console.log(`  ${dim(`(top-level: ${topGroup})`)}`);
+	}
+
+	for (const path of paths) {
+		// path is [root, mid1, mid2, ...] (target excluded).
+		// Display as: ← mid_last ← ... ← mid1 ← root ← (group: top-level)
+		// — closer-to-target hops come first when read left to right.
+		const root = path[0];
+		if (!root) continue; // collectPathsToRoots never emits empty paths; guard for TS
+		const rootGroup = groupOf(root);
+		const reversed = [...path].reverse(); // now ends with root
+		const chain = reversed.map((n) => pc.cyan(n)).join(` ${dim("←")} `);
+		const groupLabel = rootGroup ? `${rootGroup}: top-level` : "top-level";
+		console.log(`  ${dim("←")} ${chain} ${dim(`(${groupLabel})`)}`);
+	}
+}

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -32,6 +32,11 @@ Commands:
   unvendor [options]            Exit vendor mode, restore normal symlinked
                                 installs
   deps                          Dependency graph commands
+  why [options] <name>          Show which top-level dependency pulled in <name>
+
+                                Walks the resolved graph backwards from <name>
+                                to every reachable top-level dep declared in
+                                skilltree.yml. Mirrors \`npm why\`.
   registry                      Registry management commands
   search [options] <query>      Search registries for skills, agents, and
                                 commands
@@ -240,6 +245,22 @@ Options:
   --dedupe      Stop recursion under already-printed subtrees (terse, cargo-tree
                 default style)
   -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`why --help\` is stable 1`] = `
+"Usage: skilltree why [options] <name>
+
+Show which top-level dependency pulled in <name>
+
+Walks the resolved graph backwards from <name> to every reachable top-level dep
+declared in skilltree.yml. Mirrors \`npm why\`.
+
+Options:
+  -t, --type <type>  Disambiguate when <name> matches multiple entity types
+  --json             Output paths as JSON
+  -g, --global       Inspect the global lockfile
+  -h, --help         display help for command
 "
 `;
 

--- a/tests/commands/why.test.ts
+++ b/tests/commands/why.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installCommand } from "../../src/commands/install.js";
+import { whyCommand } from "../../src/commands/why.js";
+import { createLocalSkill } from "../helpers/git-fixtures.js";
+
+/**
+ * Tests for `skilltree why <name>` — reverse-lookup which top-level deps
+ * pulled in a given entity. Issue #80.
+ *
+ * The command reads the lockfile only (never writes) and walks the resolved
+ * graph backwards from the target to every reachable top-level dependency.
+ */
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-why-"));
+	return tempDir;
+}
+
+afterEach(async () => {
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+async function writeManifest(dir: string, content: string): Promise<void> {
+	await writeFile(join(dir, "skilltree.yml"), content, "utf-8");
+}
+
+function stripAnsi(s: string): string {
+	// biome-ignore lint: regex for ANSI stripping
+	return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function captureConsole(fn: () => Promise<void>): Promise<string[]> {
+	const lines: string[] = [];
+	const original = console.log;
+	console.log = (...args: unknown[]) => lines.push(args.join(" "));
+	return fn()
+		.then(() => lines.map(stripAnsi))
+		.finally(() => {
+			console.log = original;
+		});
+}
+
+describe("why command", () => {
+	test("single-path: target reached through one top-level dep", async () => {
+		const dir = await makeTempDir();
+		// task-builder → python-coding
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"  python-coding:",
+				"    local: ./skills/python-coding",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => whyCommand("python-coding", { dir }));
+
+		// Header line
+		expect(lines[0]).toContain("python-coding");
+		// Path line should mention the top-level dep and that it's top-level
+		const pathLines = lines.slice(1);
+		expect(pathLines.some((l) => l.includes("task-builder") && l.includes("top-level"))).toBe(true);
+	});
+
+	test("multi-path: target reached through two top-level deps (diamond)", async () => {
+		const dir = await makeTempDir();
+		// Diamond: left → shared, right → shared, root → left, root → right
+		await createLocalSkill(join(dir, "skills"), "shared");
+		await createLocalSkill(join(dir, "skills"), "left", ["shared"]);
+		await createLocalSkill(join(dir, "skills"), "right", ["shared"]);
+		await createLocalSkill(join(dir, "skills"), "root", ["left", "right"]);
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  root:",
+				"    local: ./skills/root",
+				"  left:",
+				"    local: ./skills/left",
+				"  right:",
+				"    local: ./skills/right",
+				"  shared:",
+				"    local: ./skills/shared",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => whyCommand("shared", { dir }));
+
+		const pathLines = lines.slice(1);
+		// At minimum two paths: one via left and one via right (both reach root too).
+		// Each path text contains the intermediate name.
+		expect(pathLines.some((l) => l.includes("left"))).toBe(true);
+		expect(pathLines.some((l) => l.includes("right"))).toBe(true);
+		// shared is also top-level itself, so a "top-level" line should appear too
+		// — but per spec, a target that IS top-level is reported separately. Here
+		// shared is BOTH top-level AND a transitive of root, so transitive paths
+		// should still surface.
+	});
+
+	test("target is itself a top-level dep with no upstream chain", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "solo");
+
+		await writeManifest(dir, "dependencies:\n  solo:\n    local: ./skills/solo\n");
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => whyCommand("solo", { dir }));
+		// Should explicitly tell the user it's a top-level dep with no upstream.
+		const all = lines.join("\n");
+		expect(all).toContain("solo");
+		expect(all.toLowerCase()).toContain("top-level");
+	});
+
+	test("missing target errors with install hint", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "only");
+		await writeManifest(dir, "dependencies:\n  only:\n    local: ./skills/only\n");
+		await installCommand(dir, {});
+
+		await expect(whyCommand("does-not-exist", { dir })).rejects.toThrow(/not in skilltree\.lock/);
+	});
+
+	test("no lockfile errors with install hint", async () => {
+		const dir = await makeTempDir();
+		await writeManifest(dir, "dependencies: {}\n");
+
+		await expect(whyCommand("anything", { dir })).rejects.toThrow(/skilltree install/);
+	});
+
+	test("name collision: skill+agent same name requires --type", async () => {
+		const dir = await makeTempDir();
+		// Two top-level deps that resolve to the same name but different types,
+		// using YAML key aliasing.
+		await createLocalSkill(join(dir, "skills"), "fooskill");
+		// Agent .md file (single-file entity)
+		await writeFile(join(dir, "skills", "fooskill", "alias.md"), "---\nname: foo\n---\nbody\n");
+		// Local agent file at top-level
+		const agentPath = join(dir, "agents");
+		await writeFile(join(await mkdtempAgents(agentPath), "foo.md"), "---\nname: foo\n---\nbody\n");
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  foo-skill:",
+				"    local: ./skills/fooskill",
+				"    name: foo",
+				"    type: skill",
+				"  foo-agent:",
+				"    local: ./agents/foo.md",
+				"    name: foo",
+				"    type: agent",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		// Without --type: ambiguous
+		await expect(whyCommand("foo", { dir })).rejects.toThrow(/--type/);
+
+		// With --type: resolves
+		const lines = await captureConsole(() => whyCommand("foo", { dir, type: "agent" }));
+		expect(lines.join("\n")).toContain("foo");
+	});
+
+	test("--json shape: top-level direct path", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"  python-coding:",
+				"    local: ./skills/python-coding",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => whyCommand("python-coding", { dir, json: true }));
+		const out = JSON.parse(lines.join("\n"));
+		expect(out.name).toBe("python-coding");
+		expect(out.type).toBe("skill");
+		expect(Array.isArray(out.paths)).toBe(true);
+		expect(out.paths.length).toBeGreaterThanOrEqual(1);
+		// First entry of each path is the top-level dep, with a `group` set.
+		const firstPath = out.paths[0];
+		expect(firstPath[0].name).toBe("task-builder");
+		expect(firstPath[0].group).toBe("dependencies");
+	});
+
+	test("--json shape: target IS a top-level dep", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "solo");
+		await writeManifest(dir, "dependencies:\n  solo:\n    local: ./skills/solo\n");
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => whyCommand("solo", { dir, json: true }));
+		const out = JSON.parse(lines.join("\n"));
+		expect(out.name).toBe("solo");
+		// Top-level case: paths is an empty array, but a `top_level` field
+		// records the group so consumers can detect it cleanly.
+		expect(out.paths).toEqual([]);
+		expect(out.top_level).toBe("dependencies");
+	});
+});
+
+// Helper: create the "agents" directory and return it. Inline to avoid
+// adding another helper module for one test.
+async function mkdtempAgents(p: string): Promise<string> {
+	const { mkdir } = await import("node:fs/promises");
+	await mkdir(p, { recursive: true });
+	return p;
+}


### PR DESCRIPTION
## Why

Adds the npm/cargo `why` mental model to skilltree. When you see something installed and want to know *who pulled it in*, `skilltree why <name>` walks the resolved graph backwards from `<name>` to every reachable top-level entry in `skilltree.yml`.

Closes #80.

## What changed

- **New command** `src/commands/why.ts` — reads `skilltree.lock` (never writes), builds a reverse adjacency from `entry.dependencies` lists, and DFS-walks upward from the target to every top-level dep. Path cycles are guarded per-walk.
- **CLI wiring** `src/cli.ts` — registers `why <name>` with `-t/--type`, `--json`, `-g/--global`.
- **Shell completion** `src/commands/completion.ts` — adds `why` so the completion-coverage tests stay green and `zsh`/`bash` completions know the new flags.
- **Help snapshot** `tests/cli/__snapshots__/help-snapshot.test.ts.snap` — refreshed to include `why` and its `--help` output.
- **Docs**: README command table + `skills/skilltree/references/commands.md` both list `why` with usage examples and flags.

## How tested

- `tests/commands/why.test.ts` — 8 tests covering:
  - single-path resolution
  - multi-path (diamond) resolution
  - target is itself a top-level dep (special-cased lead line + `top_level` JSON field)
  - missing target → install-hint error
  - missing lockfile → install-hint error
  - skill+agent name collision → ambiguous without `--type`, resolves with `--type agent`
  - `--json` shape for a transitive path (root hop carries `group`, intermediates `null`)
  - `--json` shape when target is top-level (`paths: []`, `top_level` set)
- Full suite: 1234 tests pass, lint + typecheck clean.

## Risk & rollback

Low — purely additive read-only command. No changes to install/resolve paths or lockfile semantics. Revert with `git revert <sha>`.

## Output sample

```
$ skilltree why skilltree
skilltree (skill) ←
  (top-level: dependencies)

$ skilltree why python-coding --json
{
  "name": "python-coding",
  "type": "skill",
  "paths": [
    [{ "name": "task-builder", "group": "dependencies" }]
  ]
}
```