### PR TITLE
feat(deps): tree shows @<short-sha> for unpinned, commit in JSON, canonical names for aliases (#94, #107)

### DIFF
--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -275,10 +275,20 @@ Show the dependency tree with dedup markers.
 ```bash
 skilltree deps tree
 skilltree deps tree --global
+skilltree deps tree --json
 ```
 
 **Flags:**
 - `-g, --global` — Show global dependency tree
+- `--json` — Machine-readable nested object tree per root. Every non-local node includes a `commit` field for the resolved revision (issue #94).
+- `--dedupe` — Legacy terse view (cargo-tree's default): transitive duplicates show `deduped` and stop recursing.
+
+**Version display:**
+- Pinned remote deps render as `@<version>` (e.g. `parent@2.0.0`).
+- Unpinned remote deps render as `@<short-sha>` (7 chars) — falls back to the resolved commit from `skilltree.lock` so the user still sees what was installed (issue #94, mirroring `skilltree list`).
+- Local deps render no version suffix; the `(type, local)` tag covers them.
+
+**Aliased entries:** when a manifest key uses an alias (`pc: { local: ..., name: python-coding }`), both the root and any transitive reference render under the canonical entity name (`python-coding`) — never under the YAML key (issue #107). One label per entity per tree.
 
 ## `skilltree why <name>`
 

--- a/src/commands/deps.ts
+++ b/src/commands/deps.ts
@@ -3,6 +3,7 @@ import { readGlobalManifest, readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { dim, pc } from "../core/ui.js";
 import type { EntityType, Lockfile, LockfileEntry } from "../types.js";
+import { SHORT_SHA_LEN } from "./list.js";
 
 export interface DepsOptions {
 	global?: boolean;
@@ -22,6 +23,12 @@ interface JsonTreeNode {
 	name: string;
 	type: EntityType;
 	version?: string;
+	/**
+	 * Resolved commit SHA for non-local entries — present whether or not the
+	 * caller pinned a version (issue #94). Lets `--json` consumers identify
+	 * what was actually installed without re-parsing the lockfile.
+	 */
+	commit?: string;
 	source?: string;
 	deduped?: boolean;
 	dependencies: JsonTreeNode[];
@@ -30,6 +37,38 @@ interface JsonTreeNode {
 /** cargo-tree convention: marks a node whose canonical print is elsewhere. */
 const DUPLICATE_MARKER = "(*)";
 const DEDUPED_LABEL = "deduped";
+
+/**
+ * Tree-display version suffix. Issue #94: unpinned remote deps drop to
+ * `@<short-sha>` instead of an empty string so the user can still see which
+ * commit was resolved. Local deps render no version suffix — the `(..., local)`
+ * type tag already conveys "no pinning applies."
+ *
+ * Distinct from `versionLabel` in `list.ts`: that one returns mixed shapes
+ * (`"1.0.0"` for versions, `"@abc1234"` for commits) suited to a tabular
+ * column. The tree always wants the `@` prefix.
+ */
+function treeVersionLabel(entry: LockfileEntry): string {
+	if (entry.version !== undefined) return `@${entry.version}`;
+	if (entry.source === "local") return "";
+	if (entry.commit) return `@${entry.commit.slice(0, SHORT_SHA_LEN)}`;
+	return "";
+}
+
+/**
+ * Canonical display name for a node, regardless of root vs. transitive
+ * position. Issue #107: roots previously rendered under their YAML key while
+ * transitives rendered under the frontmatter `name:` from the parent's
+ * `dependencies:` list — the same entity appeared with two different labels
+ * inside one tree when aliased.
+ *
+ * Single rule: prefer the canonical `entry.name` (which is what frontmatter
+ * references resolve to), fall back to the lookup key. Roots that aren't
+ * aliased still print under their YAML key (no `entry.name` set).
+ */
+function canonicalDisplayName(entry: LockfileEntry, lookupKey: string): string {
+	return entry.name ?? lookupKey;
+}
 
 export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<void> {
 	const isGlobal = !!opts?.global;
@@ -62,7 +101,13 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 		for (const root of roots) {
 			const entry = lockfile.packages[root];
 			if (!entry) continue;
-			tree.push(buildJsonTree(root, root, entry, lockfile, nameIndex, printedJson, true, dedupe));
+			// Issue #107: roots use the same canonical name rule as transitives
+			// (entry.name ?? key) so an aliased entry doesn't appear under
+			// two different labels in the same tree.
+			const displayName = canonicalDisplayName(entry, root);
+			tree.push(
+				buildJsonTree(displayName, root, entry, lockfile, nameIndex, printedJson, true, dedupe),
+			);
 		}
 		console.log(JSON.stringify(tree, null, 2));
 		return;
@@ -73,7 +118,8 @@ export async function depsTreeCommand(dir: string, opts?: DepsOptions): Promise<
 	for (const root of roots) {
 		const entry = lockfile.packages[root];
 		if (!entry) continue;
-		printTree(root, root, entry, lockfile, nameIndex, "", true, true, printed, dedupe);
+		const displayName = canonicalDisplayName(entry, root);
+		printTree(displayName, root, entry, lockfile, nameIndex, "", true, true, printed, dedupe);
 	}
 }
 
@@ -100,6 +146,10 @@ function buildJsonTree(
 	};
 	if (entry.version) node.version = entry.version;
 	if (entry.source) node.source = entry.source;
+	// Surface the resolved commit for every non-local entry so consumers can
+	// identify the exact installed revision (issue #94). For local deps the
+	// lockfile records `commit: HEAD` which is meaningless — skip it there.
+	if (entry.source !== "local" && entry.commit) node.commit = entry.commit;
 
 	const alreadyPrinted = printed.has(entryKey);
 	// Top-level entries are direct project deps; never mark them deduped
@@ -130,13 +180,8 @@ function buildJsonTree(
 function printTree(
 	displayName: string,
 	entryKey: string,
-	entry: { type: string; version?: string; source?: string; dependencies: string[] },
-	lockfile: {
-		packages: Record<
-			string,
-			{ type: string; version?: string; source?: string; dependencies: string[] }
-		>;
-	},
+	entry: LockfileEntry,
+	lockfile: Lockfile,
 	nameIndex: Map<string, string>,
 	prefix: string,
 	isRoot: boolean,
@@ -145,7 +190,7 @@ function printTree(
 	dedupe: boolean,
 ): void {
 	const connector = isRoot ? "" : isLast ? "└── " : "├── ";
-	const version = entry.version ? `@${entry.version}` : "";
+	const version = treeVersionLabel(entry);
 	const source = entry.source === "local" ? "local" : "";
 	const alreadyPrinted = printed.has(entryKey);
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -59,7 +59,7 @@ interface ListRow {
 }
 
 /** Short SHA convention used elsewhere in the codebase (see graph.ts install warnings). */
-const SHORT_SHA_LEN = 7;
+export const SHORT_SHA_LEN = 7;
 
 /**
  * Display label for a lockfile entry's version column.
@@ -68,8 +68,11 @@ const SHORT_SHA_LEN = 7;
  * still see a meaningful identifier instead of a bare `-`. Local deps keep
  * their `"local"` label; the literal `"-"` only appears when neither version
  * nor commit is recorded.
+ *
+ * Exported so `deps tree` and any future inspection command can share the
+ * same rendering convention without re-implementing the fallback (issue #94).
  */
-function versionLabel(entry: Lockfile["packages"][string]): string {
+export function versionLabel(entry: Lockfile["packages"][string]): string {
 	if (entry.version !== undefined) return entry.version;
 	if (entry.source === "local") return "local";
 	if (entry.commit) return `@${entry.commit.slice(0, SHORT_SHA_LEN)}`;

--- a/tests/commands/deps-tree.test.ts
+++ b/tests/commands/deps-tree.test.ts
@@ -523,6 +523,180 @@ describe("deps tree rendering", () => {
 		expect(childLine).toContain("deduped");
 	});
 
+	// Issue #94: when a remote dep has no semver pin, the tree previously
+	// dropped the version suffix entirely — even though `skilltree.lock`
+	// records the resolved commit SHA. Mirror the fix already shipped in
+	// `list` (issue #76): render `@<short-sha>` as the fallback so users
+	// can still identify what was installed.
+	test("renders @<short-sha> for unpinned remote deps in text tree (#94)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"repo",
+			[{ path: "skills/unpinned", name: "unpinned" }],
+			// No tag → version is undefined in the lockfile; only commit is set.
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "bare-unpinned");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  unpinned:\n    repo: "file://${bareDir}"\n    path: skills/unpinned\n`,
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => depsTreeCommand(dir));
+		// The first (and only) line should be `unpinned@<7-char-sha> (skill)`.
+		expect(lines[0]).toMatch(/^unpinned@[0-9a-f]{7} \(skill\)$/);
+	});
+
+	test("--json surfaces commit on every non-local entry (#94)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"repo-with-commit",
+			[
+				{ path: "skills/child", name: "child" },
+				{ path: "skills/parent", name: "parent", dependencies: ["child"] },
+			],
+			"v1.0.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "bare-commit");
+
+		await writeManifest(
+			dir,
+			`dependencies:\n  parent:\n    repo: "file://${bareDir}"\n    path: skills/parent\n    version: "*"\n`,
+		);
+		await installCommand(dir, {});
+
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+		const tree = JSON.parse(lines.join("\n")) as Array<{
+			name: string;
+			commit?: string;
+			version?: string;
+			dependencies: Array<{ name: string; commit?: string }>;
+		}>;
+		const parent = tree[0];
+		expect(parent).toBeDefined();
+		expect(parent?.commit).toMatch(/^[0-9a-f]{40}$/); // full SHA in JSON
+		expect(parent?.version).toBe("1.0.0");
+		expect(parent?.dependencies[0]?.commit).toMatch(/^[0-9a-f]{40}$/);
+	});
+
+	test("--json omits commit on local deps (commit: HEAD is meaningless there) (#94)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "local-only");
+		await writeManifest(dir, "dependencies:\n  local-only:\n    local: ./skills/local-only\n");
+		await installCommand(dir, {});
+
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => lines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+		const tree = JSON.parse(lines.join("\n")) as Array<{ name: string; commit?: string }>;
+		expect(tree[0]?.name).toBe("local-only");
+		expect(tree[0]?.commit).toBeUndefined();
+	});
+
+	// Issue #107: an aliased entry (YAML key ≠ entity name) previously rendered
+	// under its YAML key when reached as a root and under its entity name when
+	// reached as a transitive. Same entity, two labels in one tree. The fix
+	// uses `entry.name ?? key` consistently — so the root now matches the
+	// transitive label.
+	test("aliased entry uses canonical entity name as a root (#107)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => depsTreeCommand(dir));
+		// Root renders under the canonical name, not the YAML key.
+		expect(lines[0]).toBe("python-coding (skill, local)");
+		// And the YAML alias does not leak into the rendering.
+		expect(lines.some((l) => /^pc[\s(]/.test(l))).toBe(false);
+	});
+
+	test("aliased root and its transitive occurrence share one label (#107)", async () => {
+		// Aliased entry reached both as a root (`pc`) AND as a transitive
+		// (`python-coding` from task-builder's frontmatter). After the fix,
+		// both lines say `python-coding`.
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+		await createLocalSkill(join(dir, "skills"), "task-builder", ["python-coding"]);
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"  task-builder:",
+				"    local: ./skills/task-builder",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const lines = await captureConsole(() => depsTreeCommand(dir));
+		// Both the root and the transitive must use the same label.
+		const rootLine = lines.find((l) => l === "python-coding (skill, local)");
+		const transitiveLine = lines.find((l) => /└── python-coding/.test(l));
+		expect(rootLine).toBeDefined();
+		expect(transitiveLine).toBeDefined();
+		// `pc` (the YAML alias) must not appear as a node label.
+		expect(lines.some((l) => /^pc[\s(]/.test(l))).toBe(false);
+	});
+
+	test("--json: aliased root uses canonical entity name (#107)", async () => {
+		const dir = await makeTempDir();
+		await createLocalSkill(join(dir, "skills"), "python-coding");
+
+		await writeManifest(
+			dir,
+			[
+				"dependencies:",
+				"  pc:",
+				"    local: ./skills/python-coding",
+				"    name: python-coding",
+				"",
+			].join("\n"),
+		);
+		await installCommand(dir, {});
+
+		const jsonLines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => jsonLines.push(args.join(" "));
+		try {
+			await depsTreeCommand(dir, { json: true });
+		} finally {
+			console.log = original;
+		}
+		const tree = JSON.parse(jsonLines.join("\n")) as Array<{ name: string }>;
+		expect(tree).toHaveLength(1);
+		expect(tree[0]?.name).toBe("python-coding");
+	});
+
 	test("json: transitive lookup resolves aliased YAML keys (issue #102)", async () => {
 		const dir = await makeTempDir();
 		await createLocalSkill(join(dir, "skills"), "python-coding");


### PR DESCRIPTION
## Why

Two small visibility fixes in \`skilltree deps tree\`:

- **#94**: when a remote dep has no semver pin, the tree drops the version entirely even though the lockfile records the resolved commit SHA. Same blind spot as #76 (fixed in PR #93 for \`list\`) — fix it consistently in \`deps tree\` too.
- **#107**: an aliased entry (YAML key ≠ entity name) appears under its YAML key when reached as a root and under its entity name when reached as a transitive. Same entity, two different labels in one tree.

Closes #94
Closes #107

Issue #85 (resolver error attribution audit) was originally bundled here but is project-sized — see https://github.com/imarios/skilltree/issues/85#issuecomment-4480498826 for the assessment. Punted to its own development-methodology project.

## What changed

- **\`src/commands/deps.ts\`** (#94): introduce \`treeVersionLabel(entry)\` — renders \`@<version>\` for pinned deps, \`@<short-sha>\` for unpinned non-local deps, empty for local deps. The JSON tree gains a \`commit\` field on every non-local node regardless of whether \`version\` is set. Shares \`SHORT_SHA_LEN\` with \`list.ts\`.
- **\`src/commands/deps.ts\`** (#107): introduce \`canonicalDisplayName(entry, key) → entry.name ?? key\` and apply at both root iteration sites (text + JSON). Roots without aliases still render under their YAML key (no \`entry.name\` set → fallback to key).
- **\`src/commands/list.ts\`**: export \`versionLabel\` and \`SHORT_SHA_LEN\` so the inspection commands share the short-sha convention.
- **\`src/commands/deps.ts\`** drive-by: tighten \`printTree\` parameter types from inline structural shapes to \`LockfileEntry\` / \`Lockfile\` now that the local widening is no longer needed.
- **\`skills/skilltree/references/commands.md\`**: document the new \`--json\` / \`--dedupe\` flags, the version-display rules, and aliased-entry behavior.

## How tested

- Six new tests in \`tests/commands/deps-tree.test.ts\`:
  - text tree renders \`@<short-sha>\` for an unpinned remote dep (#94)
  - JSON surfaces \`commit\` (full SHA) on every non-local node (#94)
  - JSON omits \`commit\` on local deps (#94 — \`commit: HEAD\` would be meaningless)
  - aliased root renders under canonical name (#107, text)
  - aliased root + transitive share one label (#107, text)
  - aliased root in JSON uses canonical name (#107)
- Existing 16 deps-tree tests still pass (the #102 alias-tracking tests were the most likely regression target; all green).
- \`bun test\` 1464 pass / 0 fail. \`bun run typecheck\` + \`bun run lint\`: clean.

## Risk & rollback

Low. New code paths are additive (extra JSON field, fallback render); the only behavior change visible to existing consumers is "aliased roots now show entity name" — which the issue explicitly requested. \`git revert <sha>\` cleanly reverses.