### PR TITLE
chore(housekeeping): gitignore + parseIndexedSelection + lockfile fixtures + README freshness (#97, #109, #110, #116, #117)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ demo/*.mp4
 .claude/skills/
 .claude/agents/
 .claude/commands/
+.claude/worktree/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 test

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -246,30 +246,13 @@ async function promptForTargetSelection(agents: string[], ask: AskFn): Promise<s
 }
 
 /**
- * Same grammar as `parseSelectionAnswer` (empty / y → all, n → none, comma
- * indices → subset), but operating on a plain string list. Kept as its own
- * function rather than generalising because the caller's empty-result
- * handling differs (we fall back to [claude] instead of accepting empty).
+ * Thin wrapper over `parseIndexedSelection` kept as its own named export
+ * because the agent-selection prompt has a slightly different empty-result
+ * fallback (the caller substitutes `[claude]` when the user picks none).
+ * The grammar itself lives in `parseIndexedSelection`. Issue #97.
  */
 export function parseAgentSelectionAnswer(answer: string, agents: string[]): string[] {
-	const trimmed = answer.trim();
-	if (trimmed === "" || trimmed.toLowerCase() === "y") return [...agents];
-	if (trimmed.toLowerCase() === "n") return [];
-
-	const indices = trimmed
-		.split(",")
-		.map((s) => Number.parseInt(s.trim(), 10))
-		.filter((n) => Number.isInteger(n) && n >= 1 && n <= agents.length);
-
-	const selected: string[] = [];
-	const seen = new Set<number>();
-	for (const i of indices) {
-		if (seen.has(i)) continue;
-		seen.add(i);
-		const agent = agents[i - 1];
-		if (agent) selected.push(agent);
-	}
-	return selected;
+	return parseIndexedSelection(answer, agents);
 }
 
 /**
@@ -341,31 +324,47 @@ function printDiscovered(entries: LocalEntry[]): void {
 }
 
 /**
- * Parse the user's reply to the selection prompt.
- *
- * - Empty / `y` / `Y` → include all
- * - `n` / `N` → include none
- * - Comma-separated integers (1-based, matching the printed numbering) → subset
- * - Invalid indices and garbage are ignored rather than failing the init —
- *   the user can always re-run or hand-edit the manifest.
+ * Parse the user's reply to the discovered-skills selection prompt.
+ * Thin wrapper over the generic grammar. Issue #97.
  */
 export function parseSelectionAnswer(answer: string, entries: LocalEntry[]): LocalEntry[] {
+	return parseIndexedSelection(answer, entries);
+}
+
+/**
+ * Generic 1-based-index selection grammar shared by every `Include all? [Y/n/
+ * 1,3,5]` prompt in init.
+ *
+ * - Empty / `y` / `Y` → include all (returns a shallow copy so callers can
+ *   mutate without poisoning the input).
+ * - `n` / `N` → include none.
+ * - Comma-separated integers (1-based, matching the printed numbering) → subset.
+ *   Indices are de-duplicated; the FIRST occurrence wins for ordering.
+ * - Invalid indices and garbage are silently dropped — the user can always
+ *   re-run or hand-edit the manifest.
+ *
+ * Generic over `T` so a single grammar covers both `LocalEntry[]`
+ * (scan discoveries) and `string[]` (agent enrolment). Empty-result handling
+ * lives in the caller, not here.
+ */
+export function parseIndexedSelection<T>(answer: string, items: T[]): T[] {
 	const trimmed = answer.trim();
-	if (trimmed === "" || trimmed.toLowerCase() === "y") return entries;
-	if (trimmed.toLowerCase() === "n") return [];
+	const lower = trimmed.toLowerCase();
+	if (trimmed === "" || lower === "y") return [...items];
+	if (lower === "n") return [];
 
 	const indices = trimmed
 		.split(",")
 		.map((s) => Number.parseInt(s.trim(), 10))
-		.filter((n) => Number.isInteger(n) && n >= 1 && n <= entries.length);
+		.filter((n) => Number.isInteger(n) && n >= 1 && n <= items.length);
 
-	const selected: LocalEntry[] = [];
+	const selected: T[] = [];
 	const seen = new Set<number>();
 	for (const i of indices) {
 		if (seen.has(i)) continue;
 		seen.add(i);
-		const entry = entries[i - 1];
-		if (entry) selected.push(entry);
+		const item = items[i - 1];
+		if (item !== undefined) selected.push(item);
 	}
 	return selected;
 }

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { doctorCommand, runDoctor } from "../../src/commands/doctor.js";
 import { serializeLockfile } from "../../src/core/lockfile.js";
 import type { Lockfile } from "../../src/types.js";
+import { emptyLockfile, localEntry } from "../helpers/lockfile-fixtures.js";
 
 let tempDir: string;
 
@@ -40,10 +41,6 @@ async function makeProject(spec: ProjectSpec): Promise<string> {
 	return tempDir;
 }
 
-function emptyLockfile(): Lockfile {
-	return { lockfile_version: 1, install_targets: ["claude"], packages: {} };
-}
-
 function cleanProject(): ProjectSpec {
 	return {
 		manifest: ["name: clean", "install_targets:", "  - claude", "dependencies: {}", ""].join("\n"),
@@ -70,19 +67,8 @@ function projectWithLocalSkill(
 			"",
 		].join("\n"),
 		lockfile: {
-			lockfile_version: 1,
-			install_targets: ["claude"],
-			packages: {
-				[name]: {
-					source: "local",
-					path: `./skills/${name}`,
-					name,
-					type: "skill",
-					group: "prod",
-					commit: "HEAD",
-					dependencies: [],
-				},
-			},
+			...emptyLockfile(),
+			packages: { [name]: localEntry(name, { name }) },
 		},
 		files: [{ path: `skills/${name}/SKILL.md`, content: frontmatter }],
 	};

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -3,7 +3,12 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { initCommand, parseSelectionAnswer } from "../../src/commands/init.js";
+import {
+	initCommand,
+	parseAgentSelectionAnswer,
+	parseIndexedSelection,
+	parseSelectionAnswer,
+} from "../../src/commands/init.js";
 import { readManifest } from "../../src/core/manifest.js";
 import type { LocalEntry } from "../../src/core/repo-scanner.js";
 
@@ -256,6 +261,39 @@ describe("initCommand", () => {
 				expect(picked.map((e) => e.name)).toEqual(expectedNames);
 			});
 		}
+	});
+
+	// Issue #97: parseSelectionAnswer and parseAgentSelectionAnswer now both
+	// delegate to a single `parseIndexedSelection<T>` grammar. The two
+	// specialized wrappers must continue to share that grammar — these tests
+	// pin equivalence so a future change to one branch can't drift from the
+	// other.
+	describe("parseIndexedSelection (shared grammar, #97)", () => {
+		const items = ["alpha", "beta", "gamma", "delta"];
+		const stringCases: Array<[string, string[]]> = [
+			["", ["alpha", "beta", "gamma", "delta"]],
+			["y", ["alpha", "beta", "gamma", "delta"]],
+			["n", []],
+			["2", ["beta"]],
+			["1,3", ["alpha", "gamma"]],
+			["3, 1", ["gamma", "alpha"]],
+			["1,1,4", ["alpha", "delta"]],
+			["99", []],
+			["garbage", []],
+		];
+		for (const [input, expected] of stringCases) {
+			test(`generic<string> "${input}" → [${expected.join(", ")}]`, () => {
+				expect(parseIndexedSelection(input, items)).toEqual(expected);
+				// Symmetry: the agent wrapper resolves to the same answer.
+				expect(parseAgentSelectionAnswer(input, items)).toEqual(expected);
+			});
+		}
+
+		test("'y' returns a shallow copy, not the input array", () => {
+			const out = parseIndexedSelection("y", items);
+			expect(out).not.toBe(items);
+			expect(out).toEqual(items);
+		});
 	});
 
 	test("--scan with askFn drives the interactive prompt and prints the listing", async () => {

--- a/tests/core/lockfile-diff.test.ts
+++ b/tests/core/lockfile-diff.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { diffManifestLockfile } from "../../src/core/lockfile.js";
 import type { Lockfile, Manifest } from "../../src/types.js";
+import { localEntry, remoteEntry } from "../helpers/lockfile-fixtures.js";
 
 describe("diffManifestLockfile", () => {
 	test("detects unchanged entries", () => {
@@ -12,15 +13,11 @@ describe("diffManifestLockfile", () => {
 		const lockfile: Lockfile = {
 			lockfile_version: 1,
 			packages: {
-				"my-skill": {
-					type: "skill",
-					group: "prod",
+				"my-skill": remoteEntry("my-skill", {
 					repo: "github.com/user/repo",
 					path: "skills/my-skill",
 					version: "1.2.0",
-					commit: "abc",
-					dependencies: [],
-				},
+				}),
 			},
 		};
 
@@ -127,14 +124,7 @@ describe("diffManifestLockfile", () => {
 		const lockfile: Lockfile = {
 			lockfile_version: 1,
 			packages: {
-				"local-skill": {
-					type: "skill",
-					group: "prod",
-					source: "local",
-					path: "./skills/local",
-					commit: "HEAD",
-					dependencies: [],
-				},
+				"local-skill": localEntry("local-skill", { path: "./skills/local" }),
 			},
 		};
 

--- a/tests/helpers/lockfile-fixtures.ts
+++ b/tests/helpers/lockfile-fixtures.ts
@@ -1,0 +1,73 @@
+// Lockfile fixture builders for tests.
+//
+// `LockfileEntry.commit` is non-optional (see `src/types.ts`), but tsc cannot
+// catch the omission in hand-rolled fixtures because every field is
+// structural. The historical fix was to remember to add `commit: "HEAD"` in
+// every new lockfile fixture site — and it kept getting forgotten (see
+// issue #117). Use these builders so the required defaults exist in one place.
+//
+// Usage:
+//   import { emptyLockfile, localEntry, remoteEntry } from "../helpers/lockfile-fixtures";
+//   const lock = emptyLockfile();                       // valid, empty
+//   const lock2 = { ...emptyLockfile(), packages: { foo: localEntry("foo") } };
+//   const lock3 = { ...emptyLockfile(["claude", "codex"]), packages: { ... } };
+//
+// Always builders, never constants — each test gets its own object so mutation
+// in one test can't leak.
+
+import type { DependencyGroup, EntityType, Lockfile, LockfileEntry } from "../../src/types.js";
+
+export function emptyLockfile(installTargets: string[] = ["claude"]): Lockfile {
+	return { lockfile_version: 1, install_targets: installTargets, packages: {} };
+}
+
+export interface LocalEntryOpts {
+	type?: EntityType;
+	group?: DependencyGroup;
+	deps?: string[];
+	/** Override `./skills/<name>` when the test wants a non-conventional path. */
+	path?: string;
+	/** YAML-key aliasing for collision tests. */
+	name?: string;
+}
+
+export function localEntry(name: string, opts: LocalEntryOpts = {}): LockfileEntry {
+	const entry: LockfileEntry = {
+		source: "local",
+		path: opts.path ?? `./skills/${name}`,
+		type: opts.type ?? "skill",
+		group: opts.group ?? "prod",
+		commit: "HEAD",
+		dependencies: opts.deps ?? [],
+	};
+	if (opts.name) entry.name = opts.name;
+	return entry;
+}
+
+export interface RemoteEntryOpts {
+	type?: EntityType;
+	group?: DependencyGroup;
+	deps?: string[];
+	repo?: string;
+	path?: string;
+	version?: string;
+	commit?: string;
+	name?: string;
+}
+
+export function remoteEntry(name: string, opts: RemoteEntryOpts = {}): LockfileEntry {
+	const entry: LockfileEntry = {
+		repo: opts.repo ?? `github.com/example/${name}`,
+		path: opts.path ?? `skills/${name}`,
+		type: opts.type ?? "skill",
+		group: opts.group ?? "prod",
+		version: opts.version ?? "1.0.0",
+		// `commit` is non-optional in LockfileEntry — defaulting to a stable
+		// placeholder lets tests pass through readLockfile / diff helpers
+		// without surprises. Override when the test cares about the value.
+		commit: opts.commit ?? "abc123",
+		dependencies: opts.deps ?? [],
+	};
+	if (opts.name) entry.name = opts.name;
+	return entry;
+}

--- a/tests/skills/skilltree-skill-freshness.test.ts
+++ b/tests/skills/skilltree-skill-freshness.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 const SKILL_DIR = join(import.meta.dir, "..", "..", "skills", "skilltree");
 const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
+const README_PATH = join(import.meta.dir, "..", "..", "README.md");
 
 /**
  * Extract registered commands and options from cli.ts source.
@@ -92,6 +93,33 @@ describe("skilltree skill freshness", () => {
 		expect(skillMd.startsWith("---")).toBe(true);
 		expect(skillMd).toContain("name: skilltree");
 		expect(skillMd).toContain("description:");
+	});
+
+	// Issue #116: README's Commands table is a separate source of truth from
+	// `commands.md` and was drifting silently — `skilltree check` shipped weeks
+	// before it appeared in the README table, while the narrative section
+	// already referenced it. This mirrors the `commands.md` freshness check
+	// against `README.md` so the next absent row fails CI instead of waiting
+	// for someone to notice.
+	test("README.md Commands table covers all CLI commands (#116)", async () => {
+		const readme = await readFile(README_PATH, "utf-8");
+		const { commands } = await extractCliDefinitions();
+
+		const missing: string[] = [];
+		for (const cmd of commands) {
+			const searchTerm = SUBCOMMAND_PARENTS[cmd]
+				? `skilltree ${SUBCOMMAND_PARENTS[cmd]}`
+				: `skilltree ${cmd}`;
+			if (!readme.includes(searchTerm)) {
+				missing.push(cmd);
+			}
+		}
+
+		if (missing.length > 0) {
+			throw new Error(
+				`README.md is missing documentation for: ${missing.join(", ")}\nUpdate the Commands table in README.md to match the CLI.`,
+			);
+		}
 	});
 
 	test("workflows.md references all major commands", async () => {


### PR DESCRIPTION
## Why

Five small chores that have been sitting in the backlog. All low-risk and tightly themed: "leave the repo cleaner than we found it." No user-visible behavior changes.

Closes #109
Closes #110
Closes #97
Closes #117
Closes #116

## What changed

- **.gitignore** (#109 + #110): add \`.claude/worktree/\` (singular) alongside the existing plural entry. \`/resolve-issue\` writes to singular; contributors no longer see the worktree as untracked.
- **\`src/commands/init.ts\`** (#97): consolidate \`parseSelectionAnswer\` and \`parseAgentSelectionAnswer\` into one generic \`parseIndexedSelection<T>(answer, items): T[]\`. Both named wrappers preserved so call sites stay readable; grammar lives in one place.
- **\`tests/helpers/lockfile-fixtures.ts\`** (#117, new): \`emptyLockfile\`, \`localEntry\`, \`remoteEntry\` builders. Required \`commit\` field defaulted in one place. \`tests/commands/doctor.test.ts\` and \`tests/core/lockfile-diff.test.ts\` adopt them — future test files have a canonical source to copy.
- **\`tests/skills/skilltree-skill-freshness.test.ts\`** (#116): new test that mirrors the existing \`commands.md\` freshness check against \`README.md\`'s Commands table. Catches drift like \`skilltree check\` shipping weeks before its README row appeared.

## How tested

- New tests: \`parseIndexedSelection (shared grammar, #97)\` describe block — parametrized symmetry table proving the two named wrappers stay equivalent + shallow-copy invariant.
- New test: \`README.md Commands table covers all CLI commands (#116)\`.
- Existing tests using lockfile fixtures (doctor.test.ts + lockfile-diff.test.ts) refactored to use the new helper; all still pass.
- \`bun test\`: 1458 pass / 0 fail. \`bun run typecheck\` + \`bun run lint\`: clean.

## Risk & rollback

Low. \`parseIndexedSelection\` is byte-equivalent to the originals (one tiny safer change: \`y\` now returns a shallow copy instead of the input array — covered by an explicit test). Refactor + tests + 1-line gitignore + 1 new test. \`git revert <sha>\` cleanly reverses.