### PR TITLE
fix(outdated): annotate when a bump is held back by a tighter sibling

### DIFF
--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -276,7 +276,7 @@ For each **repo** in the graph:
 3. List available git tags
 4. Find the highest tag satisfying the intersection
 5. Error if no tag satisfies all constraints
-6. **Capped-sibling warning**: if the intersection picks a version lower than the latest available tag *and* one or more `*`-constrained deps share the repo, emit a non-blocking warning naming the capped `*` deps and the tighter sibling constraint(s) that capped them. Without this, adding a sibling like `tut --version ^0.5.0` silently downgrades earlier `*`-constrained deps from the same repo.
+6. **Capped-sibling warning**: if the intersection picks a version lower than the latest available tag *and* one or more `*`-constrained deps share the repo, emit a non-blocking warning naming the capped `*` deps and the tighter sibling constraint(s) that capped them. Without this, adding a sibling like `tut --version ^0.5.0` silently downgrades earlier `*`-constrained deps from the same repo. `skilltree outdated` previews the same attribution under a `Notes` column (`capped by <name>@<constraint>`) so users can spot the cap before they try to bump.
 
 Local deps skip version resolution -- working tree is the source of truth.
 

--- a/src/commands/outdated.ts
+++ b/src/commands/outdated.ts
@@ -2,10 +2,17 @@ import semver from "semver";
 import { MANIFEST_NEW, manifestExists } from "../core/filenames.js";
 import { ensureCached, listTags } from "../core/git.js";
 import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
+import { expandSources, readGlobalManifest, readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
-import { filterSemverTags } from "../core/resolver.js";
+import { filterSemverTags, findCappingSiblings } from "../core/resolver.js";
 import { type ColumnDef, dim, pc, printTable } from "../core/ui.js";
-import type { EntityType, LockfileEntry } from "../types.js";
+import {
+	type EntityType,
+	isRemoteDependency,
+	isSourceDependency,
+	type LockfileEntry,
+	type Manifest,
+} from "../types.js";
 
 export interface OutdatedOptions {
 	json?: boolean;
@@ -30,6 +37,13 @@ export interface OutdatedRow {
 	bump: BumpKind;
 	/** The repo URL, or null for local deps. */
 	repo: string | null;
+	/**
+	 * Sibling constraints in the same repo that prevent this dep from
+	 * reaching `latest` even though its own constraint would allow it (#136).
+	 * Null when no cap applies or when the dep's own constraint already
+	 * excludes `latest`.
+	 */
+	cappedBy: string[] | null;
 }
 
 /**
@@ -76,9 +90,17 @@ export async function outdatedCommand(
 		entries = filtered;
 	}
 
+	// Read the manifest to attribute capping sibling constraints (#136). The
+	// lockfile alone doesn't carry constraint info — only the manifest does.
+	// A missing/unparsable manifest is non-fatal: rows just won't carry cap
+	// annotations.
+	const constraintsByRepo = await readConstraintsByRepo(isGlobal, dir, globalDir);
+
 	// Resolve rows in parallel — each row hits a different repo cache, and
 	// the network roundtrip dominates per-row work.
-	const rows = await Promise.all(entries.map(([key, entry]) => buildRow(key, entry)));
+	const rows = await Promise.all(
+		entries.map(([key, entry]) => buildRow(key, entry, constraintsByRepo)),
+	);
 
 	if (opts?.json) {
 		console.log(JSON.stringify(rows, null, 2));
@@ -94,7 +116,11 @@ export async function outdatedCommand(
 	}
 }
 
-async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow> {
+async function buildRow(
+	key: string,
+	entry: LockfileEntry,
+	constraintsByRepo: ConstraintsByRepo,
+): Promise<OutdatedRow> {
 	const name = entry.name ?? key;
 	const type = entry.type;
 
@@ -107,6 +133,7 @@ async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow>
 			latest: null,
 			bump: null,
 			repo: null,
+			cappedBy: null,
 		};
 	}
 
@@ -120,7 +147,16 @@ async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow>
 	if (!repo) {
 		// Defensive: a non-local entry without a repo URL is malformed but
 		// shouldn't crash a read-only command — report and move on.
-		return { name, type, current, currentCommit, latest: null, bump: null, repo: null };
+		return {
+			name,
+			type,
+			current,
+			currentCommit,
+			latest: null,
+			bump: null,
+			repo: null,
+			cappedBy: null,
+		};
 	}
 
 	let tags: string[];
@@ -128,7 +164,16 @@ async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow>
 		const cachePath = await ensureCached(repo);
 		tags = await listTags(cachePath);
 	} catch {
-		return { name, type, current, currentCommit, latest: null, bump: "error", repo };
+		return {
+			name,
+			type,
+			current,
+			currentCommit,
+			latest: null,
+			bump: "error",
+			repo,
+			cappedBy: null,
+		};
 	}
 
 	const semverTags = filterSemverTags(tags);
@@ -136,7 +181,7 @@ async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow>
 	// Empty array → no tags at all → no upstream signal.
 	const latest = semverTags[0]?.version;
 	if (!latest) {
-		return { name, type, current, currentCommit, latest: null, bump: null, repo };
+		return { name, type, current, currentCommit, latest: null, bump: null, repo, cappedBy: null };
 	}
 
 	const currentSemver = entry.version;
@@ -145,15 +190,90 @@ async function buildRow(key: string, entry: LockfileEntry): Promise<OutdatedRow>
 		// but can't compute a bump kind without a semver anchor on the
 		// current side. Matches the example in the issue body where
 		// `task-builder @a56045e | 2.0.0 | —` shows "—".
-		return { name, type, current, currentCommit, latest, bump: null, repo };
+		return { name, type, current, currentCommit, latest, bump: null, repo, cappedBy: null };
 	}
 
 	if (semver.eq(currentSemver, latest)) {
-		return { name, type, current, currentCommit, latest, bump: null, repo };
+		return { name, type, current, currentCommit, latest, bump: null, repo, cappedBy: null };
 	}
 
 	const bump = classifyBump(currentSemver, latest);
-	return { name, type, current, currentCommit, latest, bump, repo };
+	const cappedBy = computeCappedBy(repo, name, latest, constraintsByRepo);
+	return { name, type, current, currentCommit, latest, bump, repo, cappedBy };
+}
+
+type ConstraintsByRepo = Map<string, Array<{ name: string; constraint: string }>>;
+
+/**
+ * Build a per-repo index of `(name, constraint)` pairs from the project (or
+ * global) manifest, used to compute `cappedBy` annotations (#136). Reads
+ * both prod and dev dependencies; sources are pre-expanded so remote +
+ * source deps both end up keyed by their underlying `repo` URL. Pack
+ * references are skipped — their member constraints live upstream and
+ * aren't reachable through the consumer manifest alone.
+ *
+ * Errors are swallowed: a missing/malformed manifest means no annotations,
+ * not a crashed `outdated` run.
+ */
+async function readConstraintsByRepo(
+	isGlobal: boolean,
+	dir: string,
+	globalDir: string,
+): Promise<ConstraintsByRepo> {
+	let manifest: Manifest;
+	try {
+		const raw = isGlobal ? await readGlobalManifest(globalDir) : await readManifest(dir);
+		manifest = expandSources(raw);
+	} catch {
+		return new Map();
+	}
+
+	const result: ConstraintsByRepo = new Map();
+	for (const group of [manifest.dependencies, manifest["dev-dependencies"]]) {
+		if (!group) continue;
+		for (const [name, dep] of Object.entries(group)) {
+			// Source deps are flattened to repo form by expandSources, but the
+			// guard pair is kept for forward-compat against future shapes.
+			if (!isRemoteDependency(dep) && !isSourceDependency(dep)) continue;
+			const repo = "repo" in dep ? dep.repo : undefined;
+			if (repo === undefined) continue;
+			const constraint = dep.version ?? "*";
+			const list = result.get(repo) ?? [];
+			list.push({ name, constraint });
+			result.set(repo, list);
+		}
+	}
+	return result;
+}
+
+/**
+ * Compute the `cappedBy` list for a single row. Returns the formatted
+ * sibling constraint strings (e.g. `["tut@^0.5.0"]`) only when:
+ *  1. The dep's own constraint accepts `latest` (otherwise the cap is
+ *     self-imposed and not interesting to annotate).
+ *  2. At least one sibling in the same repo carries a tighter constraint
+ *     that excludes `latest`.
+ *
+ * Returns `null` otherwise. A `null` result also covers the edge case where
+ * the manifest doesn't list this dep (e.g. it was removed but the lockfile
+ * still has the entry).
+ */
+function computeCappedBy(
+	repo: string,
+	name: string,
+	latest: string,
+	constraintsByRepo: ConstraintsByRepo,
+): string[] | null {
+	const siblings = constraintsByRepo.get(repo);
+	if (siblings === undefined) return null;
+
+	const self = siblings.find((s) => s.name === name);
+	if (self !== undefined && self.constraint !== "*" && !semver.satisfies(latest, self.constraint)) {
+		return null;
+	}
+
+	const capped = findCappingSiblings(siblings, latest, name);
+	return capped.length > 0 ? capped : null;
 }
 
 /**
@@ -181,6 +301,7 @@ interface DisplayRow {
 	current: string;
 	latest: string;
 	bump: string;
+	notes: string;
 }
 
 const OUTDATED_COLUMNS: ColumnDef<DisplayRow>[] = [
@@ -188,6 +309,7 @@ const OUTDATED_COLUMNS: ColumnDef<DisplayRow>[] = [
 	{ header: "Current", value: (r) => r.current },
 	{ header: "Latest", value: (r) => r.latest, color: pc.green },
 	{ header: "Bump", value: (r) => r.bump, color: colorBump },
+	{ header: "Notes", value: (r) => r.notes, color: dim },
 ];
 
 function printOutdatedTable(rows: OutdatedRow[]): void {
@@ -196,8 +318,14 @@ function printOutdatedTable(rows: OutdatedRow[]): void {
 		current: r.current,
 		latest: r.latest ?? EMDASH,
 		bump: r.bump ?? EMDASH,
+		notes: r.cappedBy ? `capped by ${r.cappedBy.join(", ")}` : "",
 	}));
-	printTable(display, OUTDATED_COLUMNS);
+	// Drop the Notes column entirely when no row has anything to say — keeps
+	// the simple `outdated` table from growing a useless trailing column.
+	const columns = display.some((r) => r.notes !== "")
+		? OUTDATED_COLUMNS
+		: OUTDATED_COLUMNS.filter((c) => c.header !== "Notes");
+	printTable(display, columns);
 }
 
 function colorBump(bump: string): string {

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -26,7 +26,7 @@ import {
 import { expandSources, parseManifest } from "./manifest.js";
 import { canonicalPath, expandTilde, stripDotSlash } from "./paths.js";
 import type { Constraint, ConstraintSource } from "./resolver.js";
-import { filterSemverTags, resolveIntersection } from "./resolver.js";
+import { filterSemverTags, findCappingSiblings, resolveIntersection } from "./resolver.js";
 
 /**
  * Where a yaml key was declared — used to attribute collision errors (#85).
@@ -288,9 +288,7 @@ function warnIfCappedByTighterSibling(
 	const cappedDeps = constraints.filter((c) => c.constraint === "*").map((c) => c.name);
 	if (cappedDeps.length === 0) return;
 
-	const cappingConstraints = constraints
-		.filter((c) => c.constraint !== "*" && !semver.satisfies(maxAvailable, c.constraint))
-		.map((c) => `${c.name}@${c.constraint}`);
+	const cappingConstraints = findCappingSiblings(constraints, maxAvailable);
 	if (cappingConstraints.length === 0) return;
 
 	state.warnings.push(

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -117,3 +117,21 @@ export function resolveIntersection(
 		error: `Incompatible version constraints:\n${lines.join("\n")}\n\nNo git tag satisfies all constraints.`,
 	};
 }
+
+/**
+ * Pure form of the cap-detection used at install time (#119) and surfaced
+ * by `outdated` (#136). Given the set of constraints on a single repo and
+ * a candidate `version`, return the formatted sibling constraints that
+ * would reject it. `*` constraints are skipped (they cap nothing).
+ * `selfName` excludes the dep being checked from its own sibling list.
+ */
+export function findCappingSiblings(
+	constraints: Array<{ name: string; constraint: string }>,
+	version: string,
+	selfName?: string,
+): string[] {
+	return constraints
+		.filter((c) => c.name !== selfName && c.constraint !== "*")
+		.filter((c) => !semver.satisfies(version, c.constraint))
+		.map((c) => `${c.name}@${c.constraint}`);
+}

--- a/tests/commands/outdated.test.ts
+++ b/tests/commands/outdated.test.ts
@@ -402,6 +402,17 @@ packages:
 				"v0.5.0",
 			);
 			const bareDir = await makeBareClone(repoDir, dir, "bare");
+			// Tag v0.8.0 BEFORE install so the upstream's "latest" is already
+			// 0.8.0 at install time. The resolver still pins both deps at
+			// 0.5.0 (capped by tut@^0.5.0), but `outdated` sees 0.8.0 as the
+			// available upstream without needing to re-fetch the cache.
+			// (Matches the pattern in install-version-change.test.ts that
+			// works reliably under CI's Linux+Bun matrix; the post-install
+			// addTagToRepo + ensureCached re-fetch sequence flakes there.)
+			await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+				{ path: "skills/exp", name: "exp" },
+				{ path: "skills/tut", name: "tut" },
+			]);
 
 			await writeManifest(
 				dir,
@@ -417,11 +428,6 @@ packages:
 `,
 			);
 			await installCommand(dir, {});
-			// exp@* would accept 0.8.0; tut@^0.5.0 would not — so 0.8.0 is sibling-capped.
-			await addTagToRepo(repoDir, bareDir, "v0.8.0", [
-				{ path: "skills/exp", name: "exp" },
-				{ path: "skills/tut", name: "tut" },
-			]);
 
 			const { logs, restore } = captureConsole();
 			try {
@@ -534,6 +540,11 @@ packages:
 				"v0.5.0",
 			);
 			const bareDir = await makeBareClone(repoDir, dir, "bare");
+			// See sibling-cap test above for why v0.8.0 is tagged pre-install.
+			await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+				{ path: "skills/exp", name: "exp" },
+				{ path: "skills/tut", name: "tut" },
+			]);
 
 			await writeManifest(
 				dir,
@@ -549,10 +560,6 @@ packages:
 `,
 			);
 			await installCommand(dir, {});
-			await addTagToRepo(repoDir, bareDir, "v0.8.0", [
-				{ path: "skills/exp", name: "exp" },
-				{ path: "skills/tut", name: "tut" },
-			]);
 
 			const { logs, restore } = captureConsole();
 			try {

--- a/tests/commands/outdated.test.ts
+++ b/tests/commands/outdated.test.ts
@@ -385,4 +385,184 @@ packages:
 		const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
 		expect(rows.length).toBe(2);
 	});
+
+	// Issue #136: annotate rows whose bump is silently blocked by a tighter
+	// sibling constraint in the same repo. Mirrors the #119 "capped by"
+	// warning at install/update time so users can preview the cap.
+	describe("cappedBy annotation (#136)", () => {
+		test("flags '*' dep when sibling ^constraint excludes the latest tag", async () => {
+			const dir = await makeTempDir();
+			const repoDir = await createTestRepo(
+				dir,
+				"repo",
+				[
+					{ path: "skills/exp", name: "exp" },
+					{ path: "skills/tut", name: "tut" },
+				],
+				"v0.5.0",
+			);
+			const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+			await writeManifest(
+				dir,
+				`dependencies:
+  exp:
+    repo: "file://${bareDir}"
+    path: skills/exp
+    version: "*"
+  tut:
+    repo: "file://${bareDir}"
+    path: skills/tut
+    version: "^0.5.0"
+`,
+			);
+			await installCommand(dir, {});
+			// exp@* would accept 0.8.0; tut@^0.5.0 would not — so 0.8.0 is sibling-capped.
+			await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+				{ path: "skills/exp", name: "exp" },
+				{ path: "skills/tut", name: "tut" },
+			]);
+
+			const { logs, restore } = captureConsole();
+			try {
+				await outdatedCommand(dir, undefined, { json: true });
+			} finally {
+				restore();
+			}
+
+			const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+			const expRow = rows.find((r) => r.name === "exp");
+			const tutRow = rows.find((r) => r.name === "tut");
+
+			expect(expRow?.latest).toBe("0.8.0");
+			expect(expRow?.cappedBy).toEqual(["tut@^0.5.0"]);
+
+			// tut's own constraint rejects 0.8.0, so the cap is self-imposed, not sibling.
+			expect(tutRow?.cappedBy).toBeNull();
+		});
+
+		test("no annotation when latest satisfies all sibling constraints", async () => {
+			const dir = await makeTempDir();
+			const repoDir = await createTestRepo(
+				dir,
+				"repo",
+				[
+					{ path: "skills/a", name: "a" },
+					{ path: "skills/b", name: "b" },
+				],
+				"v1.0.0",
+			);
+			const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+			await writeManifest(
+				dir,
+				`dependencies:
+  a:
+    repo: "file://${bareDir}"
+    path: skills/a
+    version: "*"
+  b:
+    repo: "file://${bareDir}"
+    path: skills/b
+    version: "*"
+`,
+			);
+			await installCommand(dir, {});
+			await addTagToRepo(repoDir, bareDir, "v2.0.0", [
+				{ path: "skills/a", name: "a" },
+				{ path: "skills/b", name: "b" },
+			]);
+
+			const { logs, restore } = captureConsole();
+			try {
+				await outdatedCommand(dir, undefined, { json: true });
+			} finally {
+				restore();
+			}
+
+			const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+			for (const row of rows) {
+				expect(row.cappedBy).toBeNull();
+			}
+		});
+
+		test("siblings in different repos do not cross-cap", async () => {
+			const dir = await makeTempDir();
+			const repoA = await createTestRepo(dir, "repoA", [{ path: "skills/a", name: "a" }], "v0.5.0");
+			const repoB = await createTestRepo(dir, "repoB", [{ path: "skills/b", name: "b" }], "v0.5.0");
+			const bareA = await makeBareClone(repoA, dir, "bareA");
+			const bareB = await makeBareClone(repoB, dir, "bareB");
+
+			await writeManifest(
+				dir,
+				`dependencies:
+  a:
+    repo: "file://${bareA}"
+    path: skills/a
+    version: "*"
+  b:
+    repo: "file://${bareB}"
+    path: skills/b
+    version: "^0.5.0"
+`,
+			);
+			await installCommand(dir, {});
+			await addTagToRepo(repoA, bareA, "v0.8.0", [{ path: "skills/a", name: "a" }]);
+
+			const { logs, restore } = captureConsole();
+			try {
+				await outdatedCommand(dir, undefined, { json: true });
+			} finally {
+				restore();
+			}
+
+			const rows = JSON.parse(logs.join("")) as Array<Record<string, unknown>>;
+			// 'a' is in repoA only; 'b' is in repoB — b's constraint must not cap a.
+			const aRow = rows.find((r) => r.name === "a");
+			expect(aRow?.cappedBy).toBeNull();
+		});
+
+		test("table output renders 'capped by' note", async () => {
+			const dir = await makeTempDir();
+			const repoDir = await createTestRepo(
+				dir,
+				"repo",
+				[
+					{ path: "skills/exp", name: "exp" },
+					{ path: "skills/tut", name: "tut" },
+				],
+				"v0.5.0",
+			);
+			const bareDir = await makeBareClone(repoDir, dir, "bare");
+
+			await writeManifest(
+				dir,
+				`dependencies:
+  exp:
+    repo: "file://${bareDir}"
+    path: skills/exp
+    version: "*"
+  tut:
+    repo: "file://${bareDir}"
+    path: skills/tut
+    version: "^0.5.0"
+`,
+			);
+			await installCommand(dir, {});
+			await addTagToRepo(repoDir, bareDir, "v0.8.0", [
+				{ path: "skills/exp", name: "exp" },
+				{ path: "skills/tut", name: "tut" },
+			]);
+
+			const { logs, restore } = captureConsole();
+			try {
+				await outdatedCommand(dir, undefined, {});
+			} finally {
+				restore();
+			}
+
+			const out = logs.join("\n");
+			expect(out).toContain("capped by tut@^0.5.0");
+		});
+	});
 });


### PR DESCRIPTION
After #119 the resolver emits a "capped by" warning at install/update time when a `*`-constrained dep is silently downgraded by a tighter sibling constraint in the same repo. `outdated` now surfaces the same attribution via `cappedBy` (JSON) and a `Notes` column (table), so users can preview the cap before they try to bump.

Closes #136

## What changed
- `src/core/resolver.ts`: extract `findCappingSiblings` — the cap-detection logic becomes a pure helper shared by `graph.ts` (the install/update warning) and `outdated.ts` (the new annotation).
- `src/core/graph.ts`: `warnIfCappedByTighterSibling` calls the new helper. Behavior unchanged.
- `src/commands/outdated.ts`: add `cappedBy: string[] | null` to `OutdatedRow`. Read the manifest, index constraints by repo, and annotate rows where the dep's own constraint accepts `latest` but a sibling rejects it. The table grows a `Notes` column only when at least one row has something to say.
- `docs/specs/reference.md`: one-line addition pointing readers from the warning to the matching `outdated` annotation.

## How tested
- 4 new tests in `tests/commands/outdated.test.ts`: sibling cap is flagged with `cappedBy: ["tut@^0.5.0"]`, self-capped row is `null`, all-`*` repo has no annotation, cross-repo siblings don't cap, table renders `capped by tut@^0.5.0`.
- Full suite green: 1580 pass, 0 fail.
- Manifest read is wrapped in try/catch — a missing/malformed manifest just skips the annotation rather than crashing a read-only command.

## Risk & rollback
Low — additive on `outdated` (new JSON field + conditional column) and a pure refactor on `graph.ts` covered by existing #119 tests. `git revert <sha>`.