### PR TITLE
fix(setup): skip teach on post-merge bump (#92)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,10 @@ repos:
     hooks:
       - id: auto-setup-on-bump
         name: Auto-setup after version bump
-        entry: bash -c 'PREV=$(git diff HEAD@{1} HEAD -- package.json | grep "^-.*\"version\"" | sed "s/.*\"\([0-9][^\"]*\)\".*/\1/"); CURR=$(grep "\"version\"" package.json | head -1 | sed "s/.*\"\([0-9][^\"]*\)\".*/\1/"); if [ -n "$PREV" ] && [ "$PREV" != "$CURR" ]; then echo "Version changed $PREV → $CURR, running make setup..."; make setup; fi'
+        # Calls `make setup-bump` (not `make setup`) so a transient failure in
+        # the contributor's *personal* global manifest doesn't leave the
+        # bumped binary uninstalled. See issue #92.
+        entry: bash -c 'PREV=$(git diff HEAD@{1} HEAD -- package.json | grep "^-.*\"version\"" | sed "s/.*\"\([0-9][^\"]*\)\".*/\1/"); CURR=$(grep "\"version\"" package.json | head -1 | sed "s/.*\"\([0-9][^\"]*\)\".*/\1/"); if [ -n "$PREV" ] && [ "$PREV" != "$CURR" ]; then echo "Version changed $PREV → $CURR, running make setup-bump..."; make setup-bump; fi'
         language: system
         stages: [post-merge]
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUN := $(HOME)/.bun/bin/bun
-.PHONY: help install test lint format typecheck check build clean dev setup release eval eval-llm demo gh-demo
+.PHONY: help install test lint format typecheck check build clean dev setup setup-bump release eval eval-llm demo gh-demo
 .DEFAULT_GOAL := help
 
 help: ## Show available targets
@@ -47,14 +47,21 @@ setup: build ## Build and install binary + skill + completions
 	@mkdir -p $(HOME)/.skilltree/bin $(HOME)/.skilltree/completions
 	@rm -f $(HOME)/.skilltree/bin/skilltree
 	@cp dist/skilltree $(HOME)/.skilltree/bin/skilltree
-	@$(BUN) run src/cli.ts teach > /dev/null
+	@# Issue #92: skip `teach` on the post-merge bump path. `teach` resolves
+	@# the contributor's *personal* global manifest, so transient failures
+	@# there would otherwise leave the bumped binary uninstalled.
+	@if [ -z "$(SKILTREE_SKIP_TEACH)" ]; then $(BUN) run src/cli.ts teach > /dev/null; fi
 	@$(BUN) run src/cli.ts completion zsh > $(HOME)/.skilltree/completions/_skilltree
 	@$(BUN) run src/cli.ts completion bash > $(HOME)/.skilltree/completions/skilltree.bash
 	@echo ""
 	@echo "  \033[1mskilltree v$$(grep '"version"' package.json | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/') installed\033[0m"
 	@echo ""
 	@echo "  \033[32m✔\033[0m Binary     → ~/.skilltree/bin/skilltree"
-	@echo "  \033[32m✔\033[0m Skill      → ~/.claude/skills/skilltree/"
+	@if [ -z "$(SKILTREE_SKIP_TEACH)" ]; then \
+		echo "  \033[32m✔\033[0m Skill      → ~/.claude/skills/skilltree/"; \
+	else \
+		echo "  \033[33m·\033[0m Skill      → not refreshed (run \`make setup\` to refresh global skill)"; \
+	fi
 	@echo "  \033[32m✔\033[0m Completions → ~/.skilltree/completions/"
 	@echo ""
 	@if echo "$$PATH" | grep -q "$(HOME)/.skilltree/bin"; then \
@@ -86,6 +93,9 @@ setup: build ## Build and install binary + skill + completions
 	@echo "  To seed community registries:"
 	@echo "    \033[36mskilltree registry init\033[0m"
 	@echo ""
+
+setup-bump: ## Post-bump variant of setup: binary + completions only, skips `teach` (used by post-merge hook; see issue #92)
+	@$(MAKE) setup SKILTREE_SKIP_TEACH=1
 
 demo: ## Record demo GIF + MP4 locally (no publish)
 	@command -v vhs >/dev/null || (echo "Error: vhs not installed. Run: brew install vhs"; exit 1)

--- a/tests/build/post-merge-hook.test.ts
+++ b/tests/build/post-merge-hook.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Issue #92: The post-merge `auto-setup-on-bump` hook used to run `make setup`,
+ * which invokes `skilltree teach` against the contributor's *personal* global
+ * manifest. If that manifest temporarily fails to resolve, the merge succeeds
+ * but the local binary is left stale and the failure is buried in the merge
+ * scrollback.
+ *
+ * The contract this test pins down:
+ *
+ *   1. A separate `setup-bump` make target exists for the post-merge hook to
+ *      call. It must not run `teach` (either by passing `SKILTREE_SKIP_TEACH=1`
+ *      to a guarded `setup`, or by omitting the `teach` line entirely).
+ *   2. `make setup` continues to run `teach` for contributors who deliberately
+ *      want to refresh the global skill install. If it's gated, the gate must
+ *      key off `SKILTREE_SKIP_TEACH`.
+ *   3. The post-merge hook in `.pre-commit-config.yaml` calls `setup-bump`,
+ *      not `setup`.
+ *
+ * These are structural assertions on the Makefile / pre-commit config text
+ * rather than dry-run output because GNU make's `-n` still expands recursive
+ * `$(MAKE)` calls and prints conditional branches verbatim, so dry-run output
+ * can't distinguish "teach gated off" from "teach unconditionally executed".
+ */
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+function readMakefile(): string {
+	return readFileSync(join(repoRoot, "Makefile"), "utf8");
+}
+
+/**
+ * Extract a Make recipe body (the lines following `name:` up to the next
+ * target line or blank line followed by a new target). Returns just the
+ * recipe lines (tab-indented) joined by newlines.
+ */
+function extractRecipe(makefile: string, target: string): string {
+	const lines = makefile.split("\n");
+	const startIdx = lines.findIndex((line) => new RegExp(`^${target}\\s*:`).test(line));
+	if (startIdx === -1) return "";
+	const body: string[] = [];
+	for (let i = startIdx + 1; i < lines.length; i++) {
+		const line = lines[i];
+		if (line === undefined) break;
+		// Recipe lines must start with a tab. Anything else ends the recipe.
+		if (line === "") continue;
+		if (!line.startsWith("\t")) break;
+		body.push(line);
+	}
+	return body.join("\n");
+}
+
+describe("post-merge auto-setup hook (issue #92)", () => {
+	test("`setup-bump` target exists in the Makefile", () => {
+		const makefile = readMakefile();
+		expect(makefile).toMatch(/^setup-bump\s*:/m);
+	});
+
+	test("`setup-bump` recipe does NOT invoke `teach` (directly or via unguarded setup)", () => {
+		const makefile = readMakefile();
+		const recipe = extractRecipe(makefile, "setup-bump");
+		expect(recipe.length, "setup-bump recipe is empty").toBeGreaterThan(0);
+		// Direct teach call would be a bug.
+		expect(recipe).not.toMatch(/\bcli\.ts teach\b/);
+		// If it delegates to `setup` (recursive make), it must pass the skip flag.
+		if (/\$\(MAKE\)\s+setup\b/.test(recipe)) {
+			expect(recipe).toMatch(/SKILTREE_SKIP_TEACH\s*=\s*1/);
+		}
+	});
+
+	test("`setup` recipe still calls `teach` by default, but gates it on `SKILTREE_SKIP_TEACH`", () => {
+		const makefile = readMakefile();
+		const recipe = extractRecipe(makefile, "setup");
+		expect(recipe.length).toBeGreaterThan(0);
+		expect(recipe).toMatch(/\bcli\.ts teach\b/);
+		// The teach line must be guarded by SKILTREE_SKIP_TEACH so the bump-path
+		// invocation can opt out without skipping anything else.
+		const teachLine = recipe.split("\n").find((line) => /\bcli\.ts teach\b/.test(line));
+		expect(teachLine ?? "").toMatch(/SKILTREE_SKIP_TEACH/);
+	});
+
+	test("post-merge hook calls `make setup-bump`, not `make setup`", () => {
+		const config = readFileSync(join(repoRoot, ".pre-commit-config.yaml"), "utf8");
+		// Slice from the auto-setup-on-bump id down to the next `- id:` block
+		// (or end of file) — that's the recipe we care about.
+		const startMatch = config.match(/-\s*id:\s*auto-setup-on-bump\b/);
+		expect(
+			startMatch,
+			"auto-setup-on-bump hook not found in .pre-commit-config.yaml",
+		).not.toBeNull();
+		const start = startMatch?.index ?? 0;
+		const rest = config.slice(start + (startMatch?.[0].length ?? 0));
+		const nextHook = rest.search(/\n\s*-\s*id:\s*/);
+		const block = nextHook === -1 ? rest : rest.slice(0, nextHook);
+		// Narrow to the `entry:` line (the actual executable recipe) — block-level
+		// comments are allowed to mention `make setup` in prose, but the recipe
+		// itself must not invoke it.
+		const entryLine = block.split("\n").find((line) => line.trimStart().startsWith("entry:"));
+		expect(entryLine, "entry: line not found in hook block").toBeDefined();
+		expect(entryLine ?? "").toMatch(/\bmake\s+setup-bump\b/);
+		// The standalone token `make setup` (followed by a non-`-` character)
+		// must not appear in the bump-path recipe, or we've regressed.
+		expect(entryLine ?? "").not.toMatch(/\bmake\s+setup\b(?!-)/);
+	});
+});


### PR DESCRIPTION
## Why

The `auto-setup-on-bump` post-merge pre-commit hook runs `make setup` after every version bump, which in turn runs `skilltree teach` against the contributor's **personal** `~/.skilltree/global.yml`. If that manifest is temporarily unresolvable for any reason (network blip, upstream-removed dep, stale cache, breaking change in a transitively-pinned dep), `teach` exits non-zero → `make setup` exits non-zero → the hook reports failure. But the merge has already succeeded, so the contributor is left with the pre-bump binary at `~/.skilltree/bin/skilltree` and a failure buried in the merge scrollback that's easy to miss.

A bump merge to the skilltree repo should not depend on the contributor's personal global dep graph resolving — those are orthogonal concerns.

Closes #92

## What changed

- **`Makefile`**: gate the `teach` call in `setup` on a new `SKILTREE_SKIP_TEACH` variable. When set, `teach` is skipped and the "Skill →" status line shows `not refreshed` instead of `✔`. All other setup steps (build, binary copy, completions, PATH/footer guidance) run unchanged.
- **`Makefile`**: add a one-line `setup-bump` target that re-enters `setup` with `SKILTREE_SKIP_TEACH=1`. Used by the post-merge hook.
- **`.pre-commit-config.yaml`**: `auto-setup-on-bump` now calls `make setup-bump` instead of `make setup`. Echo text updated to match.
- **`tests/build/post-merge-hook.test.ts`**: new structural contract test — verifies the `setup-bump` target exists, doesn't invoke `teach` (directly or via unguarded recursive `setup`), and that the hook calls `setup-bump` not `setup`.

`make setup` still runs `teach` for contributors who deliberately want to refresh the global skill install — only the post-merge bump path opts out.

## How tested

- New test `tests/build/post-merge-hook.test.ts` (4 assertions) — initially red on `main`, green after the fix.
- Full suite: 1310 pass / 0 fail.
- Manual verification of recipe expansion:
  - `make -n setup` → `if [ -z "" ]; then ... teach ... fi` (teach runs)
  - `make -n setup-bump` → recurses to `make setup SKILTREE_SKIP_TEACH=1` → `if [ -z "1" ]; then ... fi` (teach skipped)

## Risk & rollback

Low. Touches one pre-commit hook entry and one Make recipe; both are dev-only tooling. Revert with `git revert <sha>` if needed — the prior behavior was a single `make setup` call from the hook, which this PR doesn't remove, only shadows.