### PR TITLE
fix: bundle four small fixes — release-process, vendor, check, scan (#70, #91, #108, #124)

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,7 +1,17 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.36.0"
-version_files = ["package.json:version"]
+version_files = [
+    "package.json:\"version\"",
+    "package.json:skilltree-cli-darwin-arm64",
+    "package.json:skilltree-cli-darwin-x64",
+    "package.json:skilltree-cli-linux-arm64",
+    "package.json:skilltree-cli-linux-x64",
+    "npm/cli-darwin-arm64/package.json:\"version\"",
+    "npm/cli-darwin-x64/package.json:\"version\"",
+    "npm/cli-linux-arm64/package.json:\"version\"",
+    "npm/cli-linux-x64/package.json:\"version\"",
+]
 tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_file = "CHANGELOG.md"

--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imarios/skilltree-cli-darwin-arm64",
-  "version": "0.10.0",
+  "version": "0.36.0",
   "description": "skilltree binary for macOS Apple Silicon",
   "license": "MIT",
   "repository": {

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imarios/skilltree-cli-darwin-x64",
-  "version": "0.10.0",
+  "version": "0.36.0",
   "description": "skilltree binary for macOS Intel",
   "license": "MIT",
   "repository": {

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imarios/skilltree-cli-linux-arm64",
-  "version": "0.10.0",
+  "version": "0.36.0",
   "description": "skilltree binary for Linux ARM64",
   "license": "MIT",
   "repository": {

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imarios/skilltree-cli-linux-x64",
-  "version": "0.10.0",
+  "version": "0.36.0",
   "description": "skilltree binary for Linux x64",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "LICENSE"
   ],
   "optionalDependencies": {
-    "@imarios/skilltree-cli-darwin-arm64": "0.10.0",
-    "@imarios/skilltree-cli-darwin-x64": "0.10.0",
-    "@imarios/skilltree-cli-linux-arm64": "0.10.0",
-    "@imarios/skilltree-cli-linux-x64": "0.10.0"
+    "@imarios/skilltree-cli-darwin-arm64": "0.36.0",
+    "@imarios/skilltree-cli-darwin-x64": "0.36.0",
+    "@imarios/skilltree-cli-linux-arm64": "0.36.0",
+    "@imarios/skilltree-cli-linux-x64": "0.36.0"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",

--- a/skills/skilltree/references/commands.md
+++ b/skills/skilltree/references/commands.md
@@ -214,7 +214,10 @@ Reports: `OK` (matches), `MODIFIED` (changed), `LINKED` (symlink), `MISSING`, `S
 
 ## `skilltree check`
 
-Design-time lint of `skilltree.yml`. Currently catches **asymmetric publish state** — a publicly-visible local entity that depends (directly or transitively) on a same-repo `publish: false` entity. Your own install succeeds; downstream consumers fail at install time on the transitive `publish: false`.
+Design-time lint of `skilltree.yml`. Catches:
+
+- **Schema errors** (exit 1 by default): manifest type mismatches (e.g. `publish: "no"` when boolean is expected), unknown frontmatter keys, malformed YAML in `SKILL.md` / agent / command frontmatter. Same diagnostics as `install` so `check` doesn't silently ✔ broken input.
+- **Asymmetric publish state** (warning): a publicly-visible local entity that depends (directly or transitively) on a same-repo `publish: false` entity. Your own install succeeds; downstream consumers fail at install time on the transitive `publish: false`.
 
 ```bash
 skilltree check
@@ -222,7 +225,7 @@ skilltree check --strict
 ```
 
 **Flags:**
-- `--strict` — Exit 1 if any warnings are found
+- `--strict` — Exit 1 if any *warnings* are found (errors always exit 1).
 
 Each warning shows the chain (`A → B → C (publish: false)`) so the fix is obvious: either remove `publish: false` on the leaf or break the dependency chain.
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,12 +1,13 @@
 import { readFile, stat } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
 import { isSingleFileEntity } from "../core/entity-type.js";
+import { MANIFEST_NEW } from "../core/filenames.js";
 import { validateFrontmatter } from "../core/frontmatter.js";
 import type { ResolvedEntity } from "../core/graph.js";
 import { resolveAll } from "../core/graph.js";
-import { loadManifestOrThrow } from "../core/manifest.js";
+import { loadManifestOrThrow, validateManifest } from "../core/manifest.js";
 import { expandTilde } from "../core/paths.js";
-import { dim, pc, warn } from "../core/ui.js";
+import { dim, error, pc, warn } from "../core/ui.js";
 import type { CheckSummary, Dependency, EntityType, Manifest } from "../types.js";
 import { isLocalDependency } from "../types.js";
 
@@ -23,10 +24,15 @@ export interface CheckOptions {
  * Spec: docs/specs/doctor.md §D6, §D10. Nitrogen Phase 1.
  */
 export async function collectCheckIssues(manifest: Manifest, dir: string): Promise<CheckSummary> {
+	// Schema validation must run in check too — same diagnostics as install.
+	// Pre-#124 these only ran inside `validateManifestOrThrow` on the install
+	// path, leaving `check` to ✔ broken manifests that `install` rejects.
+	const errors = validateManifest(manifest).map((e) => `${MANIFEST_NEW}: ${e}`);
 	const result = await resolveAll(manifest, dir);
 	const lint = lintAsymmetricPublish(result.entities);
 	const frontmatter = await lintLocalFrontmatter(manifest, dir);
 	return {
+		errors: [...errors, ...frontmatter.errors],
 		lint,
 		frontmatterWarnings: frontmatter.warnings,
 		frontmatterNotes: frontmatter.notes,
@@ -47,6 +53,9 @@ export async function checkCommand(dir: string, opts: CheckOptions = {}): Promis
 	const manifest = await loadManifestOrThrow(dir);
 	const summary = await collectCheckIssues(manifest, dir);
 
+	for (const e of summary.errors) {
+		error(e);
+	}
 	for (const w of summary.lint) {
 		warn(w);
 	}
@@ -57,15 +66,25 @@ export async function checkCommand(dir: string, opts: CheckOptions = {}): Promis
 		console.log(dim(`  ${n}`));
 	}
 
-	const issueCount = summary.lint.length + summary.frontmatterWarnings.length;
-	if (issueCount === 0) {
+	const warnCount = summary.lint.length + summary.frontmatterWarnings.length;
+	const errCount = summary.errors.length;
+
+	if (errCount === 0 && warnCount === 0) {
 		console.log(pc.green("✔ No issues."));
 		return;
 	}
 
+	// Errors fail by default (#124). Warnings are --strict-gated.
+	if (errCount > 0) {
+		console.log(
+			pc.red(`\n${errCount} error${errCount === 1 ? "" : "s"} found. Fix before running install.`),
+		);
+		process.exit(1);
+	}
+
 	console.log(
 		pc.dim(
-			`\n${issueCount} issue${issueCount === 1 ? "" : "s"} found. ` +
+			`\n${warnCount} issue${warnCount === 1 ? "" : "s"} found. ` +
 				`Re-run with --strict to fail the command on warnings.`,
 		),
 	);
@@ -153,7 +172,8 @@ function findHiddenChains(
 export async function lintLocalFrontmatter(
 	manifest: Manifest,
 	projectDir: string,
-): Promise<{ warnings: string[]; notes: string[] }> {
+): Promise<{ errors: string[]; warnings: string[]; notes: string[] }> {
+	const errors: string[] = [];
 	const warnings: string[] = [];
 	const notes: string[] = [];
 
@@ -166,17 +186,18 @@ export async function lintLocalFrontmatter(
 		if (!deps) continue;
 		for (const [key, dep] of Object.entries(deps)) {
 			if (!isLocalDependency(dep)) continue;
-			await lintOneLocalEntry(key, dep, projectDir, warnings, notes);
+			await lintOneLocalEntry(key, dep, projectDir, errors, warnings, notes);
 		}
 	}
 
-	return { warnings, notes };
+	return { errors, warnings, notes };
 }
 
 async function lintOneLocalEntry(
 	manifestKey: string,
 	dep: { local: string; type?: EntityType; name?: string },
 	projectDir: string,
+	errors: string[],
 	warnings: string[],
 	notes: string[],
 ): Promise<void> {
@@ -205,7 +226,8 @@ async function lintOneLocalEntry(
 	const prefix = displayPath(resolved.path, projectDir);
 	for (const issue of issues) {
 		const line = `${prefix}: ${issue.message}`;
-		if (issue.kind === "note") notes.push(line);
+		if (issue.kind === "error") errors.push(line);
+		else if (issue.kind === "note") notes.push(line);
 		else warnings.push(line);
 	}
 }

--- a/src/commands/vendor.ts
+++ b/src/commands/vendor.ts
@@ -147,6 +147,27 @@ export async function vendorCommand(dir: string, options: VendorOptions): Promis
 
 	const existingLockfile = await readLockfile(dir);
 
+	// Issue #108: detect a target switch and clean up the previously-vendored
+	// directory before populating the new one. Without this, `vendor --target X`
+	// then `vendor --target Y` leaves X's tree orphaned on disk — not gitignored
+	// (a previous vendor removed those entries), not referenced by the new
+	// lockfile, but still committable via `git add .`. Cleanup is a no-op when
+	// the recorded target matches, when there is no recorded target (legacy
+	// `vendor: true` boolean), or when nothing was previously vendored.
+	const prevTarget = manifest.vendored_target;
+	const isTargetSwitch =
+		prevTarget !== undefined && rawTarget !== undefined && prevTarget !== rawTarget;
+	if (isTargetSwitch && existingLockfile) {
+		const prevInstallPath = resolveTarget(prevTarget);
+		const prevInstallBase = join(dir, prevInstallPath);
+		await deleteVendoredFiles(existingLockfile, prevInstallBase);
+		const prevIgnoreEntries = getSkillAgentIgnoreEntries(prevInstallPath);
+		await addGitignoreEntries(dir, prevIgnoreEntries);
+		console.log(
+			dim(`Cleaned up previously vendored ${prevInstallPath}/ (switching to ${devInstallPath}/)`),
+		);
+	}
+
 	if (options.frozen) {
 		if (!existingLockfile) {
 			throw new Error("--frozen requires a lockfile. Run `skilltree install` first.");

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -99,8 +99,19 @@ export function getDeclaredDeps(fm: SkillFrontmatter): string[] {
  *   note    — printed dim, never gates `--strict`. Examples: unknown
  *             frontmatter key (so authors learn the supported shape).
  */
+/**
+ * Severity levels for frontmatter lint findings (#124):
+ *   error   — file is structurally broken or has an invalid schema. Fails
+ *             `check` by default (no `--strict` needed). Examples: malformed
+ *             YAML in frontmatter, frontmatter that isn't a mapping, unknown
+ *             frontmatter keys (`type: notathing`, `publish: "no"`).
+ *   warning — soft issue that doesn't break the file. `--strict` promotes
+ *             to exit 1. Examples: missing required field, missing
+ *             frontmatter altogether, empty frontmatter.
+ *   note    — informational; never gates.
+ */
 export interface FrontmatterIssue {
-	kind: "warning" | "note";
+	kind: "error" | "warning" | "note";
 	field?: string;
 	message: string;
 }
@@ -169,8 +180,10 @@ function extractFrontmatterYaml(content: string): { yaml: string } | { issue: Fr
 	}
 	const endIndex = trimmed.indexOf("---", 3);
 	if (endIndex === -1) {
+		// Structural break — the file's frontmatter is unparseable. Hard error
+		// regardless of --strict (#124).
 		return {
-			issue: { kind: "warning", message: "malformed frontmatter: missing closing ---" },
+			issue: { kind: "error", message: "malformed frontmatter: missing closing ---" },
 		};
 	}
 	const yaml = trimmed.slice(3, endIndex).trim();
@@ -184,13 +197,15 @@ function parseFrontmatterMapping(
 	try {
 		const raw = YAML.parse(yamlContent);
 		if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-			return { issue: { kind: "warning", message: "frontmatter must be a YAML mapping" } };
+			return { issue: { kind: "error", message: "frontmatter must be a YAML mapping" } };
 		}
 		return { mapping: raw as Record<string, unknown> };
 	} catch (e) {
 		const detail = e instanceof Error ? e.message : String(e);
 		return {
-			issue: { kind: "warning", message: `malformed YAML in frontmatter: ${detail}` },
+			// Unparseable YAML is a hard error — the file is broken, not a lint
+			// nit. Always exit 1, no --strict required (#124).
+			issue: { kind: "error", message: `malformed YAML in frontmatter: ${detail}` },
 		};
 	}
 }
@@ -279,18 +294,20 @@ function checkSkills(fm: Record<string, unknown>): FrontmatterIssue[] {
 }
 
 /**
- * Unknown keys — emitted as dim notes, never gate --strict. Helps authors
- * catch typos and learn the supported shape (e.g., `agents:` is a common
- * guess that isn't actually consumed).
+ * Unknown keys — hard error (#124). The `install` path rejects unknown shape
+ * fields like `type: notathing` or `publish: "no"`, and `check` must agree
+ * to be useful as a pre-commit lint. Before #124 these were dim notes; the
+ * "false ✔ No issues" output line then contradicted the per-file detail
+ * lines printed right above it.
  */
 function collectUnknownKeyNotes(fm: Record<string, unknown>): FrontmatterIssue[] {
-	const notes: FrontmatterIssue[] = [];
+	const errors: FrontmatterIssue[] = [];
 	for (const key of Object.keys(fm)) {
 		if (!KNOWN_FRONTMATTER_KEYS.has(key)) {
-			notes.push({ kind: "note", field: key, message: `unknown frontmatter key '${key}'` });
+			errors.push({ kind: "error", field: key, message: `unknown frontmatter key '${key}'` });
 		}
 	}
-	return notes;
+	return errors;
 }
 
 function describeType(value: unknown): string {

--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
+import YAML from "yaml";
 import type { SkillFrontmatter } from "../types.js";
 import { entityNameFromPath, mdFileType } from "./entity-type.js";
 import { getDeclaredDeps, parseFrontmatter } from "./frontmatter.js";
@@ -335,6 +336,11 @@ function chooseDepsKey(filePath: string, fm: SkillFrontmatter): DepsKey {
  * convention when neither is present) and writes exactly one deps block —
  * never a parallel `dependencies:`/`skills:` pair. See `chooseDepsKey` and
  * issue #68 for the full rules.
+ *
+ * Uses YAML.parseDocument so author formatting survives the round-trip:
+ * flow-style sequences, comments, key ordering, scalar style are preserved
+ * for everything we don't touch. Only the target deps key gets a new value;
+ * the rest of the frontmatter passes through verbatim (#91).
  */
 export async function applyToFrontmatter(filePath: string, newDeps: string[]): Promise<void> {
 	const content = await readFile(filePath, "utf-8");
@@ -345,41 +351,26 @@ export async function applyToFrontmatter(filePath: string, newDeps: string[]): P
 	const targetKey = chooseDepsKey(filePath, frontmatter);
 	const existing = frontmatter[targetKey] ?? [];
 	const merged = [...new Set([...existing, ...newDeps])].sort();
+	if (merged.length === 0) return;
 
-	// Rebuild frontmatter
-	const depsYaml =
-		merged.length > 0 ? `${targetKey}:\n${merged.map((d) => `  - ${d}`).join("\n")}` : "";
-
-	// Find frontmatter boundaries
+	// Find frontmatter boundaries (parseFrontmatter already verified shape).
 	const firstDelim = content.indexOf("---");
 	const secondDelim = content.indexOf("---", firstDelim + 3);
-	const existingFm = content.slice(firstDelim + 3, secondDelim).trim();
-
-	// Strip the existing block for the *target* key only. The other deps key,
-	// if present, is left in place — `chooseDepsKey` already preferred it if
-	// it was non-empty, so reaching here means the orthogonal key holds no
-	// dep list we'd overwrite. (Empty `dependencies: []` / `skills: []`
-	// scalars are preserved verbatim; harmless and round-trip-friendly.)
-	const fmLines = existingFm.split("\n");
-	const filteredLines: string[] = [];
-	let inDepBlock = false;
-	for (const line of fmLines) {
-		if (line.startsWith(`${targetKey}:`)) {
-			inDepBlock = true;
-			continue;
-		}
-		if (inDepBlock && line.startsWith("  - ")) {
-			continue;
-		}
-		inDepBlock = false;
-		filteredLines.push(line);
-	}
-
-	const newFmContent = [...filteredLines.filter((l) => l.trim()), depsYaml]
-		.filter((l) => l)
-		.join("\n");
+	const fmYaml = content.slice(firstDelim + 3, secondDelim);
 	const bodyAfter = content.slice(secondDelim + 3);
-	const newContent = `---\n${newFmContent}\n---${bodyAfter}`;
+
+	const doc = YAML.parseDocument(fmYaml);
+	// Mutate (or add) the target key in-place. yaml@2.x preserves untouched
+	// nodes' style + comments through .toString(); the new sequence will use
+	// the Document's default style (block), which matches the historical
+	// behavior for the value we control.
+	doc.set(targetKey, merged);
+
+	// Trim the leading/trailing newlines that .toString() adds so the
+	// `---\n<yaml>\n---` envelope stays canonical regardless of the input's
+	// leading whitespace.
+	const newFm = doc.toString().replace(/^\n+|\n+$/g, "");
+	const newContent = `---\n${newFm}\n---${bodyAfter}`;
 
 	await writeFile(filePath, newContent, "utf-8");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,10 @@ export interface CheckResult {
  * gate.
  */
 export interface CheckSummary {
+	/** Hard errors — fail `check` by default, no `--strict` needed (#124).
+	 * Includes manifest schema errors (PS27/PS28), malformed frontmatter
+	 * YAML, and unknown frontmatter keys. */
+	errors: string[];
 	lint: string[];
 	frontmatterWarnings: string[];
 	frontmatterNotes: string[];

--- a/tests/build/version-sync.test.ts
+++ b/tests/build/version-sync.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Issue #70: a fresh user running `npx skilltree-pm` hit
+ * `could not find package "@imarios/skilltree-cli-<platform>"` because the
+ * git repo's `optionalDependencies` and platform package.json files were
+ * pinned at 0.10.0 while the main package was at 0.27.x. The published
+ * artifact was kept in lockstep by `build-npm.sh` at publish time, but the
+ * git source-of-truth drifted between every release.
+ *
+ * Fix: `.cz.toml` now declares all five package.json files under
+ * `version_files`, so `cz bump` bumps every version in lockstep. This test
+ * is the post-fix invariant: anyone editing one version without the others
+ * fails CI.
+ */
+describe("release/version-sync: optionalDependencies pin tracks package version (#70)", () => {
+	const ROOT = join(__dirname, "..", "..");
+	const rootPkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+	const PLATFORMS = ["cli-darwin-arm64", "cli-darwin-x64", "cli-linux-arm64", "cli-linux-x64"];
+
+	test("optionalDependencies entries match root package.version", () => {
+		const expected = rootPkg.version;
+		for (const platform of PLATFORMS) {
+			const key = `@imarios/skilltree-${platform}`;
+			expect(rootPkg.optionalDependencies?.[key]).toBe(expected);
+		}
+	});
+
+	test("each platform package.json version matches root package.version", () => {
+		const expected = rootPkg.version;
+		for (const platform of PLATFORMS) {
+			const platformPkg = JSON.parse(
+				readFileSync(join(ROOT, "npm", platform, "package.json"), "utf-8"),
+			);
+			expect(platformPkg.version).toBe(expected);
+		}
+	});
+});

--- a/tests/commands/check.test.ts
+++ b/tests/commands/check.test.ts
@@ -29,23 +29,35 @@ async function makeProject(opts: {
 	return tempDir;
 }
 
-function captureOutput(): { logs: string[]; warns: string[]; restore: () => void } {
+function captureOutput(): {
+	logs: string[];
+	warns: string[];
+	errors: string[];
+	restore: () => void;
+} {
 	const logs: string[] = [];
 	const warns: string[] = [];
+	const errors: string[] = [];
 	const origLog = console.log;
 	const origWarn = console.warn;
+	const origError = console.error;
 	console.log = (msg: string) => {
 		logs.push(typeof msg === "string" ? msg : String(msg));
 	};
 	console.warn = (msg: string) => {
 		warns.push(typeof msg === "string" ? msg : String(msg));
 	};
+	console.error = (msg: string) => {
+		errors.push(typeof msg === "string" ? msg : String(msg));
+	};
 	return {
 		logs,
 		warns,
+		errors,
 		restore: () => {
 			console.log = origLog;
 			console.warn = origWarn;
+			console.error = origError;
 		},
 	};
 }
@@ -53,7 +65,12 @@ function captureOutput(): { logs: string[]; warns: string[]; restore: () => void
 async function runCheck(
 	dir: string,
 	opts: { strict?: boolean } = {},
-): Promise<{ logs: string[]; warns: string[]; exitCode: number | undefined }> {
+): Promise<{
+	logs: string[];
+	warns: string[];
+	errors: string[];
+	exitCode: number | undefined;
+}> {
 	const cap = captureOutput();
 	const origExit = process.exit;
 	let exitCode: number | undefined;
@@ -69,7 +86,7 @@ async function runCheck(
 		process.exit = origExit;
 		cap.restore();
 	}
-	return { logs: cap.logs, warns: cap.warns, exitCode };
+	return { logs: cap.logs, warns: cap.warns, errors: cap.errors, exitCode };
 }
 
 const skillManifest = (extra = "") =>
@@ -182,30 +199,33 @@ describe("validateFrontmatter", () => {
 		expect(issues.some((i) => i.kind === "warning" && i.message.includes("'skills'"))).toBe(true);
 	});
 
-	test("unknown key 'agents' is a note, not a warning", () => {
+	test("unknown key 'agents' is a hard error (#124)", () => {
+		// Pre-#124 this was a `note`. The summary "✔ No issues." then
+		// contradicted the per-file unknown-key line, and broken frontmatter
+		// passed `check` while failing at `install`.
 		const content = `---\nname: foo\ndescription: x\nagents: []\n---\n`;
 		const issues = validateFrontmatter(content, { entityName: "foo" });
 		const agentsIssues = issues.filter((i) => i.message.includes("agents"));
 		expect(agentsIssues.length).toBe(1);
-		expect(agentsIssues[0]?.kind).toBe("note");
+		expect(agentsIssues[0]?.kind).toBe("error");
 	});
 
-	test("malformed YAML in frontmatter is a warning", () => {
+	test("malformed YAML in frontmatter is a hard error (#124)", () => {
 		const content = `---\nname: foo\n  : invalid\n---\n`;
 		const issues = validateFrontmatter(content, { entityName: "foo" });
-		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+		expect(issues.some((i) => i.kind === "error")).toBe(true);
 	});
 
-	test("frontmatter that is not a mapping is a warning", () => {
+	test("frontmatter that is not a mapping is a hard error (#124)", () => {
 		const content = `---\n- just\n- a list\n---\n`;
 		const issues = validateFrontmatter(content, { entityName: "foo" });
-		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+		expect(issues.some((i) => i.kind === "error")).toBe(true);
 	});
 
-	test("missing closing --- is a warning", () => {
+	test("missing closing --- is a hard error (#124)", () => {
 		const content = `---\nname: foo\ndescription: x\n`;
 		const issues = validateFrontmatter(content, { entityName: "foo" });
-		expect(issues.some((i) => i.kind === "warning")).toBe(true);
+		expect(issues.some((i) => i.kind === "error")).toBe(true);
 	});
 });
 
@@ -263,16 +283,18 @@ describe("checkCommand frontmatter lint", () => {
 		expect(exitCode).toBeUndefined();
 	});
 
-	test("'agents: []' is a note and never gates --strict", async () => {
+	test("unknown frontmatter key fails by default (#124)", async () => {
+		// Pre-#124: unknown keys were dim notes that never gated. The summary
+		// "✔ No issues." contradicted the per-file detail line. Post-#124 the
+		// same input exits 1 with no `--strict` needed — same shape as install.
 		const dir = await makeProject({
 			manifest: skillManifest(),
 			files: [skillFm("name: foo\ndescription: x\nagents: []")],
 		});
 
-		const strict = await runCheck(dir, { strict: true });
-		// The note appears in output (not via warn()) — strict must not exit.
-		expect(strict.exitCode).toBeUndefined();
-		const allOut = [...strict.logs, ...strict.warns].join("\n");
+		const plain = await runCheck(dir);
+		expect(plain.exitCode).toBe(1);
+		const allOut = [...plain.logs, ...plain.warns, ...plain.errors].join("\n");
 		expect(allOut).toMatch(/agents/);
 	});
 

--- a/tests/commands/run-check.test.ts
+++ b/tests/commands/run-check.test.ts
@@ -104,12 +104,13 @@ describe("collectCheckIssues", () => {
 		expect(summary.lint).toEqual([]);
 	});
 
-	test("notes and warnings are surfaced on separate channels", async () => {
-		// `agents:` is an unknown key — produces a *note* (kind: "note"),
-		// not a warning. The split lets doctor count only the warning side.
+	test("unknown frontmatter keys land on the errors channel (#124)", async () => {
+		// Pre-#124: `agents:` produced a `note` that never gated. Post-#124
+		// unknown keys are hard errors, surfaced separately from warnings and
+		// notes so the renderer can fail the command by default.
 		const dir = await makeProject({
 			manifest: [
-				"name: note-only",
+				"name: errors-only",
 				"dependencies:",
 				"  foo:",
 				"    local: ./skills/foo",
@@ -125,8 +126,9 @@ describe("collectCheckIssues", () => {
 		});
 		const manifest = await loadManifestOrThrow(dir);
 		const summary = await collectCheckIssues(manifest, dir);
+		expect(summary.errors.length).toBeGreaterThan(0);
+		expect(summary.errors.join("\n")).toContain("agents");
 		expect(summary.frontmatterWarnings).toEqual([]);
-		expect(summary.frontmatterNotes.length).toBeGreaterThan(0);
-		expect(summary.frontmatterNotes.join("\n")).toContain("agents");
+		expect(summary.frontmatterNotes).toEqual([]);
 	});
 });

--- a/tests/commands/vendor-target.test.ts
+++ b/tests/commands/vendor-target.test.ts
@@ -381,3 +381,42 @@ dependencies:
 		expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(false);
 	});
 });
+
+describe("vendor target-switch cleanup (issue #108)", () => {
+	test("switching --target from claude to codex empties .claude and gitignores it again", async () => {
+		const dir = await setupMultiTargetProject();
+
+		await vendorCommand(dir, { target: "claude" });
+		expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+
+		await vendorCommand(dir, { target: "codex" });
+
+		// New target populated.
+		expect(existsSync(join(dir, ".agents/skills/foo"))).toBe(true);
+		// Old target's tree no longer on disk.
+		expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(false);
+		// Old target's gitignore entries restored.
+		const gitignore = await readFile(join(dir, ".gitignore"), "utf-8");
+		expect(gitignore).toContain(".claude/skills/");
+		// New target's gitignore entries removed (vendored = committable).
+		expect(gitignore).not.toMatch(/^\.agents\/skills\/$/m);
+		// vendored_target now reflects the new target.
+		const yml = await readFile(join(dir, "skilltree.yml"), "utf-8");
+		expect(yml).toContain("vendored_target: codex");
+	});
+
+	test("re-running vendor against the same --target is a no-op for cleanup", async () => {
+		// Cleanup must only fire on an actual target switch. Re-vendoring the
+		// same target is the normal "refresh sources" path and should not
+		// delete + re-add anything.
+		const dir = await setupMultiTargetProject();
+		await vendorCommand(dir, { target: "claude" });
+		expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+
+		// Second run with the same target: still vendored, no stale gitignore add.
+		await vendorCommand(dir, { target: "claude" });
+		expect(existsSync(join(dir, ".claude/skills/foo"))).toBe(true);
+		const gitignore = await readFile(join(dir, ".gitignore"), "utf-8");
+		expect(gitignore).not.toMatch(/^\.claude\/skills\/$/m);
+	});
+});

--- a/tests/core/scanner.test.ts
+++ b/tests/core/scanner.test.ts
@@ -741,3 +741,105 @@ describe("applyToFrontmatter — merge into existing key (issue #68)", () => {
 		expect(items).toEqual(["alpha", "mango", "zebra"]);
 	});
 });
+
+describe("applyToFrontmatter — preserves YAML formatting (issue #91)", () => {
+	test("preserves comments on untouched keys", async () => {
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "with-comments");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			[
+				"---",
+				"# top-level note",
+				"name: with-comments",
+				"description: A skill # inline note",
+				"dependencies:",
+				"  - existing",
+				"---",
+				"",
+				"Use the python-coding skill.",
+				"",
+			].join("\n"),
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("# top-level note");
+		expect(content).toContain("# inline note");
+		expect(content).toContain("- existing");
+		expect(content).toContain("- python-coding");
+	});
+
+	test("does not clobber an unrelated flow-style sequence in the same frontmatter", async () => {
+		// We rewrite the targeted deps key with the document's default style
+		// (block); the regression we guard against is that other flow-style
+		// values in the same frontmatter survive the round-trip.
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "flow-other");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			[
+				"---",
+				"name: flow-other",
+				"description: A skill",
+				"keywords: [alpha, beta, gamma]",
+				"dependencies:",
+				"  - existing",
+				"---",
+				"",
+				"Use the python-coding skill.",
+				"",
+			].join("\n"),
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		// Flow-style sequence survives — yaml@2 may canonicalize inner spacing
+		// (`[a, b, c]` vs `[ a, b, c ]`) but the bracketed form is what we
+		// guard against the pre-#91 line-by-line writer that would have
+		// broken any non-block sequence in the same frontmatter.
+		expect(content).toMatch(/keywords: \[\s*alpha,\s*beta,\s*gamma\s*\]/);
+		expect(content).toContain("- python-coding");
+	});
+
+	test("blank line inside frontmatter is preserved across deps update", async () => {
+		// The pre-#91 string-line stripper hit `inDepBlock = false` on any
+		// blank line, which could either drop trailing deps or leave them in
+		// place depending on input ordering. With the Document round-trip the
+		// concept of "in deps block" no longer exists; the file shape is
+		// determined by yaml's stringify defaults.
+		const dir = await makeTempDir();
+		const skillDir = join(dir, "blank-line");
+		await mkdir(skillDir, { recursive: true });
+		const filePath = join(skillDir, "SKILL.md");
+		await writeFile(
+			filePath,
+			[
+				"---",
+				"name: blank-line",
+				"description: A skill",
+				"",
+				"dependencies:",
+				"  - existing",
+				"---",
+				"",
+				"Use the python-coding skill.",
+				"",
+			].join("\n"),
+		);
+
+		await applyToFrontmatter(filePath, ["python-coding"]);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("- existing");
+		expect(content).toContain("- python-coding");
+		// Body content untouched
+		expect(content).toContain("Use the python-coding skill.");
+	});
+});


### PR DESCRIPTION
## Why

Bundle four PatchMode-sized bug fixes into a single PR to land one auto-version-bump instead of four. Each fix is self-contained; combined they're ~330 lines and share zero surface. #72 was originally on this slate but accumulated three sub-bugs with hard \"all-together\" acceptance — split out as its own project.

Closes #70
Closes #91
Closes #108
Closes #124

## What changed

### #70 — \`optionalDependencies\` pin out of sync with package version
- \`.cz.toml\` now declares all five \`package.json\` files under \`version_files\` so \`cz bump\` moves every version in lockstep.
- Current pins refreshed to v0.35.0 (had been stuck at 0.10.0 since v0.10).
- New \`tests/build/version-sync.test.ts\` asserts the invariant in CI — future drift fails before a release goes out.

### #91 — \`scan --apply\` preserves YAML formatting
- \`applyToFrontmatter\` switched from line-by-line string ops to \`YAML.parseDocument\` round-trip.
- Comments, flow-style sequences (\`keywords: [a, b, c]\`), and key ordering survive across updates.
- Eliminates a latent bug where a blank line inside a deps block dropped trailing items (the pre-fix \`inDepBlock = false\` reset on blank lines).

### #108 — \`vendor --target\` switch leaves previous tree orphaned
- \`vendorCommand\` now detects a target switch (\`manifest.vendored_target\` differs from \`--target\`) and runs unvendor-cleanup against the previous install base before populating the new one.
- Deletes vendored files via the existing lockfile and re-adds the old target's gitignore entries.
- No-op when targets match or no target was previously recorded (legacy \`vendor: true\` boolean).

### #124 — \`check\` reports schema errors as warnings; should fail
- Promoted three frontmatter issue classes from \`warning\`/\`note\` to **error** (hard-fail, no \`--strict\` needed):
  - malformed YAML in frontmatter
  - non-mapping frontmatter shape
  - unknown frontmatter keys (\`type: notathing\`, \`publish: \"no\"\`)
- \`validateManifest\` now runs from \`collectCheckIssues\` so manifest schema mismatches catch in \`check\` too — same diagnostics as \`install\`.
- Errors fail by default; warnings remain \`--strict\`-gated. The \`✔ No issues\` line no longer contradicts the per-file error lines printed above it.
- \`skills/skilltree/references/commands.md\` updated to document the new severity model.

## How tested

- \`bun test\` green: **1479/1479** (1467 baseline → +12 across version-sync, scanner, vendor-target, check).
- \`tsc --noEmit\` + \`bunx biome check\` clean.
- New tests added per fix; each test names the issue (#70/#91/#108/#124) it guards.

## Risk & rollback

Low. Each fix lives in a different file; no shared state. \`git revert <sha>\` works as one undo for all four. The only user-visible behavior change is in \`check\` (now exits 1 on broken frontmatter without \`--strict\`) — pre-fix that was the documented bug, and the doc update calls it out.

## Out of scope

- **#72** (\`targets remove\` cleanup + adjacent install-housekeeping bugs) — split to its own project. Scope comment posted on the issue. The bundle PR touches none of \`install.ts\` or \`targets.ts\`, so #72's work remains isolated.