### PR TITLE
refactor(ui): extract shared printTable helper for list/outdated

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,7 +2,7 @@ import { MANIFEST_NEW, manifestExists } from "../core/filenames.js";
 import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
-import { dim, pc } from "../core/ui.js";
+import { type ColumnDef, dim, pc, printTable } from "../core/ui.js";
 import type { Lockfile } from "../types.js";
 
 export interface ListOptions {
@@ -94,47 +94,29 @@ function buildRows(lockfile: Lockfile): ListRow[] {
 	});
 }
 
-function printGlobalTable(rows: ListRow[]): void {
-	const widths = {
-		name: Math.max(4, ...rows.map((r) => r.name.length)),
-		type: Math.max(4, ...rows.map((r) => r.type.length)),
-		version: Math.max(7, ...rows.map((r) => r.version.length)),
-		source: Math.max(6, ...rows.map((r) => r.source.length)),
-	};
+// Shared column definitions. `dim` and `pc.green` etc. read like CSS classes —
+// the helper applies them per data cell and leaves the header bold.
+const NAME_COL: ColumnDef<ListRow> = { header: "Name", value: (r) => r.name, color: pc.cyan };
+const TYPE_COL: ColumnDef<ListRow> = { header: "Type", value: (r) => r.type, color: dim };
+const VERSION_COL: ColumnDef<ListRow> = {
+	header: "Version",
+	value: (r) => r.version,
+	color: pc.green,
+};
+const SOURCE_COL: ColumnDef<ListRow> = { header: "Source", value: (r) => r.source, color: dim };
 
-	console.log(
-		pc.bold(
-			`${"Name".padEnd(widths.name)}  ${"Type".padEnd(widths.type)}  ${"Version".padEnd(widths.version)}  Source`,
-		),
-	);
-	console.log(dim("-".repeat(widths.name + widths.type + widths.version + widths.source + 6)));
-	for (const row of rows) {
-		console.log(
-			`${pc.cyan(row.name.padEnd(widths.name))}  ${dim(row.type.padEnd(widths.type))}  ${pc.green(row.version.padEnd(widths.version))}  ${dim(row.source)}`,
-		);
-	}
+function printGlobalTable(rows: ListRow[]): void {
+	printTable(rows, [NAME_COL, TYPE_COL, VERSION_COL, SOURCE_COL]);
 }
 
 async function printProjectTable(rows: ListRow[], dir: string, globalDir: string): Promise<void> {
-	const widths = {
-		name: Math.max(4, ...rows.map((r) => r.name.length)),
-		type: Math.max(4, ...rows.map((r) => r.type.length)),
-		group: Math.max(5, ...rows.map((r) => r.group.length)),
-		version: Math.max(7, ...rows.map((r) => r.version.length)),
-		source: Math.max(6, ...rows.map((r) => r.source.length)),
-	};
-
-	const hdr = `${"Name".padEnd(widths.name)}  ${"Type".padEnd(widths.type)}  ${"Group".padEnd(widths.group)}  ${"Version".padEnd(widths.version)}  Source`;
-
-	console.log(pc.bold(hdr));
-	console.log(
-		dim("-".repeat(widths.name + widths.type + widths.group + widths.version + widths.source + 8)),
-	);
-	for (const row of rows) {
-		console.log(
-			`${pc.cyan(row.name.padEnd(widths.name))}  ${dim(row.type.padEnd(widths.type))}  ${dim(row.group.padEnd(widths.group))}  ${pc.green(row.version.padEnd(widths.version))}  ${dim(row.source)}`,
-		);
-	}
+	printTable(rows, [
+		NAME_COL,
+		TYPE_COL,
+		{ header: "Group", value: (r) => r.group, color: dim },
+		VERSION_COL,
+		SOURCE_COL,
+	]);
 
 	// Vendor mode indicator
 	try {

--- a/src/commands/outdated.ts
+++ b/src/commands/outdated.ts
@@ -4,7 +4,7 @@ import { ensureCached, listTags } from "../core/git.js";
 import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { getGlobalDir } from "../core/paths.js";
 import { filterSemverTags } from "../core/resolver.js";
-import { dim, pc } from "../core/ui.js";
+import { type ColumnDef, dim, pc, printTable } from "../core/ui.js";
 import type { EntityType, LockfileEntry } from "../types.js";
 
 export interface OutdatedOptions {
@@ -83,7 +83,7 @@ export async function outdatedCommand(
 	if (opts?.json) {
 		console.log(JSON.stringify(rows, null, 2));
 	} else {
-		printTable(rows);
+		printOutdatedTable(rows);
 	}
 
 	if (opts?.check && rows.some((r) => r.bump !== null)) {
@@ -173,32 +173,31 @@ function classifyBump(current: string, latest: string): "major" | "minor" | "pat
 	return "patch";
 }
 
-function printTable(rows: OutdatedRow[]): void {
-	const display = rows.map((r) => ({
+/** Em-dash placeholder used in the human-facing table for null `latest`/`bump`. */
+const EMDASH = "—";
+
+interface DisplayRow {
+	name: string;
+	current: string;
+	latest: string;
+	bump: string;
+}
+
+const OUTDATED_COLUMNS: ColumnDef<DisplayRow>[] = [
+	{ header: "Name", value: (r) => r.name, color: pc.cyan },
+	{ header: "Current", value: (r) => r.current },
+	{ header: "Latest", value: (r) => r.latest, color: pc.green },
+	{ header: "Bump", value: (r) => r.bump, color: colorBump },
+];
+
+function printOutdatedTable(rows: OutdatedRow[]): void {
+	const display: DisplayRow[] = rows.map((r) => ({
 		name: r.name,
 		current: r.current,
-		latest: r.latest ?? "—",
-		bump: r.bump ?? "—",
+		latest: r.latest ?? EMDASH,
+		bump: r.bump ?? EMDASH,
 	}));
-
-	const widths = {
-		name: Math.max(4, ...display.map((r) => r.name.length)),
-		current: Math.max(7, ...display.map((r) => r.current.length)),
-		latest: Math.max(6, ...display.map((r) => r.latest.length)),
-		bump: Math.max(4, ...display.map((r) => r.bump.length)),
-	};
-
-	console.log(
-		pc.bold(
-			`${"Name".padEnd(widths.name)}  ${"Current".padEnd(widths.current)}  ${"Latest".padEnd(widths.latest)}  Bump`,
-		),
-	);
-	console.log(dim("-".repeat(widths.name + widths.current + widths.latest + widths.bump + 6)));
-	for (const row of display) {
-		console.log(
-			`${pc.cyan(row.name.padEnd(widths.name))}  ${row.current.padEnd(widths.current)}  ${pc.green(row.latest.padEnd(widths.latest))}  ${colorBump(row.bump)}`,
-		);
-	}
+	printTable(display, OUTDATED_COLUMNS);
 }
 
 function colorBump(bump: string): string {

--- a/src/core/ui.ts
+++ b/src/core/ui.ts
@@ -33,6 +33,76 @@ export const label = (msg: string) => pc.blue(msg);
 /** Naive English pluralizer: returns `word` for n=1, `${word}s` otherwise. */
 export const pluralize = (word: string, n: number): string => (n === 1 ? word : `${word}s`);
 
+/** Column gutter (2 spaces) between adjacent cells in printTable output. */
+const TABLE_GUTTER = "  ";
+
+/**
+ * Declarative column descriptor for {@link printTable}.
+ *
+ * - `value` extracts the string contents of the cell for a given row.
+ * - `color` optionally wraps each data cell (NOT the header) in a colorizer
+ *   like `pc.cyan` or our `dim` helper.
+ * - `minWidth` overrides the default minimum width (= `header.length`).
+ *   The actual rendered width is `max(minWidth ?? header.length, ...cellLens)`.
+ */
+export interface ColumnDef<T> {
+	header: string;
+	value: (row: T) => string;
+	color?: (cell: string) => string;
+	minWidth?: number;
+}
+
+/**
+ * Render a bold header, dim divider, and per-row cells for `rows` using the
+ * declarative `columns`. Centralizes the width/gutter logic that previously
+ * lived inline in `list` and `outdated` (issue #101).
+ *
+ * Conventions:
+ * - Columns are padded with `padEnd` to the same width across header and rows.
+ * - The trailing column is NOT padded — colors on the final cell wouldn't
+ *   benefit from trailing whitespace, matching the prior hand-written tables.
+ * - Divider length matches the visible header length (gutters included), so
+ *   the underline lines up regardless of column count.
+ * - Empty `rows` still prints the header + divider (callers should short-
+ *   circuit earlier with a friendlier "no deps" message when appropriate).
+ */
+export function printTable<T>(rows: T[], columns: ColumnDef<T>[]): void {
+	if (columns.length === 0) return;
+
+	// Pre-extract cell strings once so we don't call `value(row)` twice.
+	const cells: string[][] = rows.map((r) => columns.map((c) => c.value(r)));
+
+	const widths = columns.map((col, i) => {
+		const min = col.minWidth ?? col.header.length;
+		let max = min;
+		for (const row of cells) {
+			const len = row[i]?.length ?? 0;
+			if (len > max) max = len;
+		}
+		return max;
+	});
+
+	const lastIdx = columns.length - 1;
+	const headerLine = columns
+		.map((col, i) => (i === lastIdx ? col.header : col.header.padEnd(widths[i] ?? 0)))
+		.join(TABLE_GUTTER);
+	console.log(pc.bold(headerLine));
+
+	const totalWidth = widths.reduce((a, b) => a + b, 0) + TABLE_GUTTER.length * lastIdx;
+	console.log(dim("-".repeat(totalWidth)));
+
+	for (const row of cells) {
+		const line = row
+			.map((cell, i) => {
+				const padded = i === lastIdx ? cell : cell.padEnd(widths[i] ?? 0);
+				const color = columns[i]?.color;
+				return color ? color(padded) : padded;
+			})
+			.join(TABLE_GUTTER);
+		console.log(line);
+	}
+}
+
 /**
  * Print resolution warnings and throw if errors exist.
  * Used by install, installGlobal, and vendor commands.

--- a/tests/core/ui.test.ts
+++ b/tests/core/ui.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { printTable } from "../../src/core/ui.js";
+
+function captureConsole(): { logs: string[]; restore: () => void } {
+	const logs: string[] = [];
+	const original = console.log;
+	console.log = (...args: unknown[]) => logs.push(args.join(" "));
+	return { logs, restore: () => (console.log = original) };
+}
+
+// Strip ANSI color codes for content assertions; we test colorization
+// separately by inspecting the raw string.
+function stripAnsi(s: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape
+	return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+interface Row {
+	name: string;
+	version: string;
+}
+
+let cap: ReturnType<typeof captureConsole>;
+beforeEach(() => {
+	cap = captureConsole();
+});
+afterEach(() => {
+	cap.restore();
+});
+
+describe("printTable", () => {
+	test("prints header, divider, then one line per row", () => {
+		const rows: Row[] = [
+			{ name: "alpha", version: "1.0.0" },
+			{ name: "beta", version: "2.1.3" },
+		];
+		printTable(rows, [
+			{ header: "Name", value: (r) => r.name },
+			{ header: "Version", value: (r) => r.version },
+		]);
+
+		expect(cap.logs.length).toBe(4); // header + divider + 2 rows
+		const plain = cap.logs.map(stripAnsi);
+		expect(plain[0]).toContain("Name");
+		expect(plain[0]).toContain("Version");
+		expect(plain[1]).toMatch(/^-+$/);
+		expect(plain[2]).toContain("alpha");
+		expect(plain[2]).toContain("1.0.0");
+		expect(plain[3]).toContain("beta");
+		expect(plain[3]).toContain("2.1.3");
+	});
+
+	test("column width grows to fit longest cell", () => {
+		const rows: Row[] = [
+			{ name: "a", version: "1.0.0" },
+			{ name: "the-longest-name-here", version: "1.0.0" },
+		];
+		printTable(rows, [
+			{ header: "Name", value: (r) => r.name },
+			{ header: "Version", value: (r) => r.version },
+		]);
+		const plain = cap.logs.map(stripAnsi);
+		// Header should reserve at least as many chars for Name as the longest cell
+		expect(plain[0]).toMatch(/Name {18,}/); // 4-char "Name" + ≥17 trailing spaces to reach 21 wide
+		// Divider length covers the full header width
+		const headerLen = plain[0]?.length ?? 0;
+		expect(plain[1]?.length ?? -1).toBe(headerLen);
+	});
+
+	test("header length is the natural minimum width", () => {
+		const rows: Row[] = [{ name: "a", version: "1" }];
+		printTable(rows, [
+			{ header: "Version", value: (r) => r.version },
+			{ header: "Name", value: (r) => r.name },
+		]);
+		const plain = cap.logs.map(stripAnsi);
+		// "Version" is 7 chars — first column reserves at least 7, even though
+		// its data cell is only 1 char long. Last column ("Name") is not padded.
+		expect(plain[2]).toMatch(/^1 {6} {2}a$/);
+	});
+
+	test("custom minWidth overrides header length when larger", () => {
+		const rows: Row[] = [{ name: "a", version: "1" }];
+		printTable(rows, [
+			{ header: "N", value: (r) => r.name, minWidth: 10 },
+			{ header: "V", value: (r) => r.version },
+		]);
+		const plain = cap.logs.map(stripAnsi);
+		// First column should be padded to 10 chars wide.
+		expect(plain[0]).toMatch(/^N {9} {2}V$/);
+		expect(plain[2]).toMatch(/^a {9} {2}1$/);
+	});
+
+	test("empty rows still prints header + divider, no data lines", () => {
+		printTable<Row>(
+			[],
+			[
+				{ header: "Name", value: (r) => r.name },
+				{ header: "Version", value: (r) => r.version },
+			],
+		);
+		expect(cap.logs.length).toBe(2);
+		const plain = cap.logs.map(stripAnsi);
+		expect(plain[0]).toContain("Name");
+		expect(plain[0]).toContain("Version");
+		expect(plain[1]).toMatch(/^-+$/);
+	});
+
+	test("all-empty column collapses to header width", () => {
+		const rows = [
+			{ name: "alpha", note: "" },
+			{ name: "beta", note: "" },
+		];
+		printTable(rows, [
+			{ header: "Name", value: (r) => r.name },
+			{ header: "Note", value: (r) => r.note },
+		]);
+		const plain = cap.logs.map(stripAnsi);
+		// "Note" is last column; last column is unpadded. Row line should
+		// end at the gutter after the "Name" column with no trailing junk.
+		expect(plain[2]).toMatch(/^alpha {2}$/);
+		expect(plain[3]).toMatch(/^beta {3}$/); // "beta" padded to width 5 ("alpha")
+	});
+
+	test("colorizer wraps data cells but not header", () => {
+		const rows: Row[] = [{ name: "alpha", version: "1.0.0" }];
+		const tag = "<<C>>";
+		printTable(rows, [
+			{ header: "Name", value: (r) => r.name, color: (s) => `${tag}${s}${tag}` },
+			{ header: "Version", value: (r) => r.version },
+		]);
+		// Header line must NOT contain the colorizer marker
+		expect(cap.logs[0]).not.toContain(tag);
+		// Data row line MUST contain the marker around "alpha"
+		expect(cap.logs[2]).toContain(`${tag}alpha`);
+	});
+
+	test("divider width equals header line width (after stripping ANSI)", () => {
+		const rows: Row[] = [
+			{ name: "abc", version: "1.0.0" },
+			{ name: "defg", version: "2.0.0" },
+		];
+		printTable(rows, [
+			{ header: "Name", value: (r) => r.name },
+			{ header: "Version", value: (r) => r.version },
+		]);
+		const plain = cap.logs.map(stripAnsi);
+		// Divider matches header length (both pad the last column conceptually);
+		// data rows may be shorter because the trailing column is not padEnded.
+		expect(plain[1]?.length ?? -1).toBe(plain[0]?.length ?? 0);
+	});
+});


### PR DESCRIPTION
## Why

`src/commands/list.ts` and `src/commands/outdated.ts` had each inlined the same width-compute → bold-header → dim-divider → per-row-padEnd pattern. As more read-only inspection commands land (tracking #77), this would keep getting copy-pasted. Centralizing it now keeps future tables consistent.

Closes #101.

## What changed

- New `printTable<T>(rows, columns)` helper in `src/core/ui.ts` with a `ColumnDef<T>` interface — per-column `value` extractor, optional `color` colorizer, optional `minWidth` (defaults to `header.length`).
- `list.ts` global and project tables refactored to declare columns and call the helper.
- `outdated.ts` table refactored similarly (renamed the local function to `printOutdatedTable` to avoid shadowing the imported helper).
- New unit-test file `tests/core/ui.test.ts` covering: header + divider + rows, width-grows-to-fit-longest, header-as-natural-min-width, custom `minWidth`, empty rows, all-empty trailing column, colorizer scoping (data cells but not header), and divider-equals-header-width invariant.

## How tested

- `bun test` → all 1314 tests pass, including 8 new `printTable` tests and the unchanged `list*.test.ts` / `outdated.test.ts` suites.
- `tsc --noEmit` clean, `biome check` clean.
- Visual snapshot: ran a 3-row fixture through `listCommand` before and after the refactor with `NO_COLOR=1` — output is byte-identical (`diff` reports no differences).

## Risk & rollback

Low — pure refactor, visual output verified byte-identical, no public API change. Revert with `git revert <sha>` if anything surfaces downstream.