### PR TITLE
fix(doctor): hardening + lsRemote locale + registry probe coverage (#114, #115, #121, #123, #128)

### DIFF
--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -48,10 +48,10 @@ skilltree add testing --dev --repo github.com/org/shared-skills --path skills/te
 - `-t, --type <skill|agent|command>` — Override type inference (commands install to `.claude/commands/`)
 - `--registry <name>` — When no `--repo`, resolve from this registry only (disambiguates multiple matches)
 - `-g, --global` — Add to global dependencies (~/.skilltree/global.yaml)
-- `--no-verify` — Skip the `git ls-remote` reachability check on `--repo` URLs (offline / pre-registering an unpushed repo)
+- `--no-verify` — Skip the `git ls-remote` reachability check on any repo-bearing dep (offline / pre-registering an unpushed repo)
 
 **Validation:**
-- For `--repo <url>`: probes the URL with `git ls-remote` (5s timeout). Unreachable URLs warn but still write the entry; auth-required URLs print a soft note. Use `--no-verify` to skip the probe.
+- For any dep that resolves to a `repo` URL — explicit `--repo <url>` **and** registry-resolved adds like `skilltree add python-coding` (issue #128) — probes the URL with `git ls-remote` (5s timeout). Unreachable URLs warn but still write the entry; auth-required URLs print a soft note. Use `--no-verify` to skip the probe.
 - For `--source <alias>`: must be an alias name registered under the manifest's `sources:` block. URLs are refused — use `--repo` for direct URLs.
 
 ## `skilltree new`
@@ -226,11 +226,11 @@ skilltree doctor --global
 
 Checks performed (in order):
 
-1. **manifest-schema** — `skilltree.yml` parses and validates.
+1. **manifest-schema** — `skilltree.yml` parses and validates. Reports YAML parse errors with the file name (e.g. `Failed to load skilltree.yml: …`) instead of conflating "missing" with "malformed" (issue #123).
 2. **lint** — wraps `skilltree check` (asymmetric publish + frontmatter validity).
-3. **lockfile-sync** — `skilltree.lock` has no `added` / `removed` / `changed` entries vs the manifest.
+3. **lockfile-sync** — `skilltree.lock` has no `added` / `removed` / `changed` entries vs the manifest. Vacuously passes when the manifest declares zero deps (no lockfile required for an empty project — issue #121). Distinguishes "missing `lockfile_version` key" from "wrong version value" in the error (issue #123).
 4. **target-consistency** — every `install_targets` entry resolves through the agent registry or is a literal path that exists.
-5. **registry-reachability** — each configured registry reachable via `git ls-remote` (5s timeout). Auth-required and timeout are reported as warnings, not failures.
+5. **registry-reachability** — each configured registry reachable via `git ls-remote` (5s timeout). The probe forces `LC_ALL=C`/`LANG=C`/`GIT_TERMINAL_PROMPT=0` on the spawn so auth/unreachable classification stays correct in non-English locales and so private-repo URLs don't block on a credential prompt (issue #114). Auth-required and timeout are reported as warnings, not failures.
 6. **frontmatter** — same as lint #2; reported separately for output readability.
 
 Exit codes:

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -93,9 +93,16 @@ export async function addCommand(name: string, opts: AddOptions, dir: string): P
 }
 
 /**
- * Probe a `--repo` dep with `git ls-remote` so typos / unreachable URLs
- * surface at add-time instead of at install-time. Issue #71. Always
- * proceeds with the write — the probe is advisory, not gating:
+ * Probe any dep that carries a `repo` field with `git ls-remote` so typos
+ * and unreachable URLs surface at add-time instead of at install-time.
+ * Issues #71 + #128 — the call happens once after `buildDependency`, so it
+ * covers all repo-bearing shapes:
+ *
+ *   - explicit `--repo <url>` deps, and
+ *   - registry-resolved deps (`skilltree add python-coding`), whose `repo`
+ *     comes from the registry index (stale URLs hide there too).
+ *
+ * Always proceeds with the write — the probe is advisory, not gating:
  *
  *   - reachable      → silent
  *   - unreachable    → warning (probably a typo, install will fail)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -105,6 +105,13 @@ export async function doctorCommand(dir: string, opts: DoctorOptions = {}): Prom
 // Per-check implementations
 // ---------------------------------------------------------------------------
 
+function countDeclaredDeps(manifest: Manifest): number {
+	return (
+		Object.keys(manifest.dependencies ?? {}).length +
+		Object.keys(manifest["dev-dependencies"] ?? {}).length
+	);
+}
+
 function checkManifestSchema(
 	manifest: Manifest | null,
 	loadError: string | undefined,
@@ -159,6 +166,12 @@ async function checkLockfileSync(
 	}
 	if (!manifest) {
 		return { name: "lockfile-sync", status: "skip", detail: "no manifest" };
+	}
+	// Vacuous pass: with zero declared deps there's nothing to lock, so the
+	// absence of a lockfile is not a problem. Without this guard the canonical
+	// `init && doctor` flow returns exit 1 on a brand-new project (issue #121).
+	if (countDeclaredDeps(manifest) === 0) {
+		return { name: "lockfile-sync", status: "pass", detail: "no dependencies declared" };
 	}
 	try {
 		const lockfile = await readLockfile(dir);

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -38,7 +38,11 @@ export type LsRemoteOutcome =
  * On timeout the underlying git process keeps running until git itself
  * gives up; we don't bother killing it because the outcome has already
  * been reported. Auth-failure detection uses stderr-text heuristics
- * (`Authentication failed`, `could not read Username`, `Permission denied`).
+ * (`Authentication failed`, `could not read Username`, `Permission denied`)
+ * — we force `LC_ALL=C`/`LANG=C` on the spawn so those English strings
+ * appear regardless of the user's locale (issue #114). Also set
+ * `GIT_TERMINAL_PROMPT=0` so a private-repo URL never blocks waiting
+ * for credentials when ssh/key-helpers aren't configured.
  */
 export async function lsRemote(
 	url: string,
@@ -46,7 +50,12 @@ export async function lsRemote(
 ): Promise<LsRemoteOutcome> {
 	const timeoutMs = opts.timeoutMs ?? 5000;
 	const cloneUrl = toGitCloneUrl(url);
-	const git = simpleGit();
+	const git = simpleGit().env({
+		...process.env,
+		LC_ALL: "C",
+		LANG: "C",
+		GIT_TERMINAL_PROMPT: "0",
+	});
 	const probe: Promise<LsRemoteOutcome> = git
 		.listRemote([cloneUrl])
 		.then(() => ({ ok: true as const }))

--- a/src/core/lockfile.ts
+++ b/src/core/lockfile.ts
@@ -117,6 +117,15 @@ export function parseLockfile(content: string): Lockfile {
 		throw new Error("Corrupted lockfile: could not parse YAML");
 	}
 
+	// Distinguish "field missing entirely" from "field present but wrong value"
+	// (issue #123). Without the name in the error, the user sees
+	// `Unsupported lockfile version: undefined` and can't tell whether the key
+	// is missing or the value is unrecognized.
+	if (raw.lockfile_version === undefined) {
+		throw new Error(
+			"Invalid lockfile: missing required key `lockfile_version`. Expected `lockfile_version: 1` at the top of the file. Run `skilltree install` to regenerate.",
+		);
+	}
 	if (raw.lockfile_version !== 1) {
 		throw new Error(`Unsupported lockfile version: ${raw.lockfile_version}`);
 	}

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -445,11 +445,24 @@ export async function loadManifestOrThrow(
 	const isGlobal = opts?.global ?? false;
 	try {
 		return isGlobal ? await readGlobalManifest(opts?.globalDir) : await readManifest(dir);
-	} catch {
+	} catch (err) {
+		// Distinguish "file absent" from "file present but parse-failed" so
+		// `doctor` doesn't tell users to run `init` when the manifest is right
+		// there — just malformed (issue #123). ENOENT comes from the readFile
+		// call inside readManifest/readGlobalManifest; everything else is
+		// either a YAML parse error or a `parseManifest` shape rejection.
+		if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+			throw new Error(
+				isGlobal
+					? "No global manifest found. Run `skilltree init --global` first."
+					: `No ${MANIFEST_NEW} found. Run \`skilltree init\` first.`,
+			);
+		}
+		const msg = err instanceof Error ? err.message : String(err);
 		throw new Error(
 			isGlobal
-				? "No global manifest found. Run `skilltree init --global` first."
-				: `No ${MANIFEST_NEW} found. Run \`skilltree init\` first.`,
+				? `Failed to load global manifest: ${msg}`
+				: `Failed to load ${MANIFEST_NEW}: ${msg}`,
 		);
 	}
 }

--- a/tests/commands/add.test.ts
+++ b/tests/commands/add.test.ts
@@ -771,3 +771,107 @@ describe("addCommand — --repo URL verification (#71)", () => {
 		expect(probeCalled).toBe(false);
 	});
 });
+
+describe("addCommand — registry-resolved verification (#128)", () => {
+	test("probes the resolved `repo` for registry-resolved deps too", async () => {
+		// Issue #128: registry-resolved adds (`skilltree add python-coding`)
+		// produce a dep with `repo` set from the registry index. The probe
+		// is called once after `buildDependency`, so it covers this path
+		// the same as explicit `--repo` — proven by injecting `lsRemoteFn`
+		// and asserting it was called with the registry-supplied URL.
+		const dir = await setup();
+		const cacheDir = join(dir, "regcache");
+		const configPath = join(dir, "registries.yaml");
+		await writeFile(
+			configPath,
+			"registries:\n  - name: vibes\n    repo: github.com/example/vibes\n",
+			"utf-8",
+		);
+		const { writeRegistryIndex } = await import("../../src/core/registry-cache.js");
+		await writeRegistryIndex(
+			{
+				registry: "vibes",
+				repo: "github.com/example/vibes",
+				updated_at: new Date().toISOString(),
+				entities: [
+					{
+						name: "registry-skill",
+						type: "skill",
+						path: "skills/registry-skill",
+						description: "A skill resolved from the registry index",
+						tags: [],
+					},
+				],
+			},
+			cacheDir,
+		);
+		const probedUrls: string[] = [];
+		await addCommand(
+			"registry-skill",
+			{
+				configPath,
+				cacheDir,
+				lsRemoteFn: async (url) => {
+					probedUrls.push(url);
+					return { ok: true };
+				},
+			},
+			dir,
+		);
+		expect(probedUrls).toContain("github.com/example/vibes");
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["registry-skill"]).toBeDefined();
+	});
+
+	test("warns when registry-resolved repo is unreachable, still writes entry", async () => {
+		const dir = await setup();
+		const cacheDir = join(dir, "regcache");
+		const configPath = join(dir, "registries.yaml");
+		await writeFile(
+			configPath,
+			"registries:\n  - name: stale\n    repo: github.com/stale/registry\n",
+			"utf-8",
+		);
+		const { writeRegistryIndex } = await import("../../src/core/registry-cache.js");
+		await writeRegistryIndex(
+			{
+				registry: "stale",
+				repo: "github.com/stale/registry",
+				updated_at: new Date().toISOString(),
+				entities: [
+					{
+						name: "moved-skill",
+						type: "skill",
+						path: "skills/moved-skill",
+						description: "A skill whose repo URL went stale upstream",
+						tags: [],
+					},
+				],
+			},
+			cacheDir,
+		);
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+		try {
+			await addCommand(
+				"moved-skill",
+				{
+					configPath,
+					cacheDir,
+					lsRemoteFn: async () => ({
+						ok: false,
+						reason: "unreachable",
+						detail: "could not resolve host",
+					}),
+				},
+				dir,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+		expect(warnings.some((w) => /unreach|could not reach/i.test(w))).toBe(true);
+		const manifest = await readManifest(dir);
+		expect(manifest.dependencies?.["moved-skill"]).toBeDefined();
+	});
+});

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -190,7 +190,10 @@ describe("runDoctor — clean project", () => {
 
 describe("runDoctor — lockfile sync", () => {
 	test("acceptance #2: deleted lockfile → fail on lockfile-sync", async () => {
-		const dir = await makeProject(cleanProject());
+		// Use a project with at least one declared dep so the missing lockfile
+		// is a real sync mismatch — empty-deps projects pass vacuously now
+		// (issue #121).
+		const dir = await makeProject(projectWithLocalSkill());
 		await unlink(join(dir, "skilltree.lock"));
 		const report = await runDoctorIsolated(dir);
 		const lock = report.checks.find((c) => c.name === "lockfile-sync");
@@ -359,7 +362,7 @@ describe("doctorCommand — exit codes", () => {
 	});
 
 	test("exit 1 on any fail", async () => {
-		const dir = await makeProject(cleanProject());
+		const dir = await makeProject(projectWithLocalSkill());
 		await unlink(join(dir, "skilltree.lock"));
 		const out = await runCli(dir);
 		expect(out.exitCode).toBe(1);
@@ -376,10 +379,10 @@ describe("doctorCommand — text rendering", () => {
 	});
 
 	test("fail row shows ✘ and the indented → fix line", async () => {
-		const dir = await makeProject(cleanProject());
+		const dir = await makeProject(projectWithLocalSkill());
 		await unlink(join(dir, "skilltree.lock"));
 		const out = await runCli(dir);
-		const all = out.logs.join("\n") + "\n" + out.warns.join("\n") + "\n" + out.errs.join("\n");
+		const all = `${out.logs.join("\n")}\n${out.warns.join("\n")}\n${out.errs.join("\n")}`;
 		expect(all).toContain("✘");
 		expect(all).toContain("lockfile-sync");
 	});
@@ -430,7 +433,7 @@ describe("runDoctor — --json output", () => {
 	});
 
 	test("J3: fail row includes detail and fix when applicable", async () => {
-		const dir = await makeProject(cleanProject());
+		const dir = await makeProject(projectWithLocalSkill());
 		await unlink(join(dir, "skilltree.lock"));
 		const report = await runDoctorIsolated(dir);
 		const lock = report.checks.find((c) => c.name === "lockfile-sync");
@@ -682,7 +685,7 @@ describe("doctorCommand — --json", () => {
 	});
 
 	test("C2: exit 1 on fail; stdout is valid JSON", async () => {
-		const dir = await makeProject(cleanProject());
+		const dir = await makeProject(projectWithLocalSkill());
 		await unlink(join(dir, "skilltree.lock"));
 		const out = await runCliWithOpts(dir, { json: true, probe: okProbe });
 		expect(out.exitCode).toBe(1);
@@ -751,5 +754,99 @@ describe("runDoctor — read-only invariant", () => {
 		for (const [path, mt] of before.entries()) {
 			expect(after.get(path)).toBe(mt);
 		}
+	});
+
+	test("RO3: global mode does not change any file mtime under globalDir (#115)", async () => {
+		// Belt-and-braces: the global codepath shares the same per-check
+		// functions as project mode but routes through `loadManifestOrThrow
+		// ({ global: true })` and short-circuits project-only checks. RO1/RO2
+		// don't cover global-specific paths, so a regression that mutated
+		// `~/.skilltree/` would slip past.
+		const { globalDir } = await makeGlobalProject({
+			manifest: "name: global\ndependencies: {}\n",
+		});
+		const cfg = await writeRegistriesFile([]);
+		const before = await snapshotMtimes(globalDir);
+		await runDoctor("/no-such-project-dir", {
+			global: true,
+			globalDir,
+			probe: okProbe,
+			registryConfigPath: cfg,
+		});
+		const after = await snapshotMtimes(globalDir);
+		expect(after.size).toBe(before.size);
+		for (const [path, mt] of before.entries()) {
+			expect(after.get(path)).toBe(mt);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Empty-deps vacuous pass for lockfile-sync (#121)
+// ---------------------------------------------------------------------------
+
+describe("runDoctor — empty-deps vacuous pass (#121)", () => {
+	test("fresh init (zero deps, no lockfile) passes lockfile-sync, exits 0", async () => {
+		const dir = await makeProject({
+			manifest: ["name: fresh", "install_targets:", "  - claude", "dependencies: {}", ""].join(
+				"\n",
+			),
+			lockfile: null,
+		});
+		const report = await runDoctorIsolated(dir);
+		const lock = report.checks.find((c) => c.name === "lockfile-sync");
+		expect(lock?.status).toBe("pass");
+		expect(lock?.detail ?? "").toMatch(/no (deps|dependencies)/i);
+		expect(report.summary.fail).toBe(0);
+	});
+
+	test("zero deps in both groups still passes vacuously", async () => {
+		const dir = await makeProject({
+			manifest: [
+				"name: fresh",
+				"install_targets:",
+				"  - claude",
+				"dependencies: {}",
+				"dev-dependencies: {}",
+				"",
+			].join("\n"),
+			lockfile: null,
+		});
+		const report = await runDoctorIsolated(dir);
+		expect(report.checks.find((c) => c.name === "lockfile-sync")?.status).toBe("pass");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Manifest / lockfile error attribution (#123)
+// ---------------------------------------------------------------------------
+
+describe("runDoctor — manifest / lockfile error attribution (#123)", () => {
+	test("malformed YAML in skilltree.yml → manifest-schema fails with a parse-error message, not 'No skilltree.yml found'", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-doctor-malformed-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: [unclosed\n", "utf-8");
+		const cfg = await writeRegistriesFile([]);
+		const report = await runDoctor(tempDir, { probe: okProbe, registryConfigPath: cfg });
+		const schema = report.checks.find((c) => c.name === "manifest-schema");
+		expect(schema?.status).toBe("fail");
+		// The new wording references the file by name and reflects a parse error
+		// rather than the misleading "No skilltree.yml found".
+		expect(schema?.detail ?? "").toMatch(/skilltree\.yml/);
+		expect(schema?.detail ?? "").not.toMatch(/No skilltree\.yml found/);
+	});
+
+	test("lockfile missing `lockfile_version` key → lockfile-sync names the missing field, not `undefined`", async () => {
+		const dir = await makeProject(projectWithLocalSkill());
+		// Overwrite the lockfile with a body that lacks `lockfile_version`.
+		await writeFile(
+			join(dir, "skilltree.lock"),
+			"# skilltree.lock -- DO NOT EDIT MANUALLY\nversion: 1\npackages: {}\n",
+			"utf-8",
+		);
+		const report = await runDoctorIsolated(dir);
+		const lock = report.checks.find((c) => c.name === "lockfile-sync");
+		expect(lock?.status).toBe("fail");
+		expect(lock?.detail ?? "").toMatch(/lockfile_version/);
+		expect(lock?.detail ?? "").not.toMatch(/undefined/);
 	});
 });

--- a/tests/core/git.test.ts
+++ b/tests/core/git.test.ts
@@ -74,6 +74,37 @@ describe("lsRemote", () => {
 			expect(["timeout", "unreachable", "other"]).toContain(outcome.reason);
 		}
 	});
+
+	test("locale-independent: stderr stays English under a non-English LC_ALL (#114)", async () => {
+		// Issue #114: classification of git stderr (auth / unreachable / other)
+		// uses English substring matching. Without locale pinning, a French/
+		// German/Japanese-locale user would see translated git messages and
+		// fall through to `reason: "other"`. The fix forces `LC_ALL=C` on
+		// the spawned process — this test sets a non-English LC_ALL on the
+		// parent and verifies the resulting stderr detail is still English.
+		const dir = await makeTempDir();
+		const fakePath = join(dir, "no-such-repo");
+		const originalLcAll = process.env.LC_ALL;
+		const originalLang = process.env.LANG;
+		process.env.LC_ALL = "fr_FR.UTF-8";
+		process.env.LANG = "fr_FR.UTF-8";
+		try {
+			const outcome = await lsRemote(`file://${fakePath}`);
+			expect(outcome.ok).toBe(false);
+			if (!outcome.ok) {
+				// English git error wording for missing repos. If the spawn
+				// had inherited fr_FR, "ne semble pas" / "n'existe pas" would
+				// appear instead. We assert at least one English token from
+				// the canonical message.
+				expect(outcome.detail).toMatch(/does not (appear to be|exist)|not a git repository/i);
+			}
+		} finally {
+			if (originalLcAll === undefined) delete process.env.LC_ALL;
+			else process.env.LC_ALL = originalLcAll;
+			if (originalLang === undefined) delete process.env.LANG;
+			else process.env.LANG = originalLang;
+		}
+	});
 });
 
 describe("repoCachePath", () => {

--- a/tests/core/lockfile-unhappy.test.ts
+++ b/tests/core/lockfile-unhappy.test.ts
@@ -11,7 +11,9 @@ describe("lockfile corruption handling", () => {
 	});
 
 	test("throws on YAML array instead of mapping", () => {
-		expect(() => parseLockfile("- item1\n- item2\n")).toThrow("Unsupported lockfile version");
+		// YAML arrays don't have `lockfile_version` either — they hit the
+		// missing-key branch and surface the named-field error (#123).
+		expect(() => parseLockfile("- item1\n- item2\n")).toThrow(/lockfile_version/);
 	});
 
 	test("throws on wrong lockfile_version", () => {
@@ -21,7 +23,8 @@ describe("lockfile corruption handling", () => {
 	});
 
 	test("throws on missing lockfile_version", () => {
-		expect(() => parseLockfile("packages: {}\n")).toThrow("Unsupported lockfile version");
+		// Naming the missing field, not the undefined value (#123).
+		expect(() => parseLockfile("packages: {}\n")).toThrow(/lockfile_version/);
 	});
 
 	test("handles lockfile with only comments", () => {

--- a/tests/core/lockfile.test.ts
+++ b/tests/core/lockfile.test.ts
@@ -134,6 +134,15 @@ describe("parseLockfile", () => {
 		);
 	});
 
+	test("missing lockfile_version key names the field, not 'undefined' (#123)", () => {
+		// Issue #123: the old message ("Unsupported lockfile version: undefined")
+		// made the user think the value was the problem rather than the key.
+		// Distinguish missing from wrong: missing → name the field; wrong-value
+		// → name the value.
+		expect(() => parseLockfile("version: 1\npackages: {}")).toThrow(/lockfile_version/);
+		expect(() => parseLockfile("version: 1\npackages: {}")).not.toThrow(/undefined/);
+	});
+
 	test("rejects a lockfile with a dependency cycle (issue #47)", () => {
 		// The resolver rejects cycles, so any cycle in a lockfile is corruption.
 		// Validate at read time so all consumers (deps tree, install --frozen)


### PR DESCRIPTION
## Why

`skilltree doctor` had three first-impression bugs and one classification gap. PR bundles five tightly-related issues touching `doctor` and the shared `lsRemote` helper.

Closes #121
Closes #123
Closes #114
Closes #115
Closes #128

## What changed

- **`doctor`** (#121): `lockfile-sync` now passes vacuously when the manifest declares zero deps. Canonical `init && doctor` flow returns exit 0 instead of a red ✘.
- **`doctor`** (#123A): `loadManifestOrThrow` distinguishes ENOENT from parse errors. Malformed `skilltree.yml` reports `Failed to load skilltree.yml: <yaml error>` instead of the misleading `No skilltree.yml found`.
- **`lockfile`** (#123B): `parseLockfile` names the missing `lockfile_version` key explicitly, replacing the leaky `Unsupported lockfile version: undefined`.
- **`lsRemote`** (#114): spawns git with `LC_ALL=C`/`LANG=C`/`GIT_TERMINAL_PROMPT=0`. Auth/unreachable stderr heuristics stay correct in non-English locales; private-repo URLs no longer block waiting for credentials.
- **`doctor`** (#115): adds RO3 mtime invariant test for `--global` mode to mirror RO1/RO2 project-mode coverage.
- **`add`** (#128): documents and tests that `verifyRepoIfNeeded` already covers registry-resolved deps — `buildDependency` produces a `repo` field for registry hits, so the existing call site fires uniformly. Added two confirming tests + tighter docstring.
- **Docs**: `skills/skilltree/references/commands.md` updated for all five behaviors.

## How tested

- New tests added (all green): `runDoctor — empty-deps vacuous pass (#121)`, `runDoctor — manifest / lockfile error attribution (#123)`, `runDoctor — read-only invariant RO3 (#115)`, `lsRemote — locale-independent stderr (#114)`, `addCommand — registry-resolved verification (#128)` (2 tests), `parseLockfile — missing lockfile_version key (#123)`.
- Existing tests that depended on `cleanProject()` (empty deps) failing on a deleted lockfile updated to use `projectWithLocalSkill()` so they still exercise the real sync mismatch.
- `bun test`: 1447 pass / 0 fail. `bun run typecheck`: clean. `bun run lint`: clean.

## Risk & rollback

Low. All changes are localized (error wording, one vacuous-pass branch, one env-injection, plus tests/docs). Revert with `git revert <sha>` if needed; no schema or lockfile-format changes.