### PR TITLE
fix(vendor): record vendored target so unvendor can't silently mismatch

### DIFF
--- a/docs/specs/vendor.md
+++ b/docs/specs/vendor.md
@@ -119,7 +119,11 @@ git commit -m "bump python-coding to 2.2.0"
 ```yaml
 # skilltree.yml
 name: my-bootstrap-project
+install_targets:
+  - claude
+  - codex
 vendor: true                          # set by skilltree vendor/unvendor
+vendored_target: codex                # set by skilltree vendor --target
 
 dependencies:
   python-coding:
@@ -131,6 +135,13 @@ dependencies:
 ```
 
 `vendor:` is a boolean, default `false`. Set automatically by `skilltree vendor` and `skilltree unvendor`. Can be set manually.
+
+`vendored_target:` records which `install_targets` entry was used the last time `skilltree vendor` ran. `skilltree unvendor` consults it to clean up the directory that was actually vendored — without it, a `--target` typo could silently no-op while still flipping `vendor: false`. Two rules:
+
+- `unvendor` (no `--target`) uses the recorded target. On a multi-target manifest, the user no longer has to repeat what skilltree already knows.
+- `unvendor --target Y` where Y disagrees with the recorded target hard-errors. The actually-vendored directory stays untouched.
+
+Legacy manifests with `vendor: true` and no `vendored_target:` (single-target, `dev_install_path`, or hand-edited) still work — `unvendor` falls back to the original resolution rules.
 
 ## How Each Dep Type Is Vendored
 

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -41,7 +41,9 @@ export interface VendorOptions {
 }
 
 /**
- * Resolve which install target a vendor/unvendor invocation should act on.
+ * Pick which raw `install_targets` entry a vendor/unvendor invocation should
+ * act on. Returns `undefined` for legacy manifests (no `install_targets`),
+ * signalling the caller to fall back to `getDevInstallPath`.
  *
  * The contract — same for both commands so users don't have to relearn:
  *
@@ -56,16 +58,15 @@ export interface VendorOptions {
  *
  *   - Legacy manifest (no `install_targets`, uses `dev_install_path` or
  *       defaults): `--target` is rejected — there are no named targets
- *       to pick from. Falls back to `getDevInstallPath()`.
+ *       to pick from. Returns `undefined`.
  *
- * Returns the resolved on-disk path relative to the project root (e.g.
- * ".claude"). Throws a user-facing `Error` for any contract violation.
+ * Throws a user-facing `Error` for any contract violation.
  */
-function resolveVendorTarget(
+function pickRawTarget(
 	manifest: Manifest,
 	cmd: "vendor" | "unvendor",
 	target: string | undefined,
-): string {
+): string | undefined {
 	const rawTargets = manifest.install_targets;
 
 	if (!rawTargets || rawTargets.length === 0) {
@@ -75,7 +76,7 @@ function resolveVendorTarget(
 				`${cmd}: --target is only valid when install_targets is configured. This manifest uses the legacy dev_install_path — drop --target or migrate with \`skilltree targets migrate\`.`,
 			);
 		}
-		return getDevInstallPath(manifest);
+		return undefined;
 	}
 
 	if (rawTargets.length > 1 && target === undefined) {
@@ -92,7 +93,26 @@ function resolveVendorTarget(
 		throw new Error(`${cmd}: no install target available (internal invariant)`);
 	}
 	assertKnownTarget(cmd, selected, rawTargets);
-	return resolveTarget(selected);
+	return selected;
+}
+
+/**
+ * Resolve the on-disk install path for a vendor/unvendor invocation.
+ *
+ * Wraps `pickRawTarget`: returns the resolved path relative to the project
+ * root (e.g. ".claude"). For legacy manifests, falls back to
+ * `getDevInstallPath()`. See `pickRawTarget` for the full contract.
+ */
+function resolveVendorTarget(
+	manifest: Manifest,
+	cmd: "vendor" | "unvendor",
+	target: string | undefined,
+): string {
+	const raw = pickRawTarget(manifest, cmd, target);
+	if (raw === undefined) {
+		return getDevInstallPath(manifest);
+	}
+	return resolveTarget(raw);
 }
 
 /**
@@ -120,7 +140,9 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 	validateManifestOrThrow(manifest);
 	warnLegacyInstallPath(manifest);
 
-	const devInstallPath = resolveVendorTarget(manifest, "vendor", options.target);
+	const rawTarget = pickRawTarget(manifest, "vendor", options.target);
+	const devInstallPath =
+		rawTarget === undefined ? getDevInstallPath(manifest) : resolveTarget(rawTarget);
 	const installBase = join(dir, devInstallPath);
 
 	const existingLockfile = await readLockfile(dir);
@@ -189,8 +211,14 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 	await writeLockfile(dir, lockfile);
 	console.log(dim("Updated skilltree.lock"));
 
-	// Set vendor: true in manifest
+	// Set vendor: true in manifest. Also record which target was vendored
+	// (issue #89) so `unvendor` can clean up the right directory without
+	// re-asking the user. Legacy manifests with no named target stay legacy:
+	// recording a fabricated name would later trip the "unknown target" check.
 	manifest.vendor = true;
+	if (rawTarget !== undefined) {
+		manifest.vendored_target = rawTarget;
+	}
 	await writeManifest(dir, manifest);
 	console.log(dim(`Updated ${MANIFEST_NEW} (vendor: true)`));
 
@@ -220,7 +248,29 @@ export async function unvendorCommand(dir: string, options?: UnvendorOptions): P
 		return;
 	}
 
-	const devInstallPath = resolveVendorTarget(manifest, "unvendor", options?.target);
+	// Cross-check --target against the recorded `vendored_target` (issue #89).
+	// Three cases:
+	//   - User supplied --target AND a target was recorded that doesn't match
+	//     → hard-error. Acting on the user's value would leave the actually-
+	//     vendored directory orphaned.
+	//   - User omitted --target AND a target was recorded
+	//     → use the recorded one. Multi-target manifests no longer need the
+	//     user to repeat what skilltree already knows.
+	//   - Otherwise (legacy `vendor: true` boolean, no `vendored_target:`)
+	//     → fall through to the original resolveVendorTarget contract.
+	const recordedTarget = manifest.vendored_target;
+	if (
+		recordedTarget !== undefined &&
+		options?.target !== undefined &&
+		options.target !== recordedTarget
+	) {
+		throw new Error(
+			`unvendor: --target '${options.target}' does not match the recorded vendored target '${recordedTarget}'.\nRun \`skilltree unvendor --target ${recordedTarget}\` (or drop --target) to clean up the directory that was actually vendored.`,
+		);
+	}
+	const effectiveTarget = options?.target ?? recordedTarget;
+
+	const devInstallPath = resolveVendorTarget(manifest, "unvendor", effectiveTarget);
 	const installBase = join(dir, devInstallPath);
 	const lockfile = await readLockfile(dir);
 
@@ -258,6 +308,7 @@ export async function unvendorCommand(dir: string, options?: UnvendorOptions): P
 	}
 
 	delete manifest.vendor;
+	delete manifest.vendored_target;
 	await writeManifest(dir, manifest);
 	console.log(dim(`Updated ${MANIFEST_NEW} (vendor: false)`));
 

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -36,6 +36,10 @@ export function parseManifest(content: string): Manifest {
 		manifest.vendor = raw.vendor;
 	}
 
+	if (typeof raw.vendored_target === "string") {
+		manifest.vendored_target = raw.vendored_target;
+	}
+
 	if (Array.isArray(raw.install_targets)) {
 		manifest.install_targets = raw.install_targets as string[];
 	}
@@ -421,7 +425,10 @@ export function validateGlobalManifest(manifest: Manifest): string[] {
 	if (manifest.install_path) {
 		errors.push("Global manifest does not support install_path. Use install_targets instead.");
 	}
-	if (manifest.vendor) {
+	// `vendor` and `vendored_target` are siblings — both are project-only and
+	// share one error message. Use `||` (not `&&`) so a hand-edit that drops
+	// `vendor:` but leaves `vendored_target:` still trips the rule.
+	if (manifest.vendor || manifest.vendored_target !== undefined) {
 		errors.push("Global manifest does not support vendor mode.");
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,16 @@ export interface Manifest {
 	install_targets?: string[]; // Agent names or literal paths (e.g., ["claude", "./custom"])
 	src_install_path?: string; // Where application runtime skills go (optional)
 	vendor?: boolean; // Vendor mode: all deps copied (no symlinks), committed to git
+	/**
+	 * Records which `install_targets` entry was used the last time
+	 * `skilltree vendor` ran, so `skilltree unvendor` can clean up the right
+	 * directory without re-asking the user. Issue #89.
+	 *
+	 * Set by `vendor --target <X>` (or `vendor` on a single-target manifest)
+	 * and cleared by `unvendor`. Legacy manifests with `dev_install_path` do
+	 * not record this — there are no named targets to record.
+	 */
+	vendored_target?: string;
 	sources?: Record<string, string>;
 	dependencies?: Record<string, Dependency>;
 	"dev-dependencies"?: Record<string, Dependency>;

--- a/tests/commands/vendor-target.test.ts
+++ b/tests/commands/vendor-target.test.ts
@@ -218,9 +218,15 @@ describe("unvendor --target (issue #69, symmetric)", () => {
 		expect(after).not.toContain("vendor: true");
 	});
 
-	test("unvendor on multi-target without --target errors with raw entries", async () => {
+	test("legacy `vendor: true` (no recorded target) on multi-target errors when --target omitted", async () => {
+		// Construct a manifest in the legacy state: vendor: true (bare boolean,
+		// no `vendored_target:` sibling) on a multi-target manifest. This is
+		// what older skilltree versions produced before #89.
 		const dir = await setupMultiTargetProject();
 		await vendorCommand(dir, { target: "claude" });
+		// Strip the recorded target to simulate the legacy state.
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		await writeFile(join(dir, "skilltree.yml"), yml.replace(/^vendored_target:.*\n/m, ""));
 
 		let caught: Error | undefined;
 		try {
@@ -249,5 +255,129 @@ describe("unvendor --target (issue #69, symmetric)", () => {
 		}
 		expect(caught).toBeDefined();
 		expect(caught?.message).toContain("bogus");
+	});
+});
+
+/**
+ * Regression coverage for issue #89:
+ *   "vendor: manifest doesn't record which target was vendored, so
+ *    unvendor --target can silently mismatch"
+ *
+ * Fix shape: `vendor --target X` records `vendored_target: X` in the
+ * manifest. `unvendor` consults that field — uses it as the implicit
+ * target when --target is omitted, and hard-errors when --target
+ * disagrees with what was actually vendored.
+ *
+ * Legacy `vendor: true` manifests (no recorded target) keep working
+ * via the original resolveVendorTarget contract — see the "legacy"
+ * test above.
+ */
+describe("vendor records which target was vendored (issue #89)", () => {
+	test("vendor --target codex records `vendored_target: codex` in the manifest", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "codex" });
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(yml).toContain("vendor: true");
+		expect(yml).toContain("vendored_target: codex");
+	});
+
+	test("vendor on a single-target manifest records the sole target", async () => {
+		const dir = await makeTempDir();
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`name: test
+install_targets:
+  - claude
+dependencies:
+  foo:
+    local: ./skills/foo
+`,
+		);
+		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+		await createLocalSkill(join(dir, "skills"), "foo");
+		await vendorCommand(dir, {});
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(yml).toContain("vendored_target: claude");
+	});
+
+	test("vendor on a legacy `dev_install_path` manifest does NOT record a target", async () => {
+		// No install_targets => no named target exists. The CLI mustn't
+		// fabricate one in the manifest, or unvendor would later reject the
+		// recorded value as "unknown target" on the next round-trip.
+		const dir = await makeTempDir();
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			`name: test
+dev_install_path: .claude
+dependencies:
+  foo:
+    local: ./skills/foo
+`,
+		);
+		await writeFile(join(dir, ".gitignore"), ".claude/skills/\n.claude/agents/\n");
+		await createLocalSkill(join(dir, "skills"), "foo");
+		await vendorCommand(dir, {});
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(yml).toContain("vendor: true");
+		expect(yml).not.toContain("vendored_target");
+	});
+
+	test("unvendor (no --target) infers the recorded target on a multi-target manifest", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "codex" });
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(true);
+
+		// No --target: previously this would error on a multi-target manifest.
+		// Now it should consult `vendored_target: codex` and unvendor cleanly.
+		await unvendorCommand(dir, {});
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(false);
+
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(yml).not.toContain("vendor: true");
+		expect(yml).not.toContain("vendored_target");
+	});
+
+	test("unvendor --target Y errors when the manifest recorded a different X", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "codex" });
+
+		let caught: Error | undefined;
+		try {
+			await unvendorCommand(dir, { target: "claude" });
+		} catch (e) {
+			caught = e as Error;
+		}
+		expect(caught).toBeDefined();
+		const msg = caught?.message ?? "";
+		expect(msg).toContain("claude");
+		expect(msg).toContain("codex");
+		// The error must clearly distinguish "what you asked" from
+		// "what was actually vendored" — vague mismatches make the user
+		// guess which one to trust.
+		expect(msg.toLowerCase()).toMatch(/vendored|recorded|mismatch/);
+
+		// Files on disk must NOT be touched — a refusal to act, not a half-clean.
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(true);
+	});
+
+	test("unvendor --target matching the recorded target succeeds", async () => {
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "codex" });
+		await unvendorCommand(dir, { target: "codex" });
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(false);
+	});
+
+	test("legacy `vendor: true` manifest (no recorded target) accepts --target without mismatch error", async () => {
+		// A manifest written by an older skilltree (or hand-edited): vendor:
+		// true with no `vendored_target:`. The user supplies --target — we
+		// have nothing to cross-check against, so the operation must proceed
+		// rather than spuriously erroring.
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "claude" });
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		await writeFile(join(dir, "skilltree.yml"), yml.replace(/^vendored_target:.*\n/m, ""));
+
+		await unvendorCommand(dir, { target: "claude" });
+		expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Why

After landing #88, `skilltree vendor --target <X>` populated the right directory but the manifest only stored `vendor: true` — not *which* target was vendored. `skilltree unvendor --target <Y>` (different target) then silently no-opped on disk while still flipping `vendor: false`, leaving the actually-vendored files orphaned and the lockfile pointing at ghosts.

Closes #89.

## What changed

- `src/types.ts`, `src/core/manifest.ts` — add `vendored_target?: string` on `Manifest`, parse it from `skilltree.yml`, and reject it (alongside `vendor`) on global manifests.
- `src/commands/vendor.ts` — extract `pickRawTarget` from `resolveVendorTarget` so the raw name is reachable. `vendorCommand` writes `vendored_target` whenever a named target was used (legacy `dev_install_path` manifests keep producing a bare `vendor: true`).
- `src/commands/vendor.ts` — `unvendorCommand` now cross-checks `options.target` against the recorded value. Mismatch is a hard error with both names in the message; an omitted `--target` falls back to the recorded target (multi-target manifests no longer require the user to repeat themselves). Both `vendor` and `vendored_target` are cleared on unvendor.
- `docs/specs/vendor.md` — document the new field and the two new rules.
- `tests/commands/vendor-target.test.ts` — six new tests covering the round-trip, single-target recording, legacy `dev_install_path` non-recording, inferred-target unvendor, mismatch hard-error (files untouched), and matching-target acceptance. The existing "unvendor on multi-target without --target errors" test now reconstructs the legacy boolean-only state to verify the fallback path still works.

## How tested

- `bun test` — 1313 / 1313 green.
- `bun run lint`, `bun run typecheck` — clean.
- Acceptance items from #89 all covered by explicit tests:
  - `vendor --target X` records X in the manifest.
  - `unvendor` infers X on multi-target and single-target manifests.
  - `unvendor --target Y` (Y ≠ recorded X) errors with both names; vendored directory stays untouched on disk.
  - Legacy `vendor: true` (no `vendored_target:`) still unvendors via the original resolveVendorTarget contract.

## Risk & rollback

Low. The new field is additive — older skilltree binaries read `vendor: true` and ignore the unknown `vendored_target:` key. Newer binaries on older manifests fall through to the legacy resolution path. Revert with `git revert <sha>` if needed.