### PR TITLE
fix(graph-readers): resolve aliased entries in transitive walks

### DIFF
--- a/src/commands/deps.ts
+++ b/src/commands/deps.ts
@@ -1,4 +1,4 @@
-import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
+import { buildNameIndex, readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { readGlobalManifest, readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { dim, pc } from "../core/ui.js";
@@ -52,13 +52,17 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 
 	const dedupe = opts?.dedupe === true;
 
+	// Resolve transitive name → YAML key once per command (issue #102, see
+	// `buildNameIndex` in core/lockfile.ts).
+	const nameIndex = buildNameIndex(lockfile);
+
 	if (opts?.json) {
 		const printedJson = new Set<string>();
 		const tree: JsonTreeNode[] = [];
 		for (const root of roots) {
 			const entry = lockfile.packages[root];
 			if (!entry) continue;
-			tree.push(buildJsonTree(root, entry, lockfile, printedJson, true, dedupe));
+			tree.push(buildJsonTree(root, root, entry, lockfile, nameIndex, printedJson, true, dedupe));
 		}
 		console.log(JSON.stringify(tree, null, 2));
 		return;
@@ -69,27 +73,35 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 	for (const root of roots) {
 		const entry = lockfile.packages[root];
 		if (!entry) continue;
-		printTree(root, entry, lockfile, "", true, true, printed, dedupe);
+		printTree(root, root, entry, lockfile, nameIndex, "", true, true, printed, dedupe);
 	}
 }
 
+/**
+ * `displayName` is what the user wrote (YAML key for roots, frontmatter name
+ * for transitive references). `entryKey` is the canonical YAML key in
+ * `lockfile.packages` — the dedup tracker keys on it so the same entity
+ * reached under both an alias and its name is recognized as one (issue #102).
+ */
 function buildJsonTree(
-	name: string,
+	displayName: string,
+	entryKey: string,
 	entry: LockfileEntry,
 	lockfile: Lockfile,
+	nameIndex: Map<string, string>,
 	printed: Set<string>,
 	isRoot: boolean,
 	dedupe: boolean,
 ): JsonTreeNode {
 	const node: JsonTreeNode = {
-		name,
+		name: displayName,
 		type: entry.type,
 		dependencies: [],
 	};
 	if (entry.version) node.version = entry.version;
 	if (entry.source) node.source = entry.source;
 
-	const alreadyPrinted = printed.has(name);
+	const alreadyPrinted = printed.has(entryKey);
 	// Top-level entries are direct project deps; never mark them deduped
 	// regardless of whether they were already printed transitively.
 	if (alreadyPrinted && !isRoot) {
@@ -98,18 +110,26 @@ function buildJsonTree(
 		// recursing so each subtree is structurally complete.
 		if (dedupe) return node;
 	}
-	printed.add(name);
+	printed.add(entryKey);
 
 	for (const depName of entry.dependencies) {
-		const depEntry = lockfile.packages[depName];
+		const depKey = nameIndex.get(depName);
+		if (!depKey) continue;
+		const depEntry = lockfile.packages[depKey];
 		if (!depEntry) continue;
-		node.dependencies.push(buildJsonTree(depName, depEntry, lockfile, printed, false, dedupe));
+		// Render the child under the name the parent's frontmatter used,
+		// not its YAML alias — matches the mental model of "this skill needs
+		// this other skill."
+		node.dependencies.push(
+			buildJsonTree(depName, depKey, depEntry, lockfile, nameIndex, printed, false, dedupe),
+		);
 	}
 	return node;
 }
 
 function printTree(
-	name: string,
+	displayName: string,
+	entryKey: string,
 	entry: { type: string; version?: string; source?: string; dependencies: string[] },
 	lockfile: {
 		packages: Record<
@@ -117,6 +137,7 @@ function printTree(
 			{ type: string; version?: string; source?: string; dependencies: string[] }
 		>;
 	},
+	nameIndex: Map<string, string>,
 	prefix: string,
 	isRoot: boolean,
 	isLast: boolean,
@@ -126,34 +147,38 @@ function printTree(
 	const connector = isRoot ? "" : isLast ? "└── " : "├── ";
 	const version = entry.version ? `@${entry.version}` : "";
 	const source = entry.source === "local" ? "local" : "";
-	const alreadyPrinted = printed.has(name);
+	const alreadyPrinted = printed.has(entryKey);
 
 	if (alreadyPrinted && !isRoot && dedupe) {
-		console.log(`${prefix}${connector}${dim(`${name} (${entry.type}, ${DEDUPED_LABEL})`)}`);
+		console.log(`${prefix}${connector}${dim(`${displayName} (${entry.type}, ${DEDUPED_LABEL})`)}`);
 		return;
 	}
 
 	// Top-level entries (isRoot) are canonical project declarations and never
-	// carry the (*) marker, even if their name was already printed transitively
+	// carry the (*) marker, even if they were already printed transitively
 	// in an earlier root's subtree. The marker only signals "this transitive
 	// occurrence has been shown above; nothing new will appear below."
 	const marker = alreadyPrinted && !isRoot ? ` ${dim(DUPLICATE_MARKER)}` : "";
 	console.log(
-		`${prefix}${connector}${pc.cyan(name)}${version ? pc.green(version) : ""} ${dim(`(${entry.type}${source ? `, ${source}` : ""})`)}${marker}`,
+		`${prefix}${connector}${pc.cyan(displayName)}${version ? pc.green(version) : ""} ${dim(`(${entry.type}${source ? `, ${source}` : ""})`)}${marker}`,
 	);
-	printed.add(name);
+	printed.add(entryKey);
 
 	const deps = entry.dependencies;
 	for (let i = 0; i < deps.length; i++) {
 		const depName = deps[i];
 		if (!depName) continue;
-		const depEntry = lockfile.packages[depName];
+		const depKey = nameIndex.get(depName);
+		if (!depKey) continue;
+		const depEntry = lockfile.packages[depKey];
 		if (!depEntry) continue;
 		const childPrefix = isRoot ? "" : prefix + (isLast ? "    " : "│   ");
 		printTree(
 			depName,
+			depKey,
 			depEntry,
 			lockfile,
+			nameIndex,
 			childPrefix,
 			false,
 			i === deps.length - 1,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -19,6 +19,7 @@ import {
 } from "../core/installer.js";
 import {
 	buildLockfile,
+	buildNameIndex,
 	diffManifestLockfile,
 	entitiesFromLockfile,
 	readGlobalLockfile,
@@ -538,12 +539,11 @@ function validateFrozenLocalDeps(
 	const expanded = expandSources(manifest);
 	const allDeps = { ...expanded.dependencies, ...expanded["dev-dependencies"] };
 	const errors: string[] = [];
-	const resolutionContext = new Map<string, string>();
 
-	// Build context for checking
-	for (const [key] of Object.entries(lockfile.packages)) {
-		resolutionContext.set(key, key);
-	}
+	// Frontmatter references entities by name; the lockfile is keyed by
+	// YAML alias. `nameIndex.has(dep)` resolves either form (see
+	// `buildNameIndex`).
+	const nameIndex = buildNameIndex(lockfile);
 
 	for (const [key, entry] of Object.entries(lockfile.packages)) {
 		const manifestDep = allDeps[key];
@@ -562,7 +562,7 @@ function validateFrozenLocalDeps(
 			const fmDeps = (fm ? getDeclaredDeps(fm) : []).filter((d) => d !== (entry.name ?? key));
 
 			for (const dep of fmDeps) {
-				if (!lockfile.packages[dep] && !resolutionContext.has(dep)) {
+				if (!nameIndex.has(dep)) {
 					errors.push(
 						`--frozen: local dep "${key}" declares new transitive dependency "${dep}" not in lockfile.\nRun \`skilltree install\` to update the lockfile.`,
 					);

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline";
 import { GLOBAL_MANIFEST, MANIFEST_NEW } from "../core/filenames.js";
 import { getTargetPath } from "../core/installer.js";
 import {
+	buildNameIndex,
 	readGlobalLockfile,
 	readLockfile,
 	writeGlobalLockfile,
@@ -278,11 +279,15 @@ async function cleanOrphans(
 }
 
 function findDependents(name: string, lockfile: Lockfile): string[] {
+	// `name` is the YAML key the user is removing. `entry.dependencies`
+	// contains entity NAMES (frontmatter), so a raw `.includes(name)` misses
+	// aliased entries. Translate via the name index so the check matches
+	// whether a sibling references the target by either form (issue #102).
+	const nameIndex = buildNameIndex(lockfile);
 	const dependents: string[] = [];
 	for (const [key, entry] of Object.entries(lockfile.packages)) {
-		if (entry.dependencies.includes(name)) {
-			dependents.push(key);
-		}
+		const referencesTarget = entry.dependencies.some((dep) => nameIndex.get(dep) === name);
+		if (referencesTarget) dependents.push(key);
 	}
 	return dependents;
 }
@@ -306,16 +311,21 @@ function findOrphans(
 	]);
 	if (exclude) manifestKeys.delete(exclude);
 
+	// Walk children by YAML key so aliased entries stay reachable. Without
+	// the translation, `walk("python-coding")` for an entry keyed `pc`
+	// silently failed to mark `pc` reachable and the sweeper deleted it
+	// (issue #102).
+	const nameIndex = buildNameIndex(lockfile);
 	const reachable = new Set<string>();
 
 	function walk(key: string): void {
 		if (reachable.has(key)) return;
 		reachable.add(key);
 		const entry = lockfile.packages[key];
-		if (entry) {
-			for (const dep of entry.dependencies) {
-				walk(dep);
-			}
+		if (!entry) return;
+		for (const dep of entry.dependencies) {
+			const depKey = nameIndex.get(dep);
+			if (depKey !== undefined) walk(depKey);
 		}
 	}
 

--- a/src/commands/why.ts
+++ b/src/commands/why.ts
@@ -1,4 +1,4 @@
-import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
+import { buildNameIndex, readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { readGlobalManifest, readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { dim, pc } from "../core/ui.js";
@@ -85,10 +85,7 @@ export async function whyCommand(target: string, opts?: WhyOptions): Promise<voi
 		return undefined;
 	};
 
-	// 3. Build reverse adjacency: child name → set of parent keys.
-	//    Mirrors `deps tree`: entries' `dependencies` lists are looked up
-	//    directly against `lockfile.packages` (works when YAML key == name,
-	//    the common case).
+	// 3. Build reverse adjacency: child YAML key → set of parent YAML keys.
 	const parentsOf = buildReverseAdjacency(lockfile);
 
 	// 4. Walk upward from the target, recording every path that ends at a
@@ -133,16 +130,19 @@ function findMatches(
 }
 
 function buildReverseAdjacency(lockfile: Lockfile): Map<string, Set<string>> {
+	// Translate child references (entity names) → YAML keys so the upward
+	// walk's keys line up with the matched target's YAML key. See
+	// `buildNameIndex` for the underlying alias-vs-name issue.
+	const nameIndex = buildNameIndex(lockfile);
 	const parentsOf = new Map<string, Set<string>>();
 	for (const [parentKey, entry] of Object.entries(lockfile.packages)) {
 		for (const childName of entry.dependencies) {
-			// childName references either a YAML key or a name. We index by the
-			// raw string used in the dependencies array — the reverse lookup
-			// will match what callers ask for (their target key).
-			let parents = parentsOf.get(childName);
+			const childKey = nameIndex.get(childName);
+			if (childKey === undefined) continue; // dangling reference; skip silently
+			let parents = parentsOf.get(childKey);
 			if (!parents) {
 				parents = new Set();
-				parentsOf.set(childName, parents);
+				parentsOf.set(childKey, parents);
 			}
 			parents.add(parentKey);
 		}

--- a/src/core/lockfile.ts
+++ b/src/core/lockfile.ts
@@ -64,6 +64,37 @@ export function buildLockfile(
 }
 
 /**
+ * Build a `name → YAML key` index for a lockfile.
+ *
+ * Background (issue #102): `LockfileEntry.dependencies` is a list of entity
+ * **names** (read from frontmatter), but `lockfile.packages` is keyed by the
+ * **YAML alias** the user authored. Whenever a graph reader walks
+ * `entry.dependencies` and needs the corresponding entry, it must translate
+ * name → key first. In the common case (alias == name) the translation is
+ * identity; when the user aliased the entry (e.g. `pc:` with `name:
+ * python-coding`), the raw `packages[depName]` lookup silently misses.
+ *
+ * The index includes identity entries (`key → key`) for every package so
+ * callers can `index.get(ref) ?? ref` uniformly, regardless of whether the
+ * reference they hold is a name or a key.
+ *
+ * Type-level disambiguation (two entries sharing a name across types) is out
+ * of scope: lockfile `dependencies` lists are plain strings with no type
+ * tag, so the last write wins — matching the install-time resolver's own
+ * "last-one-wins" name resolution (see `useExistingResolution` in graph.ts).
+ */
+export function buildNameIndex(lockfile: Lockfile): Map<string, string> {
+	const index = new Map<string, string>();
+	for (const [key, entry] of Object.entries(lockfile.packages)) {
+		index.set(key, key);
+		if (entry.name !== undefined && entry.name !== key) {
+			index.set(entry.name, key);
+		}
+	}
+	return index;
+}
+
+/**
  * Serialize a lockfile to YAML string.
  */
 export function serializeLockfile(lockfile: Lockfile): string {
@@ -106,40 +137,46 @@ function assertAcyclic(lockfile: Lockfile): void {
 	const GREY = 1;
 	const BLACK = 2;
 	const color = new Map<string, number>();
-	for (const name of Object.keys(lockfile.packages)) color.set(name, WHITE);
+	for (const key of Object.keys(lockfile.packages)) color.set(key, WHITE);
+
+	// Resolve child references (entity names) → YAML keys so cycles routed
+	// through aliased entries are still caught. See `buildNameIndex`.
+	const nameIndex = buildNameIndex(lockfile);
 
 	// Iterative DFS to keep stack depth bounded on deep graphs.
 	for (const start of color.keys()) {
 		if (color.get(start) !== WHITE) continue;
-		// Each frame: [name, indexOfNextChildToVisit]
+		// Each frame: [yamlKey, indexOfNextChildToVisit]
 		const stack: Array<[string, number]> = [[start, 0]];
 		color.set(start, GREY);
 		while (stack.length > 0) {
 			const top = stack[stack.length - 1];
 			if (!top) break;
-			const [name, idx] = top;
-			const deps = lockfile.packages[name]?.dependencies ?? [];
+			const [key, idx] = top;
+			const deps = lockfile.packages[key]?.dependencies ?? [];
 			if (idx >= deps.length) {
-				color.set(name, BLACK);
+				color.set(key, BLACK);
 				stack.pop();
 				continue;
 			}
 			top[1] = idx + 1;
-			const child = deps[idx];
-			if (!child || !lockfile.packages[child]) continue;
-			const c = color.get(child);
+			const childRef = deps[idx];
+			if (!childRef) continue;
+			const childKey = nameIndex.get(childRef);
+			if (!childKey) continue;
+			const c = color.get(childKey);
 			if (c === GREY) {
 				const cycle = [
-					...stack.map(([n]) => n).slice(stack.findIndex(([n]) => n === child)),
-					child,
+					...stack.map(([n]) => n).slice(stack.findIndex(([n]) => n === childKey)),
+					childKey,
 				];
 				throw new Error(
 					`Lockfile is corrupt: dependency cycle detected: ${cycle.join(" → ")}. The resolver rejects cycles, so this lockfile was hand-edited or written by an incompatible tool. Run 'skilltree install' to regenerate.`,
 				);
 			}
 			if (c === WHITE) {
-				color.set(child, GREY);
-				stack.push([child, 0]);
+				color.set(childKey, GREY);
+				stack.push([childKey, 0]);
 			}
 		}
 	}
@@ -306,6 +343,9 @@ function isReachableFromManifest(
 	lockfile: Lockfile,
 	manifestKeys: Set<string>,
 ): boolean {
+	// `entry.dependencies` references children by name; resolve to YAML keys
+	// via the name index. See `buildNameIndex`.
+	const nameIndex = buildNameIndex(lockfile);
 	const visited = new Set<string>();
 
 	function walk(key: string): boolean {
@@ -314,7 +354,10 @@ function isReachableFromManifest(
 		if (key === target) return true;
 		const entry = lockfile.packages[key];
 		if (!entry) return false;
-		return entry.dependencies.some((dep) => walk(dep));
+		return entry.dependencies.some((dep) => {
+			const depKey = nameIndex.get(dep);
+			return depKey !== undefined && walk(depKey);
+		});
 	}
 
 	for (const mk of manifestKeys) {

--- a/tests/commands/deps-tree.test.ts
+++ b/tests/commands/deps-tree.test.ts
@@ -448,4 +448,116 @@ describe("deps tree rendering", () => {
 		expect(lines[3]).toBe("└── branch-b (skill, local)");
 		expect(lines[4]).toBe("    └── leaf-b (skill, local)");
 	});
+
+	// Regression: issue #102. When a top-level dep is aliased (YAML key ≠ entity
+	// name), transitive references to its name from a sibling's frontmatter must
+	// still resolve. The lockfile keys by YAML alias, but `entry.dependencies`
+	// holds entity names — so a naive `packages[depName]` lookup misses the
+	// aliased entry and silently truncates the subtree.
+	test("transitive lookup resolves aliased YAML keys (issue #102)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		// `pc` is the YAML alias; the entity name is `python-coding`.
+		// task-builder's frontmatter references `python-coding` (the name),
+		// so the transitive edge from task-builder must resolve to `pc`'s entry.
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => depsTreeCommand(dir));
+
+		// task-builder must show python-coding as a transitive child, not be a
+		// leaf. With the bug, lines for task-builder's subtree would end here.
+		const taskBuilderIdx = lines.findIndex((l) => l.startsWith("task-builder"));
+		expect(taskBuilderIdx).toBeGreaterThanOrEqual(0);
+		const childLine = lines[taskBuilderIdx + 1];
+		expect(childLine).toBeDefined();
+		expect(childLine).toMatch(/└── python-coding/);
+	});
+
+	// Same alias bug, second symptom: when an aliased entry is reachable
+	// both as a root (under its YAML key) and as a transitive (under its
+	// entity name), the dedup tracker treats them as two different entities
+	// because it keys on the rendered string. `--dedupe` must still suppress
+	// the second occurrence (issue #102).
+	test("--dedupe suppresses transitive duplicate of an aliased root (issue #102)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => depsTreeCommand(dir, { dedupe: true }));
+		// `pc` is rendered as a canonical root. Under task-builder's subtree,
+		// the same entity (referenced by its name `python-coding`) must be
+		// suppressed with a `deduped` marker — not rendered as a fresh entry.
+		const taskBuilderIdx = lines.findIndex((l) => l.startsWith("task-builder"));
+		const childLine = lines[taskBuilderIdx + 1];
+		expect(childLine).toBeDefined();
+		// The dedup label proves the dedup tracker recognized this as the
+		// same entity it already printed under the YAML key alias.
+		expect(childLine).toContain("deduped");
+	});
+
+	test("json: transitive lookup resolves aliased YAML keys (issue #102)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const jsonLines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => jsonLines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+		const tree = JSON.parse(jsonLines.join("\n")) as Array<{
+			name: string;
+			dependencies: Array<{ name: string }>;
+		}>;
+		const taskBuilder = tree.find((n) => n.name === "task-builder");
+		expect(taskBuilder).toBeDefined();
+		// python-coding must surface as a child even though it's stored under
+		// the YAML key `pc`.
+		expect(taskBuilder?.dependencies.map((d) => d.name)).toContain("python-coding");
+	});
 });

--- a/tests/commands/remove.test.ts
+++ b/tests/commands/remove.test.ts
@@ -373,4 +373,50 @@ describe("removeCommand", () => {
 		await expect(stat(join(installBase, "skills", "parent"))).rejects.toThrow();
 		await expect(stat(join(installBase, "skills", "child"))).rejects.toThrow();
 	});
+
+	// Regression: issue #102. Orphan detection walks `entry.dependencies`
+	// (entity names) but indexes by `lockfile.packages[key]` (YAML alias).
+	// When a transitive child is aliased, the walk fails to mark it reachable
+	// and the orphan sweeper silently deletes a still-needed entry.
+	test("does not orphan an aliased transitive that's kept alive only by a sibling root (issue #102)", async () => {
+		const dir = await setup();
+		await addCommand("unrelated", { repo: "github.com/user/repo", path: "skills/unrelated" }, dir);
+		// `pc` is NOT in the manifest — it's a pure transitive of task-builder,
+		// reachable only via the entity name `python-coding`. This is exactly
+		// the case where the orphan-walk's name-vs-key lookup goes wrong.
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			[
+				"dependencies:",
+				"  unrelated:",
+				"    repo: github.com/user/repo",
+				"    path: skills/unrelated",
+				"  task-builder:",
+				"    repo: github.com/user/repo",
+				"    path: skills/task-builder",
+				"",
+			].join("\n"),
+		);
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			[
+				"lockfile_version: 1",
+				"packages:",
+				"  unrelated: {type: skill, group: prod, repo: github.com/user/repo, path: skills/unrelated, version: 1.0.0, commit: abc, dependencies: []}",
+				"  pc: {type: skill, group: prod, repo: github.com/user/repo, path: skills/pc, version: 1.0.0, commit: abc, name: python-coding, dependencies: []}",
+				"  task-builder: {type: skill, group: prod, repo: github.com/user/repo, path: skills/task-builder, version: 1.0.0, commit: abc, dependencies: [python-coding]}",
+				"",
+			].join("\n"),
+		);
+
+		// Remove the unrelated dep. `pc` is still kept alive by `task-builder`
+		// (transitively, via the name `python-coding`). It must NOT be swept
+		// as an orphan.
+		await removeCommand("unrelated", dir, { force: true });
+
+		const lockfile = await readLockfile(dir);
+		expect(lockfile?.packages.pc).toBeDefined();
+		expect(lockfile?.packages["task-builder"]).toBeDefined();
+		expect(lockfile?.packages.unrelated).toBeUndefined();
+	});
 });

--- a/tests/commands/why.test.ts
+++ b/tests/commands/why.test.ts
@@ -210,6 +210,43 @@ describe("why command", () => {
 		expect(firstPath[0].group).toBe("dependencies");
 	});
 
+	// Regression: issue #102. The reverse-adjacency map is keyed by the names
+	// found in `entry.dependencies`, but the matched target's key is the YAML
+	// alias. When alias ≠ name, those keys don't line up and incoming edges to
+	// the aliased target are silently lost.
+	test("finds aliased target when reached transitively (issue #102)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		// `pc` is the alias; entity name is `python-coding`. task-builder pulls
+		// in python-coding by name. `why python-coding` must trace back to
+		// task-builder via the aliased entry.
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => whyCommand("python-coding", { dir, json: true }));
+		const out = JSON.parse(lines.join("\n")) as {
+			name: string;
+			paths: Array<Array<{ name: string }>>;
+		};
+		// task-builder must appear as a root of some path even though pc is the
+		// matched YAML key.
+		expect(out.paths.length).toBeGreaterThanOrEqual(1);
+		expect(out.paths.some((p) => p[0]?.name === "task-builder")).toBe(true);
+	});
+
 	test("--json shape: target IS a top-level dep", async () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "solo");

--- a/tests/core/lockfile.test.ts
+++ b/tests/core/lockfile.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { ResolvedEntity } from "../../src/core/graph.js";
-import { buildLockfile, parseLockfile, serializeLockfile } from "../../src/core/lockfile.js";
+import {
+	buildLockfile,
+	buildNameIndex,
+	parseLockfile,
+	serializeLockfile,
+} from "../../src/core/lockfile.js";
+import type { Lockfile } from "../../src/types.js";
 
 describe("buildLockfile", () => {
 	test("builds lockfile from resolved entities", () => {
@@ -150,5 +156,109 @@ describe("parseLockfile", () => {
 			"",
 		].join("\n");
 		expect(() => parseLockfile(selfCycle)).toThrow(/cycle detected.*a → a/);
+	});
+
+	// Issue #102: cycles routed through aliased entries (alias ≠ name) must
+	// still be caught. Before the fix, `assertAcyclic` looked up children via
+	// raw `packages[childRef]` and missed alias-targeted edges entirely.
+	test("rejects a dependency cycle routed through an aliased entry (issue #102)", () => {
+		const cyclic = [
+			"lockfile_version: 1",
+			"packages:",
+			"  pc: {type: skill, group: prod, source: local, path: ./pc, commit: HEAD,",
+			"       name: python-coding, dependencies: [task-builder]}",
+			"  task-builder: {type: skill, group: prod, source: local, path: ./tb,",
+			"                 commit: HEAD, dependencies: [python-coding]}",
+			"",
+		].join("\n");
+		expect(() => parseLockfile(cyclic)).toThrow(/cycle detected/);
+	});
+});
+
+describe("buildNameIndex (issue #102)", () => {
+	function fixture(entries: ReadonlyArray<{ key: string; name?: string }>): Lockfile {
+		const packages: Lockfile["packages"] = {};
+		for (const { key, name } of entries) {
+			packages[key] = {
+				type: "skill",
+				group: "prod",
+				path: `./${key}`,
+				commit: "HEAD",
+				dependencies: [],
+				...(name !== undefined ? { name } : {}),
+			};
+		}
+		return { lockfile_version: 1, packages };
+	}
+
+	// Parametrized: a single helper, many shape variants — when a new edge
+	// case shows up, add a row, get the coverage in one place. (CLAUDE.md
+	// hardening pattern #4.)
+	test.each([
+		// alias-only: name field absent → identity mapping
+		{ name: "no alias", entries: [{ key: "a" }], ref: "a", expectedKey: "a" },
+		// alias === name (explicitly): still identity, no second mapping
+		{ name: "alias equals name", entries: [{ key: "a", name: "a" }], ref: "a", expectedKey: "a" },
+		// classic alias: lookup by name resolves to the YAML key
+		{
+			name: "alias by name",
+			entries: [{ key: "pc", name: "python-coding" }],
+			ref: "python-coding",
+			expectedKey: "pc",
+		},
+		// classic alias: lookup by YAML key still resolves to itself
+		{
+			name: "alias by key",
+			entries: [{ key: "pc", name: "python-coding" }],
+			ref: "pc",
+			expectedKey: "pc",
+		},
+		// unknown ref: no match
+		{ name: "unknown ref", entries: [{ key: "a" }], ref: "ghost", expectedKey: undefined },
+	])("$name", ({ entries, ref, expectedKey }) => {
+		const lockfile = fixture(entries);
+		const index = buildNameIndex(lockfile);
+		if (expectedKey === undefined) {
+			expect(index.get(ref)).toBeUndefined();
+		} else {
+			expect(index.get(ref)).toBe(expectedKey);
+		}
+	});
+
+	// Disambiguation collisions across types fall back to last-one-wins
+	// (matches install-time `useExistingResolution` behavior). Document the
+	// contract explicitly so a future "fix" doesn't quietly change it.
+	test("collision: two entries share a name → last write wins", () => {
+		const lockfile: Lockfile = {
+			lockfile_version: 1,
+			packages: {
+				"foo-skill": {
+					type: "skill",
+					group: "prod",
+					path: "./fs",
+					commit: "HEAD",
+					name: "foo",
+					dependencies: [],
+				},
+				"foo-agent": {
+					type: "agent",
+					group: "prod",
+					path: "./fa",
+					commit: "HEAD",
+					name: "foo",
+					dependencies: [],
+				},
+			},
+		};
+		const index = buildNameIndex(lockfile);
+		// Whichever entry was iterated last wins; both YAML keys still
+		// resolve via identity. We don't assert which one wins (insertion
+		// order over Object.entries can change with future runtimes); we
+		// just assert the contract: name → some real key from the lockfile.
+		const winner = index.get("foo");
+		expect(winner).toBeDefined();
+		expect(["foo-skill", "foo-agent"]).toContain(winner as string);
+		expect(index.get("foo-skill")).toBe("foo-skill");
+		expect(index.get("foo-agent")).toBe("foo-agent");
 	});
 });


### PR DESCRIPTION
## Why

`LockfileEntry.dependencies` is a list of entity **names** (read from frontmatter), but `lockfile.packages` is keyed by the **YAML alias** the user authored. Several graph readers walked `entry.dependencies` and looked entries up directly in `packages`, which silently failed whenever an entry was aliased (`pc:` with `name: python-coding`). Symptoms ranged from truncated `deps tree` output to **silently deleted lockfile entries during `remove`**.

Closes #102

## What changed

- **New helper** `buildNameIndex(lockfile)` in `src/core/lockfile.ts` — maps every entity name AND every YAML key → canonical YAML key, so callers can resolve a `dependencies[]` reference (either form) with a single `.get(ref)`.
- **`deps tree`** (`src/commands/deps.ts`, text + json): transitive children of aliased entries no longer disappear. The dedup tracker now keys on canonical YAML key, so the same entity reached under both its alias and its name is recognized as one (`--dedupe` works correctly).
- **`why <name>`** (`src/commands/why.ts`): incoming edges to an aliased target now surface in the reverse walk.
- **`install --frozen`** (`src/commands/install.ts`): name-references in local frontmatter no longer trigger false "new transitive dependency" errors when the target is aliased.
- **`remove`** (`src/commands/remove.ts`): orphan sweeper no longer deletes aliased transitives whose reachability runs through a name reference (this was silent data loss); the dependents check matches references by name too.
- **`assertAcyclic` + `isReachableFromManifest`** (internal helpers in `src/core/lockfile.ts`): cycle detection and reachability walks now follow alias-targeted edges.

## How tested

- 4 new behavior regression tests across `deps-tree.test.ts`, `why.test.ts`, `remove.test.ts` covering the truncation, dedup, why-target, and orphan-deletion symptoms.
- 1 new parametrized unit test for `buildNameIndex` covering identity, alias-by-name, alias-by-key, no-alias, unknown-ref, and cross-type collision cases.
- 1 new `assertAcyclic` test confirming cycles through aliased entries are still caught.
- Full suite: 1318 pass, 0 fail.

## Risk & rollback

Low. The change is additive (one new helper) and the only behavioral shift is "things that were silently broken now work." Revert via \`git revert <sha>\` is safe — no data migration involved.