### PR TITLE
fix(resolver): warn on silent sibling downgrade; sync disk + lockfile on version change

### DIFF
--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -276,6 +276,7 @@ For each **repo** in the graph:
 3. List available git tags
 4. Find the highest tag satisfying the intersection
 5. Error if no tag satisfies all constraints
+6. **Capped-sibling warning**: if the intersection picks a version lower than the latest available tag *and* one or more `*`-constrained deps share the repo, emit a non-blocking warning naming the capped `*` deps and the tighter sibling constraint(s) that capped them. Without this, adding a sibling like `tut --version ^0.5.0` silently downgrades earlier `*`-constrained deps from the same repo.
 
 Local deps skip version resolution -- working tree is the source of truth.
 
@@ -301,7 +302,7 @@ If any errors were collected, block install and report all of them together.
 
 ### Phase 5: Installation
 
-1. **Remote deps already installed**: Check integrity hash against lockfile. If modified, warn + require `--force`.
+1. **Remote deps already installed**: Check integrity hash against lockfile. If modified, warn + require `--force`. **Exception**: if the lockfile's recorded commit for the entity differs from the resolved commit (e.g. the resolver picked a different version this run), overwrite is automatic — no `--force` needed. Without this, the lockfile would silently disagree with disk after a version change.
 2. **Local deps**: Symlink from `{install_path}/skills/{name}`, `{install_path}/agents/{name}.md`, or `{install_path}/commands/{name}.md` to local path. No chmod, no integrity hash.
 3. **Remote deps**: Copy from git cache. Set `chmod 444` for files (directories keep default permissions for manageability).
 4. **`--prod --install-path`**: Local deps **copied** (not symlinked). Copies get `chmod 444` for files and integrity hash (they're production artifacts).

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -248,7 +248,14 @@ export async function installCommand(dir: string, options: InstallCommandOptions
 	printInstallOrderFromResolution(result, options);
 
 	const srcInstallBase = manifest.src_install_path ? join(dir, manifest.src_install_path) : null;
-	const integrityMap = await installToTargets(result, targets, srcInstallBase, dir, options);
+	const integrityMap = await installToTargets(
+		result,
+		targets,
+		srcInstallBase,
+		dir,
+		options,
+		existingLockfile,
+	);
 
 	if (options.dryRun) return;
 
@@ -273,6 +280,7 @@ async function installToTargets(
 	srcInstallBase: string | null,
 	dir: string,
 	options: InstallOptions,
+	existingLockfile: Lockfile | null,
 ): Promise<Map<string, string>> {
 	// Accumulate across targets instead of letting the last target win
 	// (issue #27 item 3). Content-derived hashes are identical per target
@@ -282,7 +290,13 @@ async function installToTargets(
 
 	for (const target of targets) {
 		const primaryBase = options.prod && srcInstallBase ? srcInstallBase : target.installBase;
-		const plan = await planInstall(result.entities, result.installOrder, primaryBase, options);
+		const plan = await planInstall(
+			result.entities,
+			result.installOrder,
+			primaryBase,
+			options,
+			existingLockfile,
+		);
 
 		// `--prod` skips are target-agnostic — report once, not once per target.
 		if (plan.skipped.length > 0 && !skippedReported) {
@@ -320,6 +334,7 @@ async function installToTargets(
 				result.installOrder,
 				srcInstallBase,
 				srcOptions,
+				existingLockfile,
 			);
 			if (srcPlan.toInstall.length > 0) {
 				await executeInstall(srcPlan, dir, srcOptions);
@@ -381,7 +396,14 @@ async function installGlobal(options: InstallCommandOptions): Promise<void> {
 	// Print install order once — shared across all targets.
 	printInstallOrderFromResolution(result, options);
 
-	const integrityMap = await installToTargets(result, targets, null, globalDir, options);
+	const integrityMap = await installToTargets(
+		result,
+		targets,
+		null,
+		globalDir,
+		options,
+		existingLockfile,
+	);
 
 	if (options.dryRun) return;
 
@@ -472,7 +494,7 @@ async function frozenInstall(
 	const devBase = options.installPath ?? join(dir, getDevInstallPath(manifest));
 	const srcBase = manifest.src_install_path ? join(dir, manifest.src_install_path) : null;
 	const primaryBase = options.prod && srcBase ? srcBase : devBase;
-	const plan = await planInstall(entities, installOrder, primaryBase, options);
+	const plan = await planInstall(entities, installOrder, primaryBase, options, lockfile);
 
 	printInstallOrderFromPlan(plan);
 

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -26,7 +26,7 @@ import {
 import { expandSources, parseManifest } from "./manifest.js";
 import { canonicalPath, expandTilde, stripDotSlash } from "./paths.js";
 import type { Constraint, ConstraintSource } from "./resolver.js";
-import { resolveIntersection } from "./resolver.js";
+import { filterSemverTags, resolveIntersection } from "./resolver.js";
 
 /**
  * Where a yaml key was declared — used to attribute collision errors (#85).
@@ -252,6 +252,7 @@ async function resolveOneRepo(
 			version: result.version,
 			commit,
 		});
+		warnIfCappedByTighterSibling(repo, tags, constraints, result.version, state);
 	} catch (e) {
 		const errMsg = e instanceof Error ? e.message : String(e);
 		try {
@@ -263,6 +264,38 @@ async function resolveOneRepo(
 			);
 		}
 	}
+}
+
+/**
+ * Issue #119 Bug A: detect when `*`-constrained deps were silently downgraded
+ * by a tighter sibling constraint and surface a "capped by" warning.
+ *
+ * Without this, `add tut --version ^0.5.0` to a repo where exp@* and
+ * commit-all@* were previously at 0.8.0 produces a silent downgrade — the
+ * user sees no signal that their unrelated deps just moved to 0.5.0.
+ */
+function warnIfCappedByTighterSibling(
+	repo: string,
+	tags: string[],
+	constraints: Constraint[],
+	pickedVersion: string,
+	state: ResolutionState,
+): void {
+	const sorted = filterSemverTags(tags);
+	const maxAvailable = sorted[0]?.version;
+	if (maxAvailable === undefined || maxAvailable === pickedVersion) return;
+
+	const cappedDeps = constraints.filter((c) => c.constraint === "*").map((c) => c.name);
+	if (cappedDeps.length === 0) return;
+
+	const cappingConstraints = constraints
+		.filter((c) => c.constraint !== "*" && !semver.satisfies(maxAvailable, c.constraint))
+		.map((c) => `${c.name}@${c.constraint}`);
+	if (cappingConstraints.length === 0) return;
+
+	state.warnings.push(
+		`${repo}: ${cappedDeps.join(", ")} capped at ${pickedVersion} by ${cappingConstraints.join(", ")} (latest available: ${maxAvailable}). Loosen the tighter constraint or split the dep across repos to upgrade the rest.`,
+	);
 }
 
 async function addTaglessRepoResolution(

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -43,6 +43,12 @@ export interface InstallPlan {
 		entity: ResolvedEntity;
 		action: "symlink" | "copy";
 		targetPath: string;
+		/**
+		 * Commit recorded for this entity in the previous lockfile, if any.
+		 * Used by `prepareTarget` to force overwrite when the resolver picked
+		 * a different version than the one currently on disk (#119 Bug B).
+		 */
+		previousCommit?: string;
 	}>;
 	skipped: string[];
 	warnings: string[];
@@ -152,6 +158,7 @@ export async function planInstall(
 	installOrder: string[],
 	installBase: string,
 	options: InstallOptions,
+	previousLockfile?: Lockfile | null,
 ): Promise<InstallPlan> {
 	const toInstall: InstallPlan["toInstall"] = [];
 	const skipped: string[] = [];
@@ -176,7 +183,8 @@ export async function planInstall(
 			action = "copy";
 		}
 
-		toInstall.push({ entity, action, targetPath });
+		const previousCommit = previousLockfile?.packages[entity.key]?.commit;
+		toInstall.push({ entity, action, targetPath, previousCommit });
 	}
 
 	return { toInstall, skipped, warnings };
@@ -202,9 +210,9 @@ export async function executeInstall(
 	const repoIgnore = await readRepoIgnore(projectDir);
 
 	for (const item of plan.toInstall) {
-		const { entity, action, targetPath } = item;
+		const { entity, action, targetPath, previousCommit } = item;
 
-		const skip = await prepareTarget(targetPath, entity, options, plan);
+		const skip = await prepareTarget(targetPath, entity, options, plan, previousCommit);
 		if (skip) continue;
 
 		if (action === "symlink") {
@@ -250,19 +258,28 @@ async function readRepoIgnore(projectDir: string): Promise<IgnoreMatcher> {
 /**
  * Prepare the target path for installation. Removes existing files/symlinks.
  * Returns true if the item should be skipped (already installed, no --force).
+ *
+ * When the previous lockfile recorded a different commit than the one we're
+ * about to install (e.g. a tighter sibling constraint downgraded the repo —
+ * see #119), overwrite is forced so the on-disk content stays in sync with
+ * the lockfile. Without this, the installer would warn "already installed"
+ * and leave stale content on disk while rewriting the lockfile to the new
+ * version — a silent integrity break.
  */
 async function prepareTarget(
 	targetPath: string,
 	entity: ResolvedEntity,
 	options: InstallOptions,
 	plan: InstallPlan,
+	previousCommit?: string,
 ): Promise<boolean> {
 	try {
 		const stats = await lstat(targetPath);
 		if (stats.isSymbolicLink()) {
 			await rm(targetPath);
 		} else if (stats.isDirectory() || stats.isFile()) {
-			if (!options.force && !entity.local) {
+			const versionChanged = previousCommit !== undefined && previousCommit !== entity.commit;
+			if (!options.force && !entity.local && !versionChanged) {
 				plan.warnings.push(`${entity.name} already installed. Use --force to overwrite.`);
 				return true;
 			}

--- a/tests/commands/install-version-change.test.ts
+++ b/tests/commands/install-version-change.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Issue #119 Bug B: lockfile/disk desync via skip-with-rewrite.
+ *
+ * Repro: install pins a repo at a higher version, then a second install
+ * tightens a sibling constraint that downgrades the whole repo. The
+ * installer warns "already installed. Use --force to overwrite", skips the
+ * file copy, but the lockfile still gets rewritten with the new (lower)
+ * version + commit. The recorded integrity hash is stale (preserved from
+ * the previous install) — `skilltree verify` reports OK even though the
+ * lockfile lies about what's on disk.
+ *
+ * Fix: when the lockfile records a different commit for an entity than the
+ * one currently resolved, the installer must overwrite (independent of
+ * --force) so disk and lockfile agree.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit from "simple-git";
+import { installCommand } from "../../src/commands/install.js";
+import { computeIntegrity } from "../../src/core/installer.js";
+import { readLockfile } from "../../src/core/lockfile.js";
+import { addTagToRepo, createTestRepo } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-version-change-"));
+	return tempDir;
+}
+
+async function makeBareClone(repoDir: string, baseDir: string, name: string): Promise<string> {
+	const bareDir = join(baseDir, `${name}.git`);
+	await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+	return bareDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("install: version change must overwrite on-disk files (#119 Bug B)", () => {
+	test("tighter sibling constraint downgrades repo; files updated, lockfile/disk in sync", async () => {
+		const dir = await makeTempDir();
+		// Three commands tagged at v0.5.0 (low) and v0.8.0 (high), with
+		// distinct file content per tag (addTagToRepo's "Updated content
+		// for v0.8.0" suffix lands on disk).
+		const repoDir = await createTestRepo(
+			dir,
+			"vibes",
+			[
+				{ path: "commands/exp.md", name: "exp", isAgent: true },
+				{ path: "commands/tut.md", name: "tut", isAgent: true },
+			],
+			"v0.5.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "vibes-bare");
+		await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+			{ path: "commands/exp.md", name: "exp", isAgent: true },
+			{ path: "commands/tut.md", name: "tut", isAgent: true },
+		]);
+
+		const projectDir = join(dir, "project");
+		await mkdir(projectDir, { recursive: true });
+
+		// Round 1: install at the high version (exp@* alone → 0.8.0).
+		const manifestV1 = `dependencies:
+  exp:
+    repo: "file://${bareDir}"
+    path: commands/exp.md
+    type: agent
+    version: "*"
+`;
+		await writeFile(join(projectDir, "skilltree.yml"), manifestV1);
+
+		await installCommand(projectDir, {});
+
+		const expFileV1 = join(projectDir, ".claude", "agents", "exp.md");
+		const expContentV1 = await readFile(expFileV1, "utf-8");
+		// addTagToRepo writes "# <name> Agent v2\n" for agent modifications,
+		// distinct from the v1 body "# <name> Agent\n".
+		expect(expContentV1).toContain("Agent v2");
+
+		const lockV1 = await readLockfile(projectDir);
+		expect(lockV1?.packages.exp?.version).toBe("0.8.0");
+
+		// Round 2: add `tut@^0.5.0` to the manifest. The repo intersection
+		// now caps at 0.5.0, so `exp` is downgraded.
+		const manifestV2 = `dependencies:
+  exp:
+    repo: "file://${bareDir}"
+    path: commands/exp.md
+    type: agent
+    version: "*"
+  tut:
+    repo: "file://${bareDir}"
+    path: commands/tut.md
+    type: agent
+    version: "^0.5.0"
+`;
+		await writeFile(join(projectDir, "skilltree.yml"), manifestV2);
+
+		await installCommand(projectDir, {});
+
+		// Lockfile now claims 0.5.0 for exp.
+		const lockV2 = await readLockfile(projectDir);
+		expect(lockV2?.packages.exp?.version).toBe("0.5.0");
+		const lockedExpIntegrity = lockV2?.packages.exp?.integrity;
+		expect(lockedExpIntegrity).toBeDefined();
+
+		// Disk must now hold the 0.5.0 content (not the cached 0.8.0).
+		const expContentV2 = await readFile(expFileV1, "utf-8");
+		expect(expContentV2).not.toBe(expContentV1);
+
+		// And the lockfile's recorded integrity hash must match the actual
+		// on-disk content — the core invariant Bug B violated.
+		const actualIntegrity = await computeIntegrity(expFileV1);
+		expect(actualIntegrity).toBe(lockedExpIntegrity as string);
+	});
+});

--- a/tests/core/graph-capped-warning.test.ts
+++ b/tests/core/graph-capped-warning.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Issue #119 Bug A: silent sibling downgrade.
+ *
+ * When multiple deps from the same repo are added with `version: "*"` and a
+ * later dep from the same repo carries a tightening constraint like `^0.5.0`,
+ * the resolver re-pins all three to a commit satisfying ALL constraints —
+ * silently downgrading the `*` deps.
+ *
+ * Fix: emit a "capped by" warning naming the `*` deps that would otherwise
+ * have resolved to a higher version and the constraining sibling that caps
+ * them.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit from "simple-git";
+import { resolveAll } from "../../src/core/graph.js";
+import type { Manifest } from "../../src/types.js";
+import { addTagToRepo, createTestRepo } from "../helpers/git-fixtures.js";
+
+let tempDir: string;
+
+async function makeTempDir(): Promise<string> {
+	tempDir = await mkdtemp(join(tmpdir(), "skilltree-capped-"));
+	return tempDir;
+}
+
+async function makeBareClone(repoDir: string, baseDir: string, name: string): Promise<string> {
+	const bareDir = join(baseDir, `${name}.git`);
+	await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+	return bareDir;
+}
+
+afterEach(async () => {
+	if (tempDir) await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("resolver: warn when * deps are capped by a sibling's tight constraint (#119)", () => {
+	test("two * deps + one ^0.5.0 dep from same repo → warn that the * deps are capped", async () => {
+		const dir = await makeTempDir();
+		// Repo with three command files, tagged at v0.5.0 and v0.8.0.
+		const repoDir = await createTestRepo(
+			dir,
+			"vibes",
+			[
+				{ path: "commands/exp.md", name: "exp", isAgent: true },
+				{ path: "commands/commit-all.md", name: "commit-all", isAgent: true },
+				{ path: "commands/tut.md", name: "tut", isAgent: true },
+			],
+			"v0.5.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "vibes-bare");
+		await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+			{ path: "commands/exp.md", name: "exp", isAgent: true },
+			{ path: "commands/commit-all.md", name: "commit-all", isAgent: true },
+			{ path: "commands/tut.md", name: "tut", isAgent: true },
+		]);
+
+		const manifest: Manifest = {
+			dependencies: {
+				exp: {
+					repo: `file://${bareDir}`,
+					path: "commands/exp.md",
+					type: "agent",
+					version: "*",
+				},
+				"commit-all": {
+					repo: `file://${bareDir}`,
+					path: "commands/commit-all.md",
+					type: "agent",
+					version: "*",
+				},
+				tut: {
+					repo: `file://${bareDir}`,
+					path: "commands/tut.md",
+					type: "agent",
+					version: "^0.5.0",
+				},
+			},
+		};
+
+		const result = await resolveAll(manifest, dir);
+		expect(result.errors).toEqual([]);
+
+		// All three resolve to 0.5.0 (intersection of *, *, ^0.5.0 against
+		// tags [0.5.0, 0.8.0]). That's the existing behavior — what we're
+		// adding is the warning attribution.
+		expect(result.entities.get("agent:exp")?.version).toBe("0.5.0");
+		expect(result.entities.get("agent:commit-all")?.version).toBe("0.5.0");
+		expect(result.entities.get("agent:tut")?.version).toBe("0.5.0");
+
+		// A warning must name the capped * deps and the constraining sibling.
+		const cappedWarning = result.warnings.find(
+			(w) => /capped|cap/i.test(w) && w.includes("0.5.0") && w.includes("0.8.0"),
+		);
+		expect(cappedWarning).toBeDefined();
+		// The warning should name both * deps (so users can find them in their
+		// own manifest) and the constraining sibling.
+		expect(cappedWarning).toMatch(/\bexp\b/);
+		expect(cappedWarning).toMatch(/\bcommit-all\b/);
+		expect(cappedWarning).toMatch(/\btut\b/);
+	});
+
+	test("no warning when * dep resolves at the highest available tag", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"vibes",
+			[
+				{ path: "commands/a.md", name: "a", isAgent: true },
+				{ path: "commands/b.md", name: "b", isAgent: true },
+			],
+			"v1.0.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "vibes-bare");
+
+		const manifest: Manifest = {
+			dependencies: {
+				a: { repo: `file://${bareDir}`, path: "commands/a.md", type: "agent", version: "*" },
+				b: {
+					repo: `file://${bareDir}`,
+					path: "commands/b.md",
+					type: "agent",
+					version: "^1.0.0",
+				},
+			},
+		};
+
+		const result = await resolveAll(manifest, dir);
+		expect(result.errors).toEqual([]);
+		// 1.0.0 is both the max tag and the intersection result → no cap.
+		const cappedWarning = result.warnings.find((w) => /capped|cap/i.test(w));
+		expect(cappedWarning).toBeUndefined();
+	});
+
+	test("no warning when all deps share the same explicit constraint", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"vibes",
+			[
+				{ path: "commands/a.md", name: "a", isAgent: true },
+				{ path: "commands/b.md", name: "b", isAgent: true },
+			],
+			"v0.5.0",
+		);
+		const bareDir = await makeBareClone(repoDir, dir, "vibes-bare");
+		await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+			{ path: "commands/a.md", name: "a", isAgent: true },
+			{ path: "commands/b.md", name: "b", isAgent: true },
+		]);
+
+		const manifest: Manifest = {
+			dependencies: {
+				a: {
+					repo: `file://${bareDir}`,
+					path: "commands/a.md",
+					type: "agent",
+					version: "^0.5.0",
+				},
+				b: {
+					repo: `file://${bareDir}`,
+					path: "commands/b.md",
+					type: "agent",
+					version: "^0.5.0",
+				},
+			},
+		};
+
+		const result = await resolveAll(manifest, dir);
+		expect(result.errors).toEqual([]);
+		// Both explicitly opted into ^0.5.0; no * dep is silently downgraded.
+		const cappedWarning = result.warnings.find((w) => /capped|cap/i.test(w));
+		expect(cappedWarning).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Why

Two coupled correctness bugs in the resolver + installer path that together produced silent integrity loss. The user reported this in #119 with a clean repro.

Closes #119

## What changed

### Bug A — silent sibling downgrade (resolver)
`add tut --version ^0.5.0` to a repo where `exp@*` and `commit-all@*` had resolved to 0.8.0 silently downgrades all three to 0.5.0. The user gets no signal that unrelated deps just moved backward.

- `src/core/graph.ts`: new `warnIfCappedByTighterSibling` in `resolveOneRepo`. After the intersection picks a version, if a higher tag exists and one or more `*`-constrained deps share the repo, emit a non-blocking warning naming the capped `*` deps and the sibling constraint(s) that capped them.
- Warning format: `<repo>: exp, commit-all capped at 0.5.0 by tut@^0.5.0 (latest available: 0.8.0). Loosen the tighter constraint or split the dep across repos to upgrade the rest.`
- Bug C from the issue (`update` doesn't explain refusal under whole-repo pin) falls out for free — the resolver warning fires from `update` too.

### Bug B — lockfile/disk desync via skip-with-rewrite (installer)
On version change, the installer warned "already installed. Use --force to overwrite", skipped the file copy, but the lockfile got rewritten with the new commit/version anyway. The integrity hash was preserved from the previous install (`applyIntegrityHashes`), so `skilltree verify` reported OK even though the lockfile lied about disk contents.

- `src/core/installer.ts`: `InstallPlan.toInstall[i]` now carries `previousCommit?: string`. `planInstall` takes an optional `previousLockfile` and populates this from `lockfile.packages[entity.key].commit`. `prepareTarget` accepts `previousCommit` and forces overwrite (independent of `--force`) when it differs from the resolved `entity.commit`. The "already installed" skip only fires on genuine no-op installs.
- `src/commands/install.ts`: thread `existingLockfile` through `installToTargets → planInstall` in all four call sites (regular install, global install, src-install secondary copy, frozen install).
- `docs/specs/reference.md`: document the new resolver warning (Phase 2 step 6) and the version-change overwrite exception (Phase 5).

## How tested

- New `tests/core/graph-capped-warning.test.ts` (3 tests): two `*` deps + one tighter sibling fires the warning; max-version-already-picked fires no warning; uniform explicit constraints fire no warning.
- New `tests/commands/install-version-change.test.ts` (1 integration test): round-1 install at high version, round-2 downgrade via sibling. Asserts disk content updated AND on-disk integrity matches the lockfile's `integrity` field — the core invariant Bug B violated.
- Full suite: **1576/1576 pass**, `tsc` clean, `biome` clean (3 pre-existing warnings in `tests/core/registry-scanner-packs.test.ts` from the Oxygen merge — unrelated).

## Risk & rollback

Low. Implementation change is ~90 LOC across 3 source files; the new `previousCommit` field on `InstallPlan` is optional (vendor.ts and other callers unaffected without source changes). `git revert <sha>` works as a single undo.

The new warning is informational — no exit-code change, no required flag. The new auto-overwrite behavior only fires when lockfile and resolver disagree (the bug case); other installs behave identically.