### PR TITLE
feat(projects): add `skilltree projects` read-only inspection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 | `skilltree remove <name>` | Remove a dependency |
 | `skilltree verify` | Check installed files against lockfile |
 | `skilltree list` | List installed dependencies |
+| `skilltree projects` | List skilltree-managed projects discoverable on this machine (read-only) |
 | `skilltree deps tree` | Show dependency tree |
 | `skilltree why <name>` | Reverse-lookup which top-level dep pulled in `<name>` |
 | `skilltree scan <paths...>` | Detect undeclared deps in skill body text |

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -109,6 +109,24 @@ skilltree outdated --global        # Inspect global deps
 
 **Output columns:** `Name`, `Current` (semver pin / `@<short-sha>` / `local`), `Latest` (latest semver tag on the resolved repo), `Bump` (`major` / `minor` / `patch` / `—`). Local deps and unresolved deps show `—`; a network/cache failure for a remote shows `error` in the Bump column.
 
+## `skilltree projects`
+
+Read-only inventory of skilltree-managed projects discoverable on this machine. Walks the filesystem from `--root` (default `$HOME`) and reports every directory that contains a `skilltree.yml` / `skilltree.yaml`. Counterpart to `skilltree list`, but cross-project — useful when you have many checkouts and want to know what's where.
+
+```bash
+skilltree projects                           # Walk $HOME
+skilltree projects --root ~/Projects         # Limit to a subtree
+skilltree projects --json                    # Machine-readable output
+```
+
+**Flags:**
+- `--root <path>` — Search root (default: `$HOME`)
+- `--json` — Output results as JSON
+
+**Output columns:** `Path`, `Deps` (count of `dependencies` + `dev-dependencies`), `Vendor` (`yes` if `vendor: true`), `Last install` (relative mtime of `skilltree.lock`, or `—` when no lockfile exists).
+
+**Discovery rules:** Skips `node_modules/`, `.git/`, `.skilltree/cache/`, `dist/`, `build/`, and hidden dirs (except `.claude/`). Stops descending once a manifest is found. Does not cross filesystem boundaries or follow symlink cycles. Unparseable manifests are skipped with a warning.
+
 ## `skilltree remove <name>`
 
 Remove a dependency from manifest, lockfile, and installed files.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { initCommand } from "./commands/init.js";
 import { installCommand } from "./commands/install.js";
 import { listCommand } from "./commands/list.js";
 import { outdatedCommand } from "./commands/outdated.js";
+import { projectsCommand } from "./commands/projects.js";
 import {
 	registryAddCommand,
 	registryInitCommand,
@@ -141,6 +142,18 @@ export function buildProgram(): Command {
 				json: opts.json,
 				check: opts.check,
 				global: opts.global,
+			});
+		});
+
+	program
+		.command("projects")
+		.description("List skilltree-managed projects discoverable on this machine (read-only)")
+		.option("--root <path>", "Search root (default: $HOME)")
+		.option("--json", "Output results as JSON")
+		.action(async (opts) => {
+			await projectsCommand({
+				root: opts.root,
+				json: opts.json,
 			});
 		});
 

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -116,6 +116,14 @@ const COMMANDS: CmdDef[] = [
 		],
 	},
 	{
+		name: "projects",
+		description: "List skilltree-managed projects discoverable on this machine (read-only)",
+		flags: [
+			{ long: "--root", description: "Search root (default: $HOME)" },
+			{ long: "--json", description: "Output results as JSON" },
+		],
+	},
+	{
 		name: "remove",
 		description: "Remove a dependency",
 		positionalComplete: "deps",

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,0 +1,296 @@
+import type { Dirent } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { LOCKFILE_NEW, MANIFEST_NEW, MANIFEST_NEW_ALT } from "../core/filenames.js";
+import { parseManifest } from "../core/manifest.js";
+import { collapseTilde } from "../core/paths.js";
+import { type ColumnDef, dim, pc, printTable, warn } from "../core/ui.js";
+
+/**
+ * `skilltree projects` — read-only inventory of skilltree-managed projects
+ * discoverable on this machine. See issue #81.
+ *
+ * Walks the filesystem from `--root` (default `$HOME`) and reports any
+ * directory that contains a manifest. Never writes; safe to run anytime.
+ */
+export interface ProjectsOptions {
+	root?: string;
+	json?: boolean;
+}
+
+export interface ProjectRow {
+	/** Absolute path to the project directory. */
+	path: string;
+	/** Absolute path to the manifest file that anchored the project. */
+	manifestPath: string;
+	/** Combined count of `dependencies` + `dev-dependencies`. */
+	deps: number;
+	/** True iff `vendor: true` in the manifest. */
+	vendor: boolean;
+	/** mtime of `skilltree.lock` as ISO-8601, or null when no lockfile. */
+	lastInstall: string | null;
+}
+
+// Directory names we never descend into. `.git` and `node_modules` dominate
+// real-world walk time; `dist`/`build` keep us out of generated trees that
+// occasionally contain copied manifests; `.skilltree/cache` would otherwise
+// surface cached registry repos as "projects" (they aren't).
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", "dist", "build"]);
+
+// Hidden directories (leading `.`) are skipped EXCEPT this allowlist.
+// `.claude` is where most skilltree projects live in practice, so dropping it
+// would make the command almost useless on a typical dev machine.
+const ALLOWED_HIDDEN_DIRS = new Set([".claude"]);
+
+// Path suffix (relative to root) that must be skipped. We can't catch it via
+// the name-only `SKIP_DIR_NAMES` set because `.skilltree` itself is fine to
+// descend (it might one day hold non-cache state) — only `.skilltree/cache`
+// is the dead end.
+const SKIP_REL_SUFFIXES = ["/.skilltree/cache"];
+
+/**
+ * Resolve `--root`, walk it, then render. The walker collects rows + a list
+ * of unparseable manifest paths so we can emit a single warning per path
+ * (the issue body asks for "a single dim warning per skipped path"); printing
+ * inside the walker would make ordering non-deterministic with concurrent
+ * `readdir` work.
+ */
+export async function projectsCommand(opts?: ProjectsOptions): Promise<void> {
+	const root = opts?.root ?? homedir();
+
+	const projects: ProjectRow[] = [];
+	const parseFailures: string[] = [];
+	// (dev,ino) of directories we've already entered — protects against
+	// symlink cycles (a -> b -> a) and the kind of hard-link weirdness that
+	// occasionally shows up on shared NFS mounts.
+	const visited = new Set<string>();
+
+	let rootDev: number | null = null;
+	try {
+		const rootStat = await stat(root);
+		rootDev = rootStat.dev;
+	} catch {
+		// Root doesn't exist or isn't accessible — render an empty result.
+		// Mirrors `find <missing>` exit behavior: print nothing, don't crash.
+		rootDev = null;
+	}
+
+	if (rootDev !== null) {
+		await walk(root, rootDev, projects, parseFailures, visited);
+	}
+
+	for (const path of parseFailures) {
+		warn(`Skipping unparseable manifest: ${path}`);
+	}
+
+	// Deterministic ordering — keep table + JSON output stable across runs
+	// regardless of filesystem traversal order.
+	projects.sort((a, b) => a.path.localeCompare(b.path));
+
+	if (opts?.json) {
+		console.log(JSON.stringify(projects, null, 2));
+		return;
+	}
+
+	if (projects.length === 0) {
+		console.log("No skilltree projects found.");
+		return;
+	}
+
+	printProjectsTable(projects);
+}
+
+/**
+ * Recursive walker. Stops descending into a directory once we've found a
+ * manifest there — nested manifests under a project are surprising in
+ * practice and would inflate output on monorepos. Matches the spec example
+ * (top-level project directories, not every manifest on disk).
+ */
+async function walk(
+	dir: string,
+	rootDev: number,
+	projects: ProjectRow[],
+	parseFailures: string[],
+	visited: Set<string>,
+): Promise<void> {
+	let dirStat: Awaited<ReturnType<typeof stat>>;
+	try {
+		dirStat = await stat(dir);
+	} catch {
+		return; // permission denied / vanished / etc.
+	}
+
+	// Cross-filesystem boundary check — `--root` pins the device; any nested
+	// mount (e.g. external drive, network share) is skipped per the spec.
+	if (dirStat.dev !== rootDev) return;
+
+	const key = `${dirStat.dev}:${dirStat.ino}`;
+	if (visited.has(key)) return;
+	visited.add(key);
+
+	// Is THIS directory itself a project? If so, record and stop recursing.
+	const manifestPath = await findManifest(dir);
+	if (manifestPath !== null) {
+		const row = await buildRow(dir, manifestPath);
+		if (row === null) {
+			parseFailures.push(manifestPath);
+		} else {
+			projects.push(row);
+		}
+		return;
+	}
+
+	let entries: Dirent[];
+	try {
+		entries = (await readdir(dir, { withFileTypes: true })) as Dirent[];
+	} catch {
+		return; // permission denied — skip silently
+	}
+
+	// Process subdirectories in parallel — most of the walk time is IO wait,
+	// and Node's libuv pool will serialize the actual syscalls anyway.
+	await Promise.all(
+		entries.map(async (entry) => {
+			if (!isDirCandidate(entry)) return;
+
+			const name = entry.name;
+			if (SKIP_DIR_NAMES.has(name)) return;
+			if (name.startsWith(".") && !ALLOWED_HIDDEN_DIRS.has(name)) return;
+
+			const fullPath = join(dir, name);
+			if (SKIP_REL_SUFFIXES.some((suffix) => fullPath.endsWith(suffix))) return;
+
+			await walk(fullPath, rootDev, projects, parseFailures, visited);
+		}),
+	);
+}
+
+/**
+ * Treat a dirent as a directory candidate if it's a directory OR a symlink
+ * (we resolve symlinks via the subsequent `stat()` in `walk`). `isDirectory`
+ * alone would miss symlinked project directories — common when users `ln -s`
+ * a worktree into a workspace folder.
+ */
+function isDirCandidate(entry: { isDirectory(): boolean; isSymbolicLink(): boolean }): boolean {
+	return entry.isDirectory() || entry.isSymbolicLink();
+}
+
+/**
+ * Look for both the canonical and legacy manifest names in `dir`. Returns
+ * the absolute path of whichever exists first (yml wins on tie — matches
+ * `resolveManifestPath`'s preference).
+ */
+async function findManifest(dir: string): Promise<string | null> {
+	for (const filename of [MANIFEST_NEW, MANIFEST_NEW_ALT]) {
+		const candidate = join(dir, filename);
+		try {
+			const s = await stat(candidate);
+			if (s.isFile()) return candidate;
+		} catch {
+			// Not present — try the next.
+		}
+	}
+	return null;
+}
+
+/**
+ * Read + parse a manifest into a row. Returns null on parse failure so the
+ * caller can record it for the consolidated warning pass — silently dropping
+ * unparseable manifests was rejected in the issue ("emit a single dim
+ * warning per skipped path").
+ */
+async function buildRow(projectDir: string, manifestPath: string): Promise<ProjectRow | null> {
+	let content: string;
+	try {
+		content = await readFile(manifestPath, "utf-8");
+	} catch {
+		return null;
+	}
+
+	let deps = 0;
+	let vendor = false;
+	try {
+		const manifest = parseManifest(content);
+		deps =
+			Object.keys(manifest.dependencies ?? {}).length +
+			Object.keys(manifest["dev-dependencies"] ?? {}).length;
+		vendor = manifest.vendor === true;
+	} catch {
+		return null;
+	}
+
+	const lockPath = join(projectDir, LOCKFILE_NEW);
+	let lastInstall: string | null = null;
+	try {
+		const lockStat = await stat(lockPath);
+		lastInstall = lockStat.mtime.toISOString();
+	} catch {
+		// No lockfile — leave null. Common for freshly-init'd projects that
+		// haven't run `skilltree install` yet.
+	}
+
+	return {
+		path: projectDir,
+		manifestPath,
+		deps,
+		vendor,
+		lastInstall,
+	};
+}
+
+interface DisplayRow {
+	path: string;
+	deps: string;
+	vendor: string;
+	lastInstall: string;
+}
+
+const PROJECT_COLUMNS: ColumnDef<DisplayRow>[] = [
+	{ header: "Path", value: (r) => r.path, color: pc.cyan },
+	{ header: "Deps", value: (r) => r.deps },
+	{ header: "Vendor", value: (r) => r.vendor, color: (v) => (v === "yes" ? pc.yellow(v) : dim(v)) },
+	{ header: "Last install", value: (r) => r.lastInstall, color: dim },
+];
+
+function printProjectsTable(rows: ProjectRow[]): void {
+	const display: DisplayRow[] = rows.map((r) => ({
+		path: collapseTilde(r.path),
+		deps: String(r.deps),
+		vendor: r.vendor ? "yes" : "no",
+		lastInstall: r.lastInstall ? formatRelativeTime(new Date(r.lastInstall)) : "—",
+	}));
+	printTable(display, PROJECT_COLUMNS);
+}
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+// Calendar-aware buckets are intentionally avoided — "1 month ago" is fuzzy
+// by design and a 30-day approximation matches what users expect from a
+// single-glance status column.
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+const MS_PER_MONTH = 30 * MS_PER_DAY;
+const MS_PER_YEAR = 365 * MS_PER_DAY;
+
+/**
+ * Format a past `Date` as "N <unit> ago". Exported only via the row's ISO
+ * field; the table builds the human form via this helper. Falls back to ISO
+ * on future timestamps (clock skew on shared filesystems) so the table
+ * stays readable.
+ */
+export function formatRelativeTime(then: Date, now: Date = new Date()): string {
+	const diff = now.getTime() - then.getTime();
+	if (diff < 0) return then.toISOString();
+	if (diff < MS_PER_MINUTE) return "just now";
+	if (diff < MS_PER_HOUR) return plural(Math.floor(diff / MS_PER_MINUTE), "minute");
+	if (diff < MS_PER_DAY) return plural(Math.floor(diff / MS_PER_HOUR), "hour");
+	if (diff < MS_PER_WEEK) return plural(Math.floor(diff / MS_PER_DAY), "day");
+	if (diff < MS_PER_MONTH) return plural(Math.floor(diff / MS_PER_WEEK), "week");
+	if (diff < MS_PER_YEAR) return plural(Math.floor(diff / MS_PER_MONTH), "month");
+	return plural(Math.floor(diff / MS_PER_YEAR), "year");
+}
+
+function plural(n: number, unit: string): string {
+	return `${n} ${unit}${n === 1 ? "" : "s"} ago`;
+}

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -20,6 +20,8 @@ Commands:
   update [options] [name]       Update dependencies to latest versions
   outdated [options] [name]     Preview which deps have newer versions available
                                 (read-only)
+  projects [options]            List skilltree-managed projects discoverable on
+                                this machine (read-only)
   remove [options] <name>       Remove a dependency
   verify [options]              Verify installed dependencies against lockfile
   check [options]               Lint the project's skilltree.yml for design-time
@@ -130,6 +132,18 @@ Options:
   --check       Exit 1 if any drift exists (CI-friendly)
   -g, --global  Show global deps
   -h, --help    display help for command
+"
+`;
+
+exports[`CLI help snapshots \`projects --help\` is stable 1`] = `
+"Usage: skilltree projects [options]
+
+List skilltree-managed projects discoverable on this machine (read-only)
+
+Options:
+  --root <path>  Search root (default: $HOME)
+  --json         Output results as JSON
+  -h, --help     display help for command
 "
 `;
 

--- a/tests/commands/projects.test.ts
+++ b/tests/commands/projects.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { projectsCommand } from "../../src/commands/projects.js";
+
+let tempDir: string;
+let logs: string[];
+let warns: string[];
+let originalLog: typeof console.log;
+let originalWarn: typeof console.warn;
+
+beforeEach(async () => {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-projects-"));
+	logs = [];
+	warns = [];
+	originalLog = console.log;
+	originalWarn = console.warn;
+	console.log = (...args: unknown[]) => logs.push(args.join(" "));
+	console.warn = (...args: unknown[]) => warns.push(args.join(" "));
+});
+
+afterEach(async () => {
+	console.log = originalLog;
+	console.warn = originalWarn;
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+async function writeManifest(dir: string, content: string, filename = "skilltree.yml") {
+	await mkdir(dir, { recursive: true });
+	await writeFile(join(dir, filename), content);
+}
+
+describe("projectsCommand", () => {
+	test("finds nested projects under --root", async () => {
+		await writeManifest(join(tempDir, "a"), "name: a\n");
+		await writeManifest(join(tempDir, "deep", "b"), "name: b\n");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]");
+		expect(out).toHaveLength(2);
+		const paths = (out as Array<{ path: string }>).map((p) => p.path).sort();
+		expect(paths[0]).toContain("/a");
+		expect(paths[1]).toContain("/deep/b");
+	});
+
+	test("respects --root and does not look outside it", async () => {
+		const sub = join(tempDir, "inside");
+		await writeManifest(sub, "name: in\n");
+		// Sibling manifest outside the requested root — must not be returned.
+		const outsideRoot = await mkdtemp(join(tmpdir(), "skilltree-outside-"));
+		try {
+			await writeManifest(outsideRoot, "name: out\n");
+
+			await projectsCommand({ root: sub, json: true });
+
+			const out = JSON.parse(logs[0] ?? "[]") as Array<{ path: string }>;
+			expect(out).toHaveLength(1);
+			expect(out[0]?.path).toBe(sub);
+		} finally {
+			await rm(outsideRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("skips node_modules, .git, dist, build, and .skilltree/cache", async () => {
+		// One real project at the root, and "fake" projects inside ignored dirs.
+		await writeManifest(tempDir, "name: real\n");
+		await writeManifest(join(tempDir, "node_modules", "pkg"), "name: nm\n");
+		await writeManifest(join(tempDir, ".git", "hooks"), "name: git\n");
+		await writeManifest(join(tempDir, "dist"), "name: dist\n");
+		await writeManifest(join(tempDir, "build"), "name: build\n");
+		await writeManifest(join(tempDir, ".skilltree", "cache", "x"), "name: cache\n");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{ path: string }>;
+		expect(out).toHaveLength(1);
+		expect(out[0]?.path).toBe(tempDir);
+	});
+
+	test("descends into .claude but not other hidden dirs", async () => {
+		await writeManifest(join(tempDir, ".claude", "proj"), "name: in-claude\n");
+		await writeManifest(join(tempDir, ".hidden", "proj"), "name: in-hidden\n");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{ path: string }>;
+		expect(out).toHaveLength(1);
+		expect(out[0]?.path).toContain(".claude/proj");
+	});
+
+	test("recognises both skilltree.yml and skilltree.yaml", async () => {
+		await writeManifest(join(tempDir, "yml"), "name: a\n", "skilltree.yml");
+		await writeManifest(join(tempDir, "yaml"), "name: b\n", "skilltree.yaml");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{
+			path: string;
+			manifestPath: string;
+		}>;
+		expect(out).toHaveLength(2);
+		const manifestPaths = out.map((p) => p.manifestPath).sort();
+		expect(manifestPaths[0]).toContain("yaml/skilltree.yaml");
+		expect(manifestPaths[1]).toContain("yml/skilltree.yml");
+	});
+
+	test("counts dependencies + dev-dependencies", async () => {
+		const manifest = [
+			"name: counted",
+			"dependencies:",
+			"  alpha:",
+			"    repo: github.com/x/a",
+			"  beta:",
+			"    repo: github.com/x/b",
+			"dev-dependencies:",
+			"  gamma:",
+			"    repo: github.com/x/g",
+			"",
+		].join("\n");
+		await writeManifest(tempDir, manifest);
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{ deps: number }>;
+		expect(out).toHaveLength(1);
+		expect(out[0]?.deps).toBe(3);
+	});
+
+	test("reports vendor flag", async () => {
+		await writeManifest(join(tempDir, "vendored"), "name: v\nvendor: true\n");
+		await writeManifest(join(tempDir, "regular"), "name: r\n");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{
+			path: string;
+			vendor: boolean;
+		}>;
+		const byPath = new Map(out.map((p) => [p.path, p.vendor]));
+		expect(byPath.get(join(tempDir, "vendored"))).toBe(true);
+		expect(byPath.get(join(tempDir, "regular"))).toBe(false);
+	});
+
+	test("reports lockfile mtime as ISO when present, null otherwise", async () => {
+		await writeManifest(join(tempDir, "withlock"), "name: wl\n");
+		const fixedTime = new Date("2026-01-01T12:00:00Z");
+		await writeFile(join(tempDir, "withlock", "skilltree.lock"), "lockfile_version: 1\n");
+		await utimes(join(tempDir, "withlock", "skilltree.lock"), fixedTime, fixedTime);
+
+		await writeManifest(join(tempDir, "nolock"), "name: nl\n");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{
+			path: string;
+			lastInstall: string | null;
+		}>;
+		const byPath = new Map(out.map((p) => [p.path, p.lastInstall]));
+		expect(byPath.get(join(tempDir, "withlock"))).toBe(fixedTime.toISOString());
+		expect(byPath.get(join(tempDir, "nolock"))).toBeNull();
+	});
+
+	test("skips unparseable manifests with a single warning per path", async () => {
+		await writeManifest(join(tempDir, "ok"), "name: ok\n");
+		// `[invalid: : :` opens a YAML flow sequence with a stray `:` — yaml's
+		// parser raises on this, so parseManifest should throw and the row
+		// should be dropped with exactly one warning.
+		await writeManifest(join(tempDir, "broken"), "  [invalid: : :\n  - this\n -is\n :bad");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{ path: string }>;
+		expect(out).toHaveLength(1);
+		expect(out[0]?.path).toBe(join(tempDir, "ok"));
+		// Exactly one warning mentioning the broken path
+		const brokenWarnings = warns.filter((w) => w.includes("broken"));
+		expect(brokenWarnings.length).toBe(1);
+	});
+
+	test("terminates on symlink cycles", async () => {
+		await writeManifest(tempDir, "name: root\n");
+		await mkdir(join(tempDir, "child"));
+		// Cycle: child/loop -> child (which contains loop -> ...)
+		await symlink(join(tempDir, "child"), join(tempDir, "child", "loop"));
+
+		// If the walk doesn't detect cycles, this hangs / blows the call stack.
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{ path: string }>;
+		expect(out).toHaveLength(1);
+		expect(out[0]?.path).toBe(tempDir);
+	});
+
+	test("table output includes header row and project rows", async () => {
+		await writeManifest(tempDir, "name: t\n");
+
+		await projectsCommand({ root: tempDir }); // no --json
+
+		const all = logs.join("\n");
+		expect(all).toContain("Path");
+		expect(all).toContain("Deps");
+		expect(all).toContain("Vendor");
+		expect(all).toContain("Last install");
+	});
+
+	test("empty walk prints a friendly message in table mode and [] in JSON mode", async () => {
+		await projectsCommand({ root: tempDir, json: true });
+		expect(logs[0]).toBe("[]");
+
+		logs.length = 0;
+		await projectsCommand({ root: tempDir });
+		expect(logs.some((l) => l.toLowerCase().includes("no skilltree projects"))).toBe(true);
+	});
+
+	test("does not descend into a discovered project's subdirectories", async () => {
+		// A skilltree project should not be probed further — if `a/` is a
+		// project, nested `a/sub/` should be ignored even if it has its own manifest.
+		// This matches `find -name skilltree.yml -prune`-style scanning and keeps
+		// the walk fast on monorepos.
+		await writeManifest(join(tempDir, "a"), "name: a\n");
+		await writeManifest(join(tempDir, "a", "sub"), "name: nested\n");
+
+		await projectsCommand({ root: tempDir, json: true });
+
+		const out = JSON.parse(logs[0] ?? "[]") as Array<{ path: string }>;
+		expect(out).toHaveLength(1);
+		expect(out[0]?.path).toBe(join(tempDir, "a"));
+	});
+});


### PR DESCRIPTION
## Why

`skilltree projects` lists every skilltree-managed project discoverable on this machine — a first-class verb for the "where are my checkouts?" question. A UX evaluator with 24 `skilltree.yml` files had to shell out to `find` to enumerate them. Part of the read-only inspection layer.

Closes #81

## What changed

- New `src/commands/projects.ts`: filesystem walk from `--root` (default `$HOME`) reporting `path`, `manifestPath`, `deps`, `vendor`, `lastInstall`. Renders a colored table or `--json`.
- Skip rules per spec: `node_modules/`, `.git/`, `.skilltree/cache/`, `dist/`, `build/`, hidden dirs (except `.claude/`). Stops descending into a project.
- Symlink cycles + cross-filesystem detection via a `(dev, ino)` visited set. Unparseable manifests skipped with one consolidated warning per path.
- Wired into `src/cli.ts` and the completion generator. README + skill docs updated.