### PR TITLE
feat(cli): authoring input-validation hardening (#71, #120, #122, #125, #126)

### DIFF
--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -11,6 +11,7 @@ skilltree init --global     # Global manifest (~/.skilltree/global.yaml)
 
 **Flags:**
 - `-g, --global` — Initialize global dependencies instead of project
+- `-f, --force` — Overwrite an existing `skilltree.yml` (works on legacy `.yaml` too)
 
 Creates `skilltree.yml` with project name from directory, adds `.claude/skills/` and `.claude/agents/` to `.gitignore`.
 
@@ -47,6 +48,11 @@ skilltree add testing --dev --repo github.com/org/shared-skills --path skills/te
 - `-t, --type <skill|agent|command>` — Override type inference (commands install to `.claude/commands/`)
 - `--registry <name>` — When no `--repo`, resolve from this registry only (disambiguates multiple matches)
 - `-g, --global` — Add to global dependencies (~/.skilltree/global.yaml)
+- `--no-verify` — Skip the `git ls-remote` reachability check on `--repo` URLs (offline / pre-registering an unpushed repo)
+
+**Validation:**
+- For `--repo <url>`: probes the URL with `git ls-remote` (5s timeout). Unreachable URLs warn but still write the entry; auth-required URLs print a soft note. Use `--no-verify` to skip the probe.
+- For `--source <alias>`: must be an alias name registered under the manifest's `sources:` block. URLs are refused — use `--repo` for direct URLs.
 
 ## `skilltree new`
 
@@ -75,6 +81,7 @@ skilltree new skill testing-helpers --dev
 
 **Behavior:**
 - Refuses to overwrite an existing file at the target path
+- Requires `skilltree.yml` in the current dir (unless `--no-register`) — fails fast without writing any files when missing
 - After scaffolding, runs the equivalent of `skilltree add <name> --local <path> --type <type>`
 - Names must start with a letter or digit and contain only letters, digits, hyphens, and underscores
 
@@ -289,17 +296,20 @@ skilltree why bar --global          # inspect global lockfile
 - `--json` — Output paths as JSON
 - `-g, --global` — Inspect the global lockfile
 
-## `skilltree scan <paths...>`
+## `skilltree scan [paths...]`
 
 Detect undeclared dependencies in skill body text using regex patterns.
 
 ```bash
-skilltree scan ./skills/                    # Scan all skills
-skilltree scan --check ./skills/            # Pre-commit mode (exit 1 if gaps)
-skilltree scan --apply ./skills/            # Auto-update frontmatter
-skilltree scan --llm ./skills/              # LLM-assisted deep scan
-skilltree scan --json ./skills/             # Machine-readable output
+skilltree scan                              # Scan the project's install-target dirs (.claude/skills, etc.)
+skilltree scan ./skills/                    # Scan an explicit path
+skilltree scan --check                      # Pre-commit mode (exit 1 if gaps)
+skilltree scan --apply                      # Auto-update frontmatter
+skilltree scan --llm                        # LLM-assisted deep scan
+skilltree scan --json                       # Machine-readable output
 ```
+
+With no `<paths>`, scans the project's resolved install-target directories (e.g. `.claude/skills`, `.claude/agents`, `.claude/commands`, plus equivalents for codex/cursor/gemini). Requires `skilltree.yml`. Pass explicit paths to scan elsewhere.
 
 **Flags:**
 - `--check` — Exit 1 if undeclared deps found (pre-commit safe)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,10 +103,11 @@ export function buildProgram(): Command {
 		.option("--no-verify", "Skip git ls-remote reachability check on --repo URLs")
 		.action(async (name: string, opts) => {
 			// Commander turns `--no-verify` into `opts.verify === false`. Translate
-			// to the `noVerify` flag the command expects so the rest of the option
-			// surface stays consistent with `--no-register` / `--no-X` idioms used
-			// elsewhere.
-			await addCommand(name, { ...opts, noVerify: opts.verify === false }, process.cwd());
+			// to the `noVerify` flag the command expects so the option surface
+			// stays consistent with the `--no-X` idiom; drop the `verify` key so
+			// it doesn't ride along on AddOptions as a stray field.
+			const { verify: _verify, ...rest } = opts;
+			await addCommand(name, { ...rest, noVerify: opts.verify === false }, process.cwd());
 		});
 
 	// `new` accepts two equivalent forms:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,8 +270,13 @@ export function buildProgram(): Command {
 		});
 
 	program
-		.command("scan <paths...>")
-		.description("Scan skills, agents, and commands for undeclared dependencies")
+		.command("scan [paths...]")
+		.description(
+			"Scan skills, agents, and commands for undeclared dependencies\n\n" +
+				"With no <paths>, scans the project's install-target directories " +
+				"(`.claude/skills`, etc.) derived from skilltree.yml. Pass explicit " +
+				"paths to scan elsewhere.",
+		)
 		.option("--check", "Exit 1 if undeclared deps found (pre-commit mode)")
 		.option("--apply", "Auto-update frontmatter with detected deps (regex only)")
 		.option("--llm", "Use LLM for deep dependency detection (requires ANTHROPIC_API_KEY)")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,8 +100,13 @@ export function buildProgram(): Command {
 		.option("--registry <name>", "Resolve from this registry (when no --repo)")
 		.option("-g, --global", "Add to global dependencies")
 		.option("-y, --yes", "Skip the glob-mode confirmation prompt")
+		.option("--no-verify", "Skip git ls-remote reachability check on --repo URLs")
 		.action(async (name: string, opts) => {
-			await addCommand(name, opts, process.cwd());
+			// Commander turns `--no-verify` into `opts.verify === false`. Translate
+			// to the `noVerify` flag the command expects so the rest of the option
+			// surface stays consistent with `--no-register` / `--no-X` idioms used
+			// elsewhere.
+			await addCommand(name, { ...opts, noVerify: opts.verify === false }, process.cwd());
 		});
 
 	// `new` accepts two equivalent forms:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,7 @@ export function buildProgram(): Command {
 			"-y, --yes",
 			"Skip prompts: include all discovered scan entries and enrol all detected agents",
 		)
+		.option("-f, --force", "Overwrite an existing skilltree.yml")
 		.option(
 			"--target <name>",
 			"Explicit install target (skips detection). Repeat for multiple, e.g. --target claude --target codex",
@@ -81,6 +82,7 @@ export function buildProgram(): Command {
 				global: opts.global,
 				scan: opts.scan,
 				yes: opts.yes,
+				force: opts.force,
 				targets: opts.target,
 			});
 		});

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline/promises";
 import semver from "semver";
 import { canonicalSource } from "../core/deps.js";
 import { MANIFEST_NEW } from "../core/filenames.js";
+import { type LsRemoteOutcome, lsRemote } from "../core/git.js";
 import { loadManifestOrThrow, writeGlobalManifest, writeManifest } from "../core/manifest.js";
 import { collapseTilde, expandTilde, getGlobalDir } from "../core/paths.js";
 import { loadFreshRegistryIndex } from "../core/registry-cache.js";
@@ -29,6 +30,13 @@ export interface AddOptions {
 	global?: boolean;
 	/** Skip the glob-mode confirmation prompt. */
 	yes?: boolean;
+	/**
+	 * Skip the `git ls-remote` reachability probe on `--repo` deps. Issue #71 —
+	 * the probe catches typo'd / unreachable URLs at add-time, but the user
+	 * may want to bypass it (offline, intermittent network, intentionally
+	 * pre-registering a not-yet-pushed repo).
+	 */
+	noVerify?: boolean;
 	// Test overrides (avoid touching real ~/.skilltree/)
 	configPath?: string;
 	cacheDir?: string;
@@ -37,6 +45,13 @@ export interface AddOptions {
 	askFn?: (question: string) => Promise<string>;
 	/** Test hook: override TTY detection. Defaults to process.stdout.isTTY. */
 	isInteractive?: boolean;
+	/**
+	 * Test hook: substitute the `git ls-remote` probe. Defaults to the real
+	 * `lsRemote` in non-test env, or a no-op in `NODE_ENV=test` to keep
+	 * existing tests off the network. Inject this in tests that want to
+	 * exercise the verification code path.
+	 */
+	lsRemoteFn?: (url: string, opts: { timeoutMs: number }) => Promise<LsRemoteOutcome>;
 }
 
 export async function addCommand(name: string, opts: AddOptions, dir: string): Promise<void> {
@@ -46,6 +61,7 @@ export async function addCommand(name: string, opts: AddOptions, dir: string): P
 	}
 	validateAddFlags(opts);
 	const dep = await buildDependency(name, opts, dir);
+	await verifyRepoIfNeeded(dep, opts);
 
 	const globalDir = opts.globalDir ?? getGlobalDir();
 	const manifest = await loadManifestOrThrow(dir, { global: opts.global, globalDir });
@@ -74,6 +90,45 @@ export async function addCommand(name: string, opts: AddOptions, dir: string): P
 	success(`Added ${name} to ${group}${opts.global ? " (global)" : ""}`);
 	const installCmd = opts.global ? "skilltree install --global" : "skilltree install";
 	console.log(dim(`  Run \`${installCmd}\` to install.`));
+}
+
+/**
+ * Probe a `--repo` dep with `git ls-remote` so typos / unreachable URLs
+ * surface at add-time instead of at install-time. Issue #71. Always
+ * proceeds with the write — the probe is advisory, not gating:
+ *
+ *   - reachable      → silent
+ *   - unreachable    → warning (probably a typo, install will fail)
+ *   - auth required  → soft note (normal for private repos)
+ *   - timeout/other  → soft note (transient or non-standard transport)
+ *
+ * Skipped for `--no-verify`, for non-`repo` deps (local + source-alias
+ * resolve their URL later), and in `NODE_ENV=test` unless the test
+ * explicitly injects an `lsRemoteFn`.
+ */
+async function verifyRepoIfNeeded(dep: Dependency, opts: AddOptions): Promise<void> {
+	if (opts.noVerify === true) return;
+	if (!("repo" in dep) || !dep.repo) return;
+	// Tests opt in by providing lsRemoteFn; bare tests skip the network probe.
+	if (opts.lsRemoteFn === undefined && process.env.NODE_ENV === "test") return;
+	const probe = opts.lsRemoteFn ?? lsRemote;
+	const outcome = await probe(dep.repo, { timeoutMs: 5000 });
+	if (outcome.ok) return;
+	if (outcome.reason === "unreachable") {
+		warn(
+			`could not reach ${dep.repo} (${outcome.detail}). Entry added, but install will fail unless the URL is correct.`,
+		);
+		return;
+	}
+	if (outcome.reason === "auth") {
+		console.log(dim(`  note: ${dep.repo} requires authentication — skipping verification.`));
+		return;
+	}
+	if (outcome.reason === "timeout") {
+		console.log(dim(`  note: verification timed out (${outcome.detail}) — skipping.`));
+		return;
+	}
+	console.log(dim(`  note: verification skipped (${outcome.detail}).`));
 }
 
 /** A literal `*` or `?` in a name signals user-intent glob expansion (Issue #14). */

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -298,9 +298,27 @@ async function loadRegistryEntities(opts: AddOptions): Promise<RegistryEntity[]>
 	return entities;
 }
 
+/**
+ * Heuristic for "did the user pass a URL where an alias name was expected?"
+ * Matches the two URL shapes the rest of the tool accepts as a `repo:` value:
+ * scheme-prefixed (`https://`, `file://`, `git://`, `ssh://`, ...) and SSH
+ * shorthand (`git@host:path`). Anything else passes through as a candidate
+ * alias name — bare `vibes` or `my-source` should still be honored.
+ */
+const URL_LIKE_RE = /^(?:[a-z][a-z0-9+.-]*:\/\/|[\w.-]+@[\w.-]+:)/i;
+
 function validateAddFlags(opts: AddOptions): void {
 	if (opts.repo && opts.source) {
 		throw new Error("--repo and --source are mutually exclusive");
+	}
+	// Issue #122: --source expects an alias name registered under top-level
+	// `sources:`. Without this guard, a URL passed here lands literally in the
+	// manifest as `source: <url>` and install fails with "Unknown source alias".
+	if (opts.source && URL_LIKE_RE.test(opts.source)) {
+		throw new Error(
+			`--source expects an alias name registered under \`sources:\`, not a URL (got "${opts.source}"). ` +
+				`Use \`--repo <url>\` to pass a URL directly, or register the URL under \`sources:\` first and pass the alias name.`,
+		);
 	}
 	if (opts.global && opts.dev) {
 		throw new Error(

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -56,6 +56,7 @@ const COMMANDS: CmdDef[] = [
 				short: "-y",
 				description: "Include all discovered entries without prompting",
 			},
+			{ long: "--force", short: "-f", description: "Overwrite an existing skilltree.yml" },
 		],
 	},
 	{
@@ -82,6 +83,7 @@ const COMMANDS: CmdDef[] = [
 				valueComplete: "registries",
 			},
 			{ long: "--global", short: "-g", description: "Add to global dependencies" },
+			{ long: "--no-verify", description: "Skip git ls-remote check on --repo URLs" },
 		],
 	},
 	{

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { rm, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { detectInstalledAgents, resolveTarget } from "../core/agents.js";
@@ -38,6 +38,12 @@ export interface InitOptions {
 	scan?: boolean;
 	yes?: boolean;
 	/**
+	 * Overwrite an existing manifest non-interactively. Issue #126 — CI scripts
+	 * and automation can't re-initialize a project without manually deleting
+	 * the manifest first.
+	 */
+	force?: boolean;
+	/**
 	 * Explicit install targets (from repeatable `--target` flag). When set,
 	 * detection is bypassed entirely — the user has already told us what they want.
 	 * Issue #74.
@@ -67,13 +73,22 @@ export async function initCommand(dir: string, options?: InitOptions): Promise<v
 	// actually wanted `targets add` or `targets detect`. Issue #74 (Friction A).
 	const existing = findExistingManifest(dir);
 	if (existing) {
-		throw new Error(
-			`${existing} already exists.\n` +
-				`  To add a coding agent to this project, run:\n` +
-				`    skilltree targets add <agent>      (e.g. claude, codex)\n` +
-				`    skilltree targets detect           (auto-add any newly-installed agents)\n` +
-				`  To start fresh, remove ${existing} first.`,
-		);
+		if (options?.force) {
+			// --force: clear the existing manifest so the rest of initCommand
+			// can proceed as if starting fresh. We remove the actual on-disk
+			// file (which may be `.yaml`, not just the canonical `.yml`) so a
+			// legacy project's re-init lands on `.yml` cleanly.
+			await rm(`${dir}/${existing}`);
+		} else {
+			throw new Error(
+				`${existing} already exists.\n` +
+					`  To add a coding agent to this project, run:\n` +
+					`    skilltree targets add <agent>      (e.g. claude, codex)\n` +
+					`    skilltree targets detect           (auto-add any newly-installed agents)\n` +
+					`  To overwrite, re-run with --force.\n` +
+					`  To start fresh manually, remove ${existing} first.`,
+			);
+		}
 	}
 
 	const installTargets = await selectInstallTargets(options);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,5 +1,6 @@
 import { mkdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { findExistingManifest } from "../core/filenames.js";
 import { dim, success } from "../core/ui.js";
 import type { EntityType } from "../types.js";
 import { addCommand } from "./add.js";
@@ -37,6 +38,17 @@ export async function newCommand(
 ): Promise<void> {
 	validateEntityType(type);
 	validateName(name);
+
+	// Issue #120: when we're going to register the new entity (the default),
+	// require the manifest up front. Without this check, the file gets written
+	// to disk and *then* `addCommand` fails to load the manifest — leaving
+	// orphan files behind on a failed `new`. Skipped for `--no-register` since
+	// that mode is explicit scaffold-only and doesn't touch the manifest.
+	if (opts.register !== false && !findExistingManifest(dir)) {
+		throw new Error(
+			"No skilltree.yml found. Run `skilltree init` first, or pass --no-register to scaffold without registering.",
+		);
+	}
 
 	const target = resolveTargetPath(type, name, dir);
 	await assertNoCollision(target.displayPath, target.absPath);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,6 +1,8 @@
+import { existsSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { entityNameFromPath, mdFileType } from "../core/entity-type.js";
+import { getSkillAgentIgnoreEntriesForTarget } from "../core/gitignore.js";
 import { readGlobalManifest, readManifest } from "../core/manifest.js";
 import type { ScanResult } from "../core/scanner.js";
 import { applyToFrontmatter, scanFiles, scanFileWithLlm } from "../core/scanner.js";
@@ -66,6 +68,45 @@ async function buildKnownEntities(
 }
 
 /**
+ * Build the default scan path list from the project's install targets when
+ * the user runs `skilltree scan` with no positional. Issue #125 — typing
+ * out `.claude/skills .claude/agents ...` every time was clumsy and
+ * required users to know the install layout of each enrolled agent.
+ *
+ * Resolves each `install_targets` entry through the agent registry (so
+ * codex → `.agents/`, copilot → `.github/`, etc. land correctly) and
+ * filters to paths that actually exist on disk — listing dirs that
+ * haven't been created yet would just produce noisy "no files found"
+ * output.
+ */
+async function defaultScanPaths(): Promise<string[]> {
+	const cwd = process.cwd();
+	let manifest: Awaited<ReturnType<typeof readManifest>>;
+	try {
+		manifest = await readManifest(cwd);
+	} catch {
+		throw new Error(
+			"No skilltree.yml found in the current directory. Run `skilltree init` first, or pass explicit paths (e.g. `skilltree scan .claude/skills`).",
+		);
+	}
+	const seen = new Set<string>();
+	const paths: string[] = [];
+	for (const target of manifest.install_targets ?? []) {
+		for (const entry of getSkillAgentIgnoreEntriesForTarget(target)) {
+			// `.claude/skills/` → `.claude/skills`. Trailing-slash stripping keeps
+			// `readdir`/`stat` happy (they don't care, but the display in error
+			// messages is cleaner without it).
+			const dir = entry.replace(/\/$/, "");
+			if (seen.has(dir)) continue;
+			seen.add(dir);
+			const abs = join(cwd, dir);
+			if (existsSync(abs)) paths.push(abs);
+		}
+	}
+	return paths;
+}
+
+/**
  * Collect names the scanner should treat as already-known, beyond the
  * hardcoded `BUILTIN_HARNESS_COMMANDS` set. Unions the project manifest's
  * `scan.ignore` with the global manifest's, ignoring missing manifests
@@ -92,8 +133,9 @@ async function loadExtraIgnores(): Promise<Set<string>> {
 }
 
 export async function scanCommand(paths: string[], options: ScanOptions): Promise<void> {
+	const effectivePaths = paths.length > 0 ? paths : await defaultScanPaths();
 	const allFiles: string[] = [];
-	for (const p of paths) {
+	for (const p of effectivePaths) {
 		const files = await collectMdFiles(p);
 		allFiles.push(...files);
 	}

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -40,8 +40,14 @@ Commands:
 
                                      Lifecycle: new → check → doctor → git tag
   list [options]                     List installed dependencies
-  scan [options] <paths...>          Scan skills, agents, and commands for
+  scan [options] [paths...]          Scan skills, agents, and commands for
                                      undeclared dependencies
+
+                                     With no <paths>, scans the project's
+                                     install-target directories
+                                     (\`.claude/skills\`, etc.) derived from
+                                     skilltree.yml. Pass explicit paths to scan
+                                     elsewhere.
   teach [options]                    Install the skilltree skill to all detected
                                      coding agents
   vendor [options]                   Copy all deps as real files for git commit
@@ -249,9 +255,13 @@ Options:
 `;
 
 exports[`CLI help snapshots \`scan --help\` is stable 1`] = `
-"Usage: skilltree scan [options] <paths...>
+"Usage: skilltree scan [options] [paths...]
 
 Scan skills, agents, and commands for undeclared dependencies
+
+With no <paths>, scans the project's install-target directories
+(\`.claude/skills\`, etc.) derived from skilltree.yml. Pass explicit paths to scan
+elsewhere.
 
 Options:
   --check     Exit 1 if undeclared deps found (pre-commit mode)

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -84,6 +84,7 @@ Options:
                    register them as local deps
   -y, --yes        Skip prompts: include all discovered scan entries and enrol
                    all detected agents
+  -f, --force      Overwrite an existing skilltree.yml
   --target <name>  Explicit install target (skips detection). Repeat for
                    multiple, e.g. --target claude --target codex
   -h, --help       display help for command

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -113,6 +113,8 @@ Options:
   --registry <name>           Resolve from this registry (when no --repo)
   -g, --global                Add to global dependencies
   -y, --yes                   Skip the glob-mode confirmation prompt
+  --no-verify                 Skip git ls-remote reachability check on --repo
+                              URLs
   -h, --help                  display help for command
 "
 `;

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -696,6 +696,41 @@ describe("addCommand — --repo URL verification (#71)", () => {
 		expect(manifest.dependencies?.slow).toBeDefined();
 	});
 
+	test("emits a soft note on the catch-all 'other' reason — proceeds anyway", async () => {
+		// Any outcome shape we don't explicitly classify lands in the `other`
+		// branch — exotic transport errors, unusual stderr text, etc.
+		const dir = await setup();
+		const warnings: string[] = [];
+		const logs: string[] = [];
+		const originalWarn = console.warn;
+		const originalLog = console.log;
+		console.warn = (msg: string) => warnings.push(msg);
+		console.log = (msg: string) => logs.push(msg);
+		try {
+			await addCommand(
+				"exotic",
+				{
+					repo: "github.com/exotic/repo",
+					path: "skills/exotic",
+					lsRemoteFn: async () => ({
+						ok: false,
+						reason: "other",
+						detail: "weird stderr message",
+					}),
+				},
+				dir,
+			);
+		} finally {
+			console.warn = originalWarn;
+			console.log = originalLog;
+		}
+		// No console.warn — this is a quieter signal than `unreachable`.
+		expect(warnings).toEqual([]);
+		expect(logs.some((l) => /verification skipped|weird stderr/i.test(l))).toBe(true);
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.exotic).toBeDefined();
+	});
+
 	test("--no-verify (noVerify: true) skips the probe entirely", async () => {
 		const dir = await setup();
 		let probeCalled = false;

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -586,3 +586,153 @@ describe("addCommand on a legacy .yaml manifest", () => {
 		);
 	});
 });
+
+describe("addCommand — --repo URL verification (#71)", () => {
+	test("calls lsRemoteFn for --repo deps and stays silent on reachable URL", async () => {
+		const dir = await setup();
+		const calls: string[] = [];
+		await addCommand(
+			"foo",
+			{
+				repo: "github.com/example/skills",
+				path: "skills/foo",
+				lsRemoteFn: async (url) => {
+					calls.push(url);
+					return { ok: true };
+				},
+			},
+			dir,
+		);
+		expect(calls).toContain("github.com/example/skills");
+		// Dep still added on success.
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.foo).toBeDefined();
+	});
+
+	test("warns but still writes the entry when URL is unreachable", async () => {
+		const dir = await setup();
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+		try {
+			await addCommand(
+				"unreach",
+				{
+					repo: "github.com/nope/nope",
+					path: "skills/unreach",
+					lsRemoteFn: async () => ({
+						ok: false,
+						reason: "unreachable",
+						detail: "could not resolve host",
+					}),
+				},
+				dir,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		// Entry written despite the probe failure — the URL might come back up,
+		// or the user might be authoring offline.
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.unreach).toBeDefined();
+		// Warning surfaces so the user knows the install will fail until the URL is fixed.
+		expect(warnings.some((w) => /unreach|could not reach|unreachable/i.test(w))).toBe(true);
+	});
+
+	test("emits a soft note (not a warning) on auth failure — proceeds anyway", async () => {
+		const dir = await setup();
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+		try {
+			await addCommand(
+				"private",
+				{
+					repo: "github.com/private/repo",
+					path: "skills/private",
+					lsRemoteFn: async () => ({
+						ok: false,
+						reason: "auth",
+						detail: "Authentication failed",
+					}),
+				},
+				dir,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		// Auth-required is normal for private repos; not a warning, just a note.
+		expect(warnings).toEqual([]);
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.private).toBeDefined();
+	});
+
+	test("emits a soft note on timeout — proceeds anyway", async () => {
+		const dir = await setup();
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+		try {
+			await addCommand(
+				"slow",
+				{
+					repo: "github.com/slow/repo",
+					path: "skills/slow",
+					lsRemoteFn: async () => ({
+						ok: false,
+						reason: "timeout",
+						detail: "timed out after 5000ms",
+					}),
+				},
+				dir,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+		expect(warnings).toEqual([]);
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.slow).toBeDefined();
+	});
+
+	test("--no-verify (noVerify: true) skips the probe entirely", async () => {
+		const dir = await setup();
+		let probeCalled = false;
+		await addCommand(
+			"skipped",
+			{
+				repo: "github.com/whatever/repo",
+				path: "skills/skipped",
+				noVerify: true,
+				lsRemoteFn: async () => {
+					probeCalled = true;
+					return { ok: true };
+				},
+			},
+			dir,
+		);
+		expect(probeCalled).toBe(false);
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.skipped).toBeDefined();
+	});
+
+	test("does not probe local deps", async () => {
+		const dir = await setup();
+		await writeFile(join(dir, "local-skill.md"), "---\nname: local\n---\n");
+		let probeCalled = false;
+		await addCommand(
+			"local",
+			{
+				local: "./local-skill.md",
+				type: "agent",
+				lsRemoteFn: async () => {
+					probeCalled = true;
+					return { ok: true };
+				},
+			},
+			dir,
+		);
+		expect(probeCalled).toBe(false);
+	});
+});

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -145,6 +145,23 @@ describe("addCommand", () => {
 		).rejects.toThrow("mutually exclusive");
 	});
 
+	test("rejects a URL passed to --source and points at --repo (#122)", async () => {
+		// --source expects an alias name registered under top-level `sources:`,
+		// not a URL. Without this guard, the URL gets written literally as the
+		// source alias and install fails downstream with "Unknown source alias".
+		const dir = await setup();
+		for (const url of [
+			"file:///tmp/foo",
+			"https://github.com/example/repo",
+			"http://example.com/repo",
+			"git@github.com:example/repo.git",
+		]) {
+			await expect(
+				addCommand("bad", { source: url, path: "skills/x", type: "skill" }, dir),
+			).rejects.toThrow(/--source.*alias|--repo/i);
+		}
+	});
+
 	test("errors when --repo and --local used together", async () => {
 		const dir = await setup();
 		await expect(

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -127,6 +128,39 @@ describe("initCommand", () => {
 		await mkdir(fakeHome, { recursive: true });
 		await writeFile(join(dir, "skilltree.yaml"), "name: legacy\ndependencies: {}\n");
 		await expect(initCommand(dir, { homeDir: fakeHome })).rejects.toThrow(/skilltree\.yaml/);
+	});
+
+	test("--force overwrites an existing skilltree.yml without prompting (#126)", async () => {
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+		// Seed an existing manifest with content we can detect after overwrite.
+		await writeFile(
+			join(dir, "skilltree.yml"),
+			"name: old\ndependencies:\n  marker: { local: ./x }\n",
+		);
+
+		await initCommand(dir, { homeDir: fakeHome, force: true });
+
+		const manifest = await readManifest(dir);
+		// New manifest replaces the old one — the marker dep is gone.
+		expect(manifest.dependencies?.marker).toBeUndefined();
+		expect(manifest.name).not.toBe("old");
+	});
+
+	test("--force also overwrites a legacy .yaml manifest (#126)", async () => {
+		// --force should clear whichever existing manifest is on disk, not just
+		// the canonical .yml — otherwise legacy projects can't re-init.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+		await writeFile(join(dir, "skilltree.yaml"), "name: legacy\ndependencies: {}\n");
+
+		await initCommand(dir, { homeDir: fakeHome, force: true });
+
+		// After --force, only the canonical .yml should remain; the legacy file is gone.
+		expect(existsSync(join(dir, "skilltree.yml"))).toBe(true);
+		expect(existsSync(join(dir, "skilltree.yaml"))).toBe(false);
 	});
 
 	test("--scan with --yes registers discovered skills and agents as local deps", async () => {

--- a/tests/commands/new.test.ts
+++ b/tests/commands/new.test.ts
@@ -263,6 +263,34 @@ describe("`new` CLI handler — argument sniffing errors", () => {
 	});
 });
 
+describe("newCommand — no skilltree.yml (#120)", () => {
+	test("fails fast without writing files when no manifest exists", async () => {
+		// In a dir without skilltree.yml, the registration step would fail
+		// downstream — but only after the file was already written, leaving an
+		// orphan on disk. Fail-fast keeps the FS clean.
+		const dir = await mkdtemp(join(tmpdir(), "skilltree-new-orphan-"));
+		try {
+			await expect(newCommand("skill", "orphan", {}, dir)).rejects.toThrow(/no skilltree\.yml/i);
+			expect(existsSync(join(dir, "skills", "orphan", "SKILL.md"))).toBe(false);
+			expect(existsSync(join(dir, "skills", "orphan"))).toBe(false);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("--no-register still works without a manifest (scaffold-only mode)", async () => {
+		// The user explicitly opted out of manifest registration, so absence
+		// of skilltree.yml is fine — they just want the template.
+		const dir = await mkdtemp(join(tmpdir(), "skilltree-new-scaffold-only-"));
+		try {
+			await newCommand("skill", "scaffold-only", { register: false }, dir);
+			expect(existsSync(join(dir, "skills", "scaffold-only", "SKILL.md"))).toBe(true);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("newCommand — CLI parity (subcommand form vs --type)", () => {
 	test("--type produces the same scaffold as the subcommand form", async () => {
 		// We invoke newCommand directly with the type argument here — both CLI

--- a/tests/commands/scan.test.ts
+++ b/tests/commands/scan.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { initCommand } from "../../src/commands/init.js";
 import { classifyEntityFile, scanCommand } from "../../src/commands/scan.js";
 import type { EntityType } from "../../src/types.js";
 
@@ -38,6 +39,57 @@ function captureConsole(): { logs: string[]; restore: () => void } {
 	console.log = (...args: unknown[]) => logs.push(args.join(" "));
 	return { logs, restore: () => (console.log = originalLog) };
 }
+
+describe("scanCommand — default paths from install targets (#125)", () => {
+	test("with no positional paths, scans the project's install-target directories", async () => {
+		// Seed an installed-shape skill under .claude/ (the default target) with
+		// an undeclared body reference. The scan should pick it up without the
+		// user having to spell out the dirs.
+		const dir = await makeTempDir();
+		const fakeHome = join(dir, "empty-home");
+		await mkdir(fakeHome, { recursive: true });
+		await initCommand(dir, { homeDir: fakeHome });
+
+		// Body references "obscure-helper-xyz" — not declared in frontmatter and
+		// not in any ignore list — so it should surface as undeclared.
+		await createSkill(
+			join(dir, ".claude/skills"),
+			"auto-scan-me",
+			[],
+			"This skill calls the obscure-helper-xyz skill to do its work.",
+		);
+
+		const cwd = process.cwd();
+		process.chdir(dir);
+		const { logs, restore } = captureConsole();
+		try {
+			await scanCommand([], {});
+		} finally {
+			restore();
+			process.chdir(cwd);
+		}
+
+		const output = logs.join("\n");
+		// Two signals that the default-paths code path ran: the file was
+		// discovered (no "No .md files found"), and the undeclared dep surfaced.
+		expect(output).not.toContain("No .md files found");
+		expect(output).toContain("auto-scan-me");
+	});
+
+	test("with no positional paths and no manifest, errors clearly", async () => {
+		// Without a manifest there's nothing to derive defaults from. Surface a
+		// clear actionable error instead of a generic "missing argument" or a
+		// silent "no .md files found".
+		const dir = await makeTempDir();
+		const cwd = process.cwd();
+		process.chdir(dir);
+		try {
+			await expect(scanCommand([], {})).rejects.toThrow(/skilltree\.yml|paths/i);
+		} finally {
+			process.chdir(cwd);
+		}
+	});
+});
 
 describe("scanCommand", () => {
 	test("reports no files found for empty directory", async () => {

--- a/tests/core/git.test.ts
+++ b/tests/core/git.test.ts
@@ -10,6 +10,7 @@ import {
 	getDefaultBranch,
 	listDirAtRef,
 	listTags,
+	lsRemote,
 	readFileAtRef,
 	repoCachePath,
 } from "../../src/core/git.js";
@@ -26,6 +27,53 @@ afterEach(async () => {
 	if (tempDir) {
 		await rm(tempDir, { recursive: true, force: true });
 	}
+});
+
+describe("lsRemote", () => {
+	test("returns { ok: true } against a reachable local repo", async () => {
+		// `file://` against a fresh test repo — exercises the success path
+		// without needing network or a real remote. Mirrors how registries are
+		// reached locally in CI.
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "reachable", [{ path: "skills/a", name: "a" }]);
+
+		const outcome = await lsRemote(`file://${repoDir}`);
+
+		expect(outcome.ok).toBe(true);
+	});
+
+	test("returns { ok: false, reason: 'unreachable' } when the path doesn't exist", async () => {
+		// Bad file:// path → git fails with "does not appear to be a git repo"
+		// or similar. The categorization heuristic should land it in either
+		// `unreachable` or `other` — both are non-fatal for `add`, but tests
+		// against the actual category we shipped behavior for.
+		const dir = await makeTempDir();
+		const fakePath = join(dir, "does-not-exist");
+
+		const outcome = await lsRemote(`file://${fakePath}`);
+
+		expect(outcome.ok).toBe(false);
+		// The exact reason depends on git's error text — both unreachable and
+		// other are legitimate; we just need a stable non-ok signal here.
+		if (!outcome.ok) {
+			expect(["unreachable", "other"]).toContain(outcome.reason);
+			expect(outcome.detail).toBeTruthy();
+		}
+	});
+
+	test("respects the timeout when the probe stalls", async () => {
+		// 1ms timeout against any URL is essentially guaranteed to fire the
+		// timer before simpleGit returns. We're testing the race-resolution
+		// shape, not the underlying git call. A non-existent URL is fine here
+		// — the probe either times out (timer wins) or fails fast (git wins).
+		const outcome = await lsRemote("file:///dev/null/nope", { timeoutMs: 1 });
+
+		expect(outcome.ok).toBe(false);
+		if (!outcome.ok) {
+			// Whichever side of the race won; both are valid terminal states.
+			expect(["timeout", "unreachable", "other"]).toContain(outcome.reason);
+		}
+	});
 });
 
 describe("repoCachePath", () => {


### PR DESCRIPTION
## Why

Five small CLI input-validation papercuts surfaced during v0.32.0 integration testing. Each bites a real user in the first 5 minutes of `init → add → new → scan`. Bundled because they share the theme — validate input earlier or fall back to a sensible default.

Closes #71
Closes #120
Closes #122
Closes #125
Closes #126

## What changed

- **`new` (#120)** — Check for `skilltree.yml` before writing the scaffolded file; previously orphan files were left behind in non-skilltree dirs. `--no-register` bypasses the check.
- **`init` (#126)** — New `-f, --force` flag to overwrite an existing manifest (works on legacy `.yaml` too).
- **`add --source` (#122)** — Refuse URL-shaped values at parse time and point at `--repo`. Previously the URL landed literally as the alias and install crashed with `Unknown source alias`.
- **`scan` (#125)** — `[paths...]` is now optional; defaults to the project's resolved install-target directories. Fails clearly without a manifest.
- **`add --repo` (#71)** — Probe URL with `git ls-remote` (5s timeout). Unreachable → warn; auth/timeout → soft note; always proceeds with the write. New `--no-verify` flag skips the probe.