### PR TITLE
fix(packs): publisher-repo UX cluster + .skilltreeignore for remote installs

### DIFF
--- a/docs/specs/packs.md
+++ b/docs/specs/packs.md
@@ -100,6 +100,65 @@ dependencies:
     pack: my-stack
 ```
 
+## Publishing Patterns
+
+When a repository **defines** packs for downstream consumers (instead of, or in addition to, consuming them), three details bite the first time around. The spec rules don't change — these are conventions on top of them.
+
+### Suffix the bundle alias when it would collide with a local skill
+
+R8 (parse-time) rejects a manifest where `packs.<name>` and a non-pack `dependencies.<name>` share a key. Publisher repos hit this whenever the natural pack name matches a skill they also expose locally — e.g. an `elastic-architect` skill that the maintainer wants to bundle under the same name.
+
+Resolve it by suffixing the **bundle alias** (members keep their original names):
+
+```yaml
+# instead of `elastic-architect:` (collides with the local dep of the same name)
+packs:
+  elastic-architect-pack:
+    - repo: https://github.com/marios-oss/elastic-skills
+      name: elastic-architect
+      version: "*"
+```
+
+`-pack` is the recommended suffix; `-bundle` is fine too. The R8 error message names both options as fix-it hints.
+
+### Use `name:` to set a member's identifier when `path:` is absent or misleading
+
+Pack members are a YAML list, so each member needs its own identifier. The resolver derives the key as follows (first match wins): `name:` → `basename(path)` → `basename(local)`. Two cases force you to set `name:`:
+
+1. **`basename(path)` doesn't match the skill's published name.** If your skill lives at `plugins/kibana/skills/agent-builder` but is published as `kibana-agent-builder`, you must set `name:` so the installer finds the right entity:
+
+   ```yaml
+   - repo: https://github.com/elastic/agent-skills
+     name: kibana-agent-builder
+     path: plugins/kibana/skills/agent-builder
+     version: "*"
+   ```
+
+2. **You're using the self-referential `repo:` pattern with no explicit `path:`** (see next section). With no `path:` and no `local:`, the resolver has nothing to derive a key from — set `name:` or you'll get *"Pack member has no derivable name."*
+
+### Self-reference your own repo to ship locally-defined skills in a remote pack
+
+Remote packs reject `local:` members — a relative path is meaningless on the consumer's filesystem, and an absolute path is worse. The workaround: declare a member that points back at the publishing repo using `repo:`. When a consumer installs the pack, the resolver fetches the repo (the same one that defined the pack), reads origin's `skilltree.yml` to find `<name>`, and installs the matching skill.
+
+```yaml
+# In the publisher's skilltree.yml — bundles a locally-defined skill into a remote pack
+packs:
+  elastic-stack:
+    - repo: https://github.com/marios-oss/elastic-skills
+      name: esql-details
+      version: "*"
+```
+
+A few behavioral subtleties worth knowing:
+
+- Members are installed **as copies from the bare cache**, not symlinks. The maintainer's working-tree edits aren't visible to consumers until a new tag is published.
+- The self-referential version `"*"` picks up whatever the latest tag is — pin to a specific version for stability.
+- The `name:` field is mandatory in this shape (per the previous section), because origin-manifest resolution supplies the `path:` rather than the pack member declaring it.
+
+### The "pack defined but never referenced" warning
+
+A publisher manifest that defines packs but doesn't consume them itself **does not** trigger the unreferenced-pack warning — that warning fires only when the manifest references at least one pack and one definition is orphaned (typo, rename, dead code). On a pure publisher manifest, every pack is "unreferenced" by design and the resolver stays silent.
+
 ## Constraints
 
 - **No new file type.** Packs are a `skilltree.yml` section; this keeps the manifest the single source of truth.

--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -123,8 +123,10 @@ A pack reference may not carry `path`, `type`, `name`, `force_path`, or `local`.
 
 - Members are full dep entries with the same shape as direct deps (no bare names).
 - A member may not itself be a `pack:` entry in v1 (nested packs deferred).
-- Local-path members (`local:`) in a **remote** pack must be relative; absolute paths are rejected (they would point at the pack author's filesystem).
+- Local-path members (`local:`) in a **remote** pack must be relative; absolute paths are rejected (they would point at the pack author's filesystem). To bundle locally-defined skills into a remote pack, use the self-referential `repo:` pattern — see "Publishing Patterns" in [packs.md](packs.md).
 - Members may be drawn from multiple repos.
+
+**Member identifier (`deriveMemberKey`):** the resolver derives the key by first match — `name:` → `basename(path)` → `basename(local)`. Set `name:` explicitly when the path basename doesn't match the published skill name, or when the member has neither `path:` nor `local:` (self-referential `repo:` pattern).
 
 **Error matrix:**
 
@@ -134,10 +136,11 @@ A pack reference may not carry `path`, `type`, `name`, `force_path`, or `local`.
 | Remote manifest has no `packs:` / missing the pack | Resolver error names repo + ref + pack name. |
 | Pack member collides with a consumer-declared dep | Resolver error names both sides. No silent merge. |
 | Two packs share a member | Same collision error. |
-| `packs.X` + non-pack `dependencies.X` (same key) | Parse-time error with fix-it hint. |
+| `packs.X` + non-pack `dependencies.X` (same key) | Parse-time error names both sides and suggests `pack: X` or a `-pack` / `-bundle` rename. |
 | `PackDependency` with `path`/`type`/`name`/`local`/`force_path` | Parse-time error names the field. |
 | `PackDependency` with `version` and no `repo`/`source` | Parse-time error. |
-| Local pack defined but never referenced | Non-blocking warning. |
+| Pack member has no derivable name (no `name:`, `path:`, or `local:`) | Resolver error names the pack. |
+| Local pack defined but never referenced (manifest also references at least one pack) | Non-blocking warning. Pure publisher manifests — packs defined, no pack refs — are silent. |
 
 A pack is never registered as an entity — only its expanded members appear in `state.entities` and the lockfile. See [packs.md](packs.md) for the full spec.
 

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -481,6 +481,14 @@ function describeCollidingDep(key: string, dep: Dependency, state: ResolutionSta
 function warnUnreferencedPacks(state: ResolutionState): void {
 	const packs = state.expanded.packs;
 	if (!packs) return;
+	// Publisher-repo heuristic (#145): if the manifest defines packs but
+	// references none of them, treat the file as consumer-facing and stay
+	// silent. The warning is meant to catch typos and orphaned definitions
+	// in *consuming* manifests; on a publisher repo every install would fire
+	// it, training maintainers to ignore the signal. A manifest with at
+	// least one pack reference still gets the per-pack warning for any
+	// pack name that wasn't actually used.
+	if (state.packsReferencedByName.size === 0) return;
 	for (const name of Object.keys(packs)) {
 		if (!state.packsReferencedByName.has(name)) {
 			state.warnings.push(

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -209,6 +209,11 @@ export async function executeInstall(
 	// Repo-wide ignore patterns apply to every local entity copy. Read once.
 	const repoIgnore = await readRepoIgnore(projectDir);
 
+	// Origin's `.skilltreeignore` is repo-wide and ref-stable, so cache by
+	// `cachePath@ref` to avoid re-reading from the bare repo for every sibling
+	// entity drawn from the same source (issue #148).
+	const originRepoIgnoreCache = new Map<string, IgnoreMatcher>();
+
 	for (const item of plan.toInstall) {
 		const { entity, action, targetPath, previousCommit } = item;
 
@@ -230,7 +235,8 @@ export async function executeInstall(
 				});
 			} else if (entity.cachePath) {
 				const entityIgnore = new IgnoreMatcher(entity.exclude ?? []);
-				await copyFromGitCache(entity, targetPath, entityIgnore);
+				const originRepoIgnore = await getOriginRepoIgnore(entity, originRepoIgnoreCache);
+				await copyFromGitCache(entity, targetPath, entityIgnore, originRepoIgnore);
 			}
 			await setReadOnly(targetPath);
 			integrityMap.set(entity.key, await computeIntegrity(targetPath));
@@ -238,6 +244,34 @@ export async function executeInstall(
 	}
 
 	return integrityMap;
+}
+
+/**
+ * Load origin's `.skilltreeignore` from the bare cache once per `cachePath@ref`.
+ * Returns an empty matcher when origin has no `.skilltreeignore` at that ref —
+ * the bug being fixed (issue #148) is the symmetric half of `.skilltreeignore`
+ * support: `publication_surface.md` §PS9–PS11 describes a repo-root file that
+ * should apply both when the maintainer installs locally and when a downstream
+ * consumer pulls the same skill as a remote dep.
+ */
+async function getOriginRepoIgnore(
+	entity: ResolvedEntity,
+	cache: Map<string, IgnoreMatcher>,
+): Promise<IgnoreMatcher> {
+	if (!entity.cachePath) return new IgnoreMatcher([]);
+	const ref = entity.tag ?? entity.commit;
+	const cacheKey = `${entity.cachePath}@${ref}`;
+	const cached = cache.get(cacheKey);
+	if (cached) return cached;
+	let matcher: IgnoreMatcher;
+	try {
+		const content = await readFileAtRef(entity.cachePath, ref, ".skilltreeignore");
+		matcher = new IgnoreMatcher(content.split(/\r?\n/));
+	} catch {
+		matcher = new IgnoreMatcher([]);
+	}
+	cache.set(cacheKey, matcher);
+	return matcher;
 }
 
 /**
@@ -358,16 +392,20 @@ function shouldExclude(src: string, sourcePath: string, ctx: CopyContext): boole
 /**
  * Copy files from git cache at a specific ref.
  *
- * For multi-file entities the optional `entityIgnore` filters blobs against
- * the per-entity `exclude:` patterns the origin declared in its manifest
- * (publication_surface.md §PS17 — applied symmetrically on the consumer
- * side per issue #139). Single-file entities (agents, commands) skip the
- * matcher: the file IS the entity, so there is nothing to filter inside.
+ * For multi-file entities two matchers may filter blobs before write:
+ * - `entityIgnore` — per-entity `exclude:` (entity-relative paths, §PS17)
+ * - `repoIgnore` — origin's `.skilltreeignore` (repo-root-relative, §PS9–PS11)
+ *
+ * Both halves of `publication_surface.md` are now applied symmetrically on the
+ * consumer side (#139 covered `exclude:`; #148 added `.skilltreeignore`).
+ * Single-file entities (agents, commands) skip both matchers: the file IS the
+ * entity, so there is nothing to filter inside.
  */
 async function copyFromGitCache(
 	entity: ResolvedEntity,
 	targetPath: string,
 	entityIgnore?: IgnoreMatcher,
+	repoIgnore?: IgnoreMatcher,
 ): Promise<void> {
 	if (!entity.cachePath) return;
 
@@ -381,7 +419,7 @@ async function copyFromGitCache(
 			await writeFile(targetPath, content, "utf-8");
 		} else {
 			await mkdir(targetPath, { recursive: true });
-			await copyTreeFromGit(entity.cachePath, ref, path, targetPath, entityIgnore);
+			await copyTreeFromGit(entity.cachePath, ref, path, targetPath, entityIgnore, repoIgnore);
 		}
 	} catch (cause) {
 		const refLabel = entity.tag ?? entity.commit.slice(0, 8);
@@ -397,8 +435,10 @@ async function copyFromGitCache(
  * Copy a directory tree from a git bare repo using a single `ls-tree -r`
  * call instead of recursive subprocess spawning.
  *
- * Optional `entityIgnore` filters blobs by their entity-relative path —
- * the same matcher the local-copy path applies for `exclude:` rules.
+ * Two optional matchers filter blobs before write — see `copyFromGitCache`
+ * for the §PS17 / §PS9–PS11 mapping. `entityIgnore` is tested against the
+ * entity-relative path; `repoIgnore` against the repo-relative path. Either
+ * match → skip the blob.
  */
 async function copyTreeFromGit(
 	cachePath: string,
@@ -406,6 +446,7 @@ async function copyTreeFromGit(
 	treePath: string,
 	targetDir: string,
 	entityIgnore?: IgnoreMatcher,
+	repoIgnore?: IgnoreMatcher,
 ): Promise<void> {
 	const git = simpleGit(cachePath);
 
@@ -426,6 +467,11 @@ async function copyTreeFromGit(
 		}
 
 		const itemPath = treePath === "." ? relativePath : `${treePath}/${relativePath}`;
+
+		if (repoIgnore && !repoIgnore.isEmpty && repoIgnore.ignores(itemPath)) {
+			continue;
+		}
+
 		const targetItemPath = join(targetDir, relativePath);
 
 		await mkdir(dirname(targetItemPath), { recursive: true });

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -505,19 +505,28 @@ function validatePacksSection(manifest: Manifest, errors: string[]): void {
 		// Collision: a pack named `X` and a non-pack `dependencies.X` shares a
 		// resolved name space. The resolver would either silently shadow one or
 		// surface a confusing duplicate. Catch it here with a fix-it hint.
+		// The `-pack` / `-bundle` suffix is the publisher-repo convention
+		// (#144) — publisher repos that consume their own skills locally hit
+		// this rule most often and need a concrete rename to suggest.
 		const directEntry = manifest.dependencies?.[packName];
 		if (directEntry && !isPackDependency(directEntry)) {
-			errors.push(
-				`"${packName}" is defined under \`packs:\` but dependencies.${packName} is a skill/agent/command entry — use \`pack: ${packName}\` to reference the pack, or rename one.`,
-			);
+			errors.push(formatPackCollisionError(packName, "dependencies"));
 		}
 		const devEntry = manifest["dev-dependencies"]?.[packName];
 		if (devEntry && !isPackDependency(devEntry)) {
-			errors.push(
-				`"${packName}" is defined under \`packs:\` but dev-dependencies.${packName} is a skill/agent/command entry — use \`pack: ${packName}\` to reference the pack, or rename one.`,
-			);
+			errors.push(formatPackCollisionError(packName, "dev-dependencies"));
 		}
 	}
+}
+
+function formatPackCollisionError(
+	packName: string,
+	group: "dependencies" | "dev-dependencies",
+): string {
+	return (
+		`"${packName}" is defined under \`packs:\` but ${group}.${packName} is a skill/agent/command entry — use \`pack: ${packName}\` to reference the pack, ` +
+		`or rename the pack (publisher convention: \`${packName}-pack\` or \`${packName}-bundle\`).`
+	);
 }
 
 /**

--- a/tests/core/graph-packs.test.ts
+++ b/tests/core/graph-packs.test.ts
@@ -215,7 +215,7 @@ describe("packs — local pack errors", () => {
 		expect(result.errors.some((e) => /collides/.test(e))).toBe(true);
 	});
 
-	test("I4 — unreferenced local pack → non-blocking warning", async () => {
+	test("I4 — unreferenced local pack with other pack refs → non-blocking warning", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-packs-i4-"));
 		const origin = await createTestRepo(
 			tempDir,
@@ -225,7 +225,11 @@ describe("packs — local pack errors", () => {
 		);
 
 		const manifest: Manifest = {
-			packs: { unused: [{ repo: `file://${origin}`, path: "foo", version: "*" }] },
+			packs: {
+				unused: [{ repo: `file://${origin}`, path: "foo", version: "*" }],
+				used: [{ repo: `file://${origin}`, path: "foo", version: "*" }],
+			},
+			dependencies: { used: { pack: "used" } },
 		};
 
 		const result = await resolveAll(manifest, tempDir);
@@ -233,6 +237,28 @@ describe("packs — local pack errors", () => {
 		expect(result.warnings.some((w) => /"unused"/.test(w) && /never referenced/.test(w))).toBe(
 			true,
 		);
+	});
+
+	test("I5 — publisher repo (packs defined, no pack refs) → no 'never referenced' warning (issue #145)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-packs-i5-"));
+		const origin = await createTestRepo(
+			tempDir,
+			"origin",
+			[{ path: "foo", name: "foo" }],
+			"v1.0.0",
+		);
+
+		// Manifest defines packs for downstream consumers but doesn't reference
+		// any pack itself — the canonical publisher pattern.
+		const manifest: Manifest = {
+			packs: {
+				"published-pack": [{ repo: `file://${origin}`, path: "foo", version: "*" }],
+			},
+		};
+
+		const result = await resolveAll(manifest, tempDir);
+		expect(result.errors).toEqual([]);
+		expect(result.warnings.some((w) => /never referenced/.test(w))).toBe(false);
 	});
 });
 

--- a/tests/core/installer-exclude.test.ts
+++ b/tests/core/installer-exclude.test.ts
@@ -250,3 +250,146 @@ describe("installer — exclude applied when copying from git cache (issue #139)
 		expect(existsSync(join(targetPath, "experiments/a/SKILL.md"))).toBe(true);
 	});
 });
+
+describe("installer — origin's .skilltreeignore applied to remote installs (issue #148)", () => {
+	test("origin's .skilltreeignore filters blobs when consumer installs as a remote dep", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"origin",
+			[{ path: "skills/foo", name: "foo" }],
+			undefined,
+		);
+		await writeFile(join(repoDir, "skills/foo/keep.md"), "keep\n", "utf-8");
+		await writeFile(join(repoDir, "skills/foo/notes.scratch"), "scratch\n", "utf-8");
+		await mkdir(join(repoDir, "skills/foo/sub"), { recursive: true });
+		await writeFile(join(repoDir, "skills/foo/sub/inner.scratch"), "deep scratch\n", "utf-8");
+		await writeFile(join(repoDir, ".skilltreeignore"), "**/*.scratch\n", "utf-8");
+		const git = simpleGit(repoDir);
+		await git.add(".");
+		await git.commit("Add .skilltreeignore and scratch files");
+		await git.addTag("v1.0.0");
+
+		const bareDir = join(dir, "bare");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		const installBase = join(dir, ".claude");
+		const targetPath = join(installBase, "skills", "foo");
+		const entity: ResolvedEntity = {
+			key: "foo",
+			name: "foo",
+			type: "skill",
+			group: "prod",
+			repo: "github.com/test/origin",
+			path: "skills/foo",
+			version: "1.0.0",
+			tag: "v1.0.0",
+			commit: "deadbeef",
+			local: false,
+			dependencies: [],
+			cachePath: bareDir,
+		};
+
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: installBase, force: true });
+
+		expect(existsSync(join(targetPath, "SKILL.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "keep.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "notes.scratch"))).toBe(false);
+		expect(existsSync(join(targetPath, "sub/inner.scratch"))).toBe(false);
+	});
+
+	test("origin's .skilltreeignore layers with per-entity exclude (union of patterns)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"origin",
+			[{ path: "skills/foo", name: "foo" }],
+			undefined,
+		);
+		await writeFile(join(repoDir, "skills/foo/keep.md"), "keep\n", "utf-8");
+		await writeFile(join(repoDir, "skills/foo/notes.scratch"), "scratch\n", "utf-8");
+		await mkdir(join(repoDir, "skills/foo/experiments"), { recursive: true });
+		await writeFile(join(repoDir, "skills/foo/experiments/e.md"), "exp\n", "utf-8");
+		await writeFile(join(repoDir, ".skilltreeignore"), "**/*.scratch\n", "utf-8");
+		const git = simpleGit(repoDir);
+		await git.add(".");
+		await git.commit("Add .skilltreeignore + experiments");
+		await git.addTag("v1.0.0");
+
+		const bareDir = join(dir, "bare");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		const installBase = join(dir, ".claude");
+		const targetPath = join(installBase, "skills", "foo");
+		const entity: ResolvedEntity = {
+			key: "foo",
+			name: "foo",
+			type: "skill",
+			group: "prod",
+			repo: "github.com/test/origin",
+			path: "skills/foo",
+			version: "1.0.0",
+			tag: "v1.0.0",
+			commit: "deadbeef",
+			local: false,
+			dependencies: [],
+			cachePath: bareDir,
+			exclude: ["experiments/"],
+		};
+
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: installBase, force: true });
+
+		expect(existsSync(join(targetPath, "SKILL.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "keep.md"))).toBe(true);
+		expect(existsSync(join(targetPath, "notes.scratch"))).toBe(false);
+		expect(existsSync(join(targetPath, "experiments"))).toBe(false);
+	});
+
+	test("no .skilltreeignore in origin → every blob still copied (regression guard)", async () => {
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(
+			dir,
+			"origin",
+			[{ path: "skills/foo", name: "foo" }],
+			"v1.0.0",
+		);
+		const bareDir = join(dir, "bare");
+		await simpleGit().clone(repoDir, bareDir, ["--bare"]);
+
+		const installBase = join(dir, ".claude");
+		const targetPath = join(installBase, "skills", "foo");
+		const entity: ResolvedEntity = {
+			key: "foo",
+			name: "foo",
+			type: "skill",
+			group: "prod",
+			repo: "github.com/test/origin",
+			path: "skills/foo",
+			version: "1.0.0",
+			tag: "v1.0.0",
+			commit: "deadbeef",
+			local: false,
+			dependencies: [],
+			cachePath: bareDir,
+		};
+
+		const plan = {
+			toInstall: [{ entity, action: "copy" as const, targetPath }],
+			skipped: [],
+			warnings: [],
+		};
+		await executeInstall(plan, dir, { installPath: installBase, force: true });
+
+		expect(existsSync(join(targetPath, "SKILL.md"))).toBe(true);
+	});
+});

--- a/tests/core/manifest-packs.test.ts
+++ b/tests/core/manifest-packs.test.ts
@@ -500,6 +500,24 @@ dependencies:
 		);
 	});
 
+	test("D3.a.i — R8 collision error suggests a -pack suffix as a rename hint (issue #144)", () => {
+		const m = parseManifest(`
+packs:
+  elastic-architect:
+    - repo: a
+      path: foo
+dependencies:
+  elastic-architect:
+    repo: b
+    path: bar
+`);
+		const errors = validateManifest(m);
+		const r8 = errors.find((e) => /elastic-architect/.test(e) && /packs:/.test(e));
+		expect(r8).toBeDefined();
+		// Names a concrete renamed alternative the publisher can use:
+		expect(r8).toMatch(/elastic-architect-pack/);
+	});
+
 	test("D3.b — packs.X with matching pack ref is fine", () => {
 		const m = parseManifest(`
 packs:


### PR DESCRIPTION
Five related issues, surfaced while building the `elastic-stack` publisher pack in marios-oss/elastic-skills — plus the mirror of #139's installer bug that #142 only fixed for `exclude:`.

Closes #144 #145 #146 #147 #148

- **#148** — installer now reads origin's `.skilltreeignore` from the bare cache (cached per `cachePath@ref`) and filters blobs by their repo-relative path. With #142 this finishes the symmetric application of `publication_surface.md` §PS9–PS11 / §PS17 on the consumer side.
- **#145** — `warnUnreferencedPacks` short-circuits when no pack is referenced anywhere. Pure publisher manifests stay silent; orphaned definitions in consuming manifests still warn.
- **#144** — R8 collision error now names a concrete rename (`<name>-pack` / `<name>-bundle`) instead of the generic "rename one."
- **#146 + #147** — docs. `packs.md` gains a "Publishing Patterns" section (suffix convention, `name:` member-key derivation, self-referential `repo:` for local skills in remote packs, silenced warning). `reference.md` error matrix updated.

Tests: 5 new (3 in `installer-exclude.test.ts` for #148; 1 each in `graph-packs.test.ts` and `manifest-packs.test.ts`). Existing I4 reworked so it still exercises the orphan-warning path under its new condition.