### PR TITLE
fix(installer): apply origin's exclude: rules when installing remote deps

### DIFF
--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -775,6 +775,8 @@ async function resolveRemoteEntity(
 		declaredIn,
 		cachePath: resolution.cachePath,
 	};
+	const originExclude = await readOriginExclude(entityName, resolution);
+	if (originExclude) entity.exclude = originExclude;
 	if (viaPack) entity.viaPack = viaPack;
 
 	registerEntity(entity, state);
@@ -860,6 +862,32 @@ async function readOriginManifestAtRef(cachePath: string, ref: string): Promise<
 		return await readFileAtRef(cachePath, ref, MANIFEST_NEW);
 	} catch {
 		return await readFileAtRef(cachePath, ref, MANIFEST_NEW_ALT);
+	}
+}
+
+/**
+ * Read origin's `exclude:` patterns for `entityName` from origin's manifest,
+ * or null if the manifest is missing, malformed, the entry doesn't declare
+ * `exclude:`, or the entry is not a local dependency (only `local:` entries
+ * support `exclude:` per publication_surface.md §PS6–PS8). Propagated onto
+ * the remote `ResolvedEntity` so the installer can filter blobs the same
+ * way it does for the local-copy path (issue #139, §PS17 applied symmetrically).
+ */
+async function readOriginExclude(
+	entityName: string,
+	resolution: RepoResolution,
+): Promise<string[] | null> {
+	const ref = resolution.tag ?? resolution.commit;
+	try {
+		const manifestContent = await readOriginManifestAtRef(resolution.cachePath, ref);
+		const originManifest = parseManifest(manifestContent);
+		const expanded = expandSources(originManifest);
+		const entry = expanded.dependencies?.[entityName];
+		if (!entry || !isLocalDependency(entry)) return null;
+		const exclude = entry.exclude;
+		return exclude && exclude.length > 0 ? [...exclude] : null;
+	} catch {
+		return null;
 	}
 }
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -229,7 +229,8 @@ export async function executeInstall(
 					repoIgnore,
 				});
 			} else if (entity.cachePath) {
-				await copyFromGitCache(entity, targetPath);
+				const entityIgnore = new IgnoreMatcher(entity.exclude ?? []);
+				await copyFromGitCache(entity, targetPath, entityIgnore);
 			}
 			await setReadOnly(targetPath);
 			integrityMap.set(entity.key, await computeIntegrity(targetPath));
@@ -356,8 +357,18 @@ function shouldExclude(src: string, sourcePath: string, ctx: CopyContext): boole
 
 /**
  * Copy files from git cache at a specific ref.
+ *
+ * For multi-file entities the optional `entityIgnore` filters blobs against
+ * the per-entity `exclude:` patterns the origin declared in its manifest
+ * (publication_surface.md §PS17 — applied symmetrically on the consumer
+ * side per issue #139). Single-file entities (agents, commands) skip the
+ * matcher: the file IS the entity, so there is nothing to filter inside.
  */
-async function copyFromGitCache(entity: ResolvedEntity, targetPath: string): Promise<void> {
+async function copyFromGitCache(
+	entity: ResolvedEntity,
+	targetPath: string,
+	entityIgnore?: IgnoreMatcher,
+): Promise<void> {
 	if (!entity.cachePath) return;
 
 	const ref = entity.tag ?? entity.commit;
@@ -370,7 +381,7 @@ async function copyFromGitCache(entity: ResolvedEntity, targetPath: string): Pro
 			await writeFile(targetPath, content, "utf-8");
 		} else {
 			await mkdir(targetPath, { recursive: true });
-			await copyTreeFromGit(entity.cachePath, ref, path, targetPath);
+			await copyTreeFromGit(entity.cachePath, ref, path, targetPath, entityIgnore);
 		}
 	} catch (cause) {
 		const refLabel = entity.tag ?? entity.commit.slice(0, 8);
@@ -385,12 +396,16 @@ async function copyFromGitCache(entity: ResolvedEntity, targetPath: string): Pro
 /**
  * Copy a directory tree from a git bare repo using a single `ls-tree -r`
  * call instead of recursive subprocess spawning.
+ *
+ * Optional `entityIgnore` filters blobs by their entity-relative path —
+ * the same matcher the local-copy path applies for `exclude:` rules.
  */
 async function copyTreeFromGit(
 	cachePath: string,
 	ref: string,
 	treePath: string,
 	targetDir: string,
+	entityIgnore?: IgnoreMatcher,
 ): Promise<void> {
 	const git = simpleGit(cachePath);
 
@@ -405,6 +420,10 @@ async function copyTreeFromGit(
 
 		const [, , relativePath] = match;
 		if (!relativePath) continue;
+
+		if (entityIgnore && !entityIgnore.isEmpty && entityIgnore.ignores(relativePath)) {
+			continue;
+		}
 
 		const itemPath = treePath === "." ? relativePath : `${treePath}/${relativePath}`;
 		const targetItemPath = join(targetDir, relativePath);

--- a/tests/core/graph-origin-manifest.test.ts
+++ b/tests/core/graph-origin-manifest.test.ts
@@ -771,4 +771,44 @@ describe("origin-manifest transitive resolution", () => {
 		expect(grandchild?.repo).toBe(`file://${thirdPartyRepo}`);
 		expect(grandchild?.path).toBe("skills/source/grandchild");
 	});
+
+	test("propagates exclude: from origin's manifest onto remote resolved entity (issue #139)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-origin-manifest-"));
+
+		const originManifestYaml = [
+			"name: origin",
+			"dependencies:",
+			"  esql-details:",
+			"    local: ./esql-details",
+			"    exclude:",
+			'      - "docs/"',
+			'      - "evals/"',
+			"",
+		].join("\n");
+
+		const originRepo = await createTestRepo(
+			tempDir,
+			"origin",
+			[{ path: "esql-details", name: "esql-details" }],
+			"v1.0.0",
+			originManifestYaml,
+		);
+
+		const consumerManifest: Manifest = {
+			dependencies: {
+				"esql-details": {
+					repo: `file://${originRepo}`,
+					version: "*",
+				},
+			},
+		};
+
+		const result = await resolveAll(consumerManifest, tempDir);
+
+		expect(result.errors).toEqual([]);
+		const entity = result.entities.get("skill:esql-details");
+		expect(entity).toBeDefined();
+		expect(entity?.local).toBe(false);
+		expect(entity?.exclude).toEqual(["docs/", "evals/"]);
+	});
 });

--- a/tests/core/installer-exclude.test.ts
+++ b/tests/core/installer-exclude.test.ts
@@ -3,8 +3,10 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import simpleGit from "simple-git";
 import type { ResolvedEntity } from "../../src/core/graph.js";
 import { executeInstall } from "../../src/core/installer.js";
+import { createTestRepo } from "../helpers/git-fixtures.js";
 
 let tempDir: string;
 
@@ -148,5 +150,103 @@ describe("installer — exclude + .skilltreeignore (Carbon Phase 3)", () => {
 
 		expect(existsSync(join(dir, ".claude/skills/foo/SKILL.md"))).toBe(true);
 		expect(existsSync(join(dir, ".claude/skills/foo/experiments/x.md"))).toBe(true);
+	});
+});
+
+describe("installer — exclude applied when copying from git cache (issue #139)", () => {
+	test("per-entity exclude filters blobs read from the bare repo", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"origin",
+			[
+				{ path: "skills/foo", name: "foo" },
+				{ path: "skills/foo/experiments/a", name: "experiment-a" },
+				{ path: "skills/foo/experiments/b", name: "experiment-b" },
+				{ path: "skills/foo/docs/raw", name: "docs-raw" },
+			],
+			"v1.0.0",
+		);
+		await writeFile(join(repoDir, "skills/foo/keep.md"), "keep\n", "utf-8");
+		const git = simpleGit(repoDir);
+		await git.add(".");
+		await git.commit("Add keep.md");
+		await git.tag(["-d", "v1.0.0"]);
+		await git.addTag("v1.0.0");
+
+		const bareDir = join(dir, "bare");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		const installBase = join(dir, ".claude");
+		const targetPath = join(installBase, "skills", "foo");
+		const entity: ResolvedEntity = {
+			key: "foo",
+			name: "foo",
+			type: "skill",
+			group: "prod",
+			repo: "github.com/test/origin",
+			path: "skills/foo",
+			version: "1.0.0",
+			tag: "v1.0.0",
+			commit: "deadbeef",
+			local: false,
+			dependencies: [],
+			cachePath: bareDir,
+			exclude: ["experiments/", "docs/"],
+		};
+
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: installBase, force: true });
+
+		expect(existsSync(join(targetPath, "SKILL.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "keep.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "experiments"))).toBe(false);
+		expect(existsSync(join(targetPath, "docs"))).toBe(false);
+	});
+
+	test("no exclude on remote entity → every blob is copied (regression guard)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"origin",
+			[
+				{ path: "skills/foo", name: "foo" },
+				{ path: "skills/foo/experiments/a", name: "experiment-a" },
+			],
+			"v1.0.0",
+		);
+		const bareDir = join(dir, "bare");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		const installBase = join(dir, ".claude");
+		const targetPath = join(installBase, "skills", "foo");
+		const entity: ResolvedEntity = {
+			key: "foo",
+			name: "foo",
+			type: "skill",
+			group: "prod",
+			repo: "github.com/test/origin",
+			path: "skills/foo",
+			version: "1.0.0",
+			tag: "v1.0.0",
+			commit: "deadbeef",
+			local: false,
+			dependencies: [],
+			cachePath: bareDir,
+		};
+
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: installBase, force: true });
+
+		expect(existsSync(join(targetPath, "SKILL.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "experiments/a/SKILL.md"))).toBe(true);
 	});
 });


### PR DESCRIPTION
## Why

`exclude:` patterns declared on a `local:` entry in origin's `skilltree.yml` were silently ignored when a downstream consumer installed that same skill as a remote dep. Authors who carefully marked `docs/`, `evals/`, or `experiments/` as dev-only saw those directories shipped to every consumer anyway — exactly the kind of publication-surface trim the field is supposed to provide.

Closes #139

## What changed

- `src/core/graph.ts` — `resolveRemoteEntity` reads origin's manifest for the entity name. If origin declared `exclude:` on its `local:` entry, the patterns are copied onto the remote `ResolvedEntity`. New helper `readOriginExclude` mirrors the existing `inferDirectDepPath` / `detectPathMismatch` lookups; returns null when origin's manifest is missing, malformed, the entry isn't local, or `exclude:` is absent/empty.
- `src/core/installer.ts` — `copyFromGitCache` accepts an optional `IgnoreMatcher` and threads it into `copyTreeFromGit`, which checks each `ls-tree` blob's entity-relative path against the matcher before writing. The local-copy path was already doing this; this fills in the symmetric half of `publication_surface.md` §PS17 on the consumer side.

## How tested

- `tests/core/installer-exclude.test.ts` — new "remote install" describe block:
  - per-entity `exclude:` on a remote entity filters blobs read from the bare repo (the bug case from the issue)
  - no `exclude:` on a remote entity → every blob still copied (regression guard for existing behavior)
- `tests/core/graph-origin-manifest.test.ts` — new test confirms that `resolveAll` end-to-end propagates origin's `exclude:` onto the remote `ResolvedEntity` (the graph half of the fix, independent of the installer).
- Full suite green: 1583 tests pass, 0 fail. `tsc --noEmit` clean, biome clean.

## Risk & rollback

Low — additive change to the installer's copy path; the new code path only activates when origin declared `exclude:`, and existing remote installs (no exclude) keep their current behavior, which is exercised by the regression guard test. Revert with `git revert <sha>`.