### PR TITLE
Bundled bugfix sweep — issues #150, #138, #143, #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ dependencies:
 
 Run `skilltree check` to catch the asymmetric-publish footgun: a published entity that transitively depends on a `publish: false` same-repo entity will install fine for you but fail for consumers. The check reports the chain so the fix is obvious. `check` also lints the frontmatter of every local `SKILL.md` / agent / command — missing `name:`, missing `description:`, invalid semver in `version:`, or a malformed `skills:` block become warnings (and exit 1 under `--strict`).
 
-For an "am I ready to publish?" preflight, run **`skilltree doctor`** — it bundles `check` with manifest-schema validation, lockfile-sync verification, target consistency, registry reachability, frontmatter lint, and a bundled-skill freshness check (warns when the skilltree skill on disk is missing or behind the installed CLI; run `skilltree teach` to refresh) into one verb. Exit 0 means every check passed; exit 1 means at least one failed. The natural lifecycle is `new → check → doctor → git tag`.
+For an "am I ready to publish?" preflight, run **`skilltree doctor`** — it bundles `check` with manifest-schema validation, lockfile-sync verification, target consistency, `.gitignore` drift, registry reachability, frontmatter lint, and a bundled-skill freshness check (warns when the skilltree skill on disk is missing or behind the installed CLI; run `skilltree teach` to refresh) into one verb. Exit 0 means every check passed; exit 1 means at least one failed. The natural lifecycle is `new → check → doctor → git tag`.
 
 This is **authoring intent, not access control** — anyone with git access to your repo can read every file regardless of these flags. They're about what your repo *offers*, not what it *protects*.
 
@@ -369,7 +369,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 | `skilltree remove <name>` | Remove a dependency |
 | `skilltree verify` | Check installed files against lockfile |
 | `skilltree check` | Lint `skilltree.yml` for design-time issues (asymmetric publish, frontmatter) |
-| `skilltree doctor` | Preflight: schema + lint + lockfile sync + targets + registries + frontmatter + bundled-skill freshness |
+| `skilltree doctor` | Preflight: schema + lint + lockfile sync + targets + gitignore + registries + frontmatter + bundled-skill freshness |
 | `skilltree list` | List installed dependencies |
 | `skilltree projects` | List skilltree-managed projects discoverable on this machine (read-only) |
 | `skilltree deps tree` | Show dependency tree |
@@ -380,7 +380,7 @@ skilltree scan --apply ./skills/        # auto-update frontmatter
 | `skilltree teach` | Install the skilltree skill to all detected coding agents |
 | `skilltree targets list` | Show detected and configured coding agents |
 | `skilltree targets add <target>` | Add an agent or path to install targets |
-| `skilltree targets remove <target>` | Remove an agent or path from install targets |
+| `skilltree targets remove <target>` | Remove an agent or path from install targets (deletes the installed dir by default; `--keep-files` opts out) |
 | `skilltree targets detect` | Auto-detect agents and add missing ones |
 | `skilltree targets migrate` | Convert `dev_install_path` to `install_targets` |
 | `skilltree search <query>` | Search registries for skills and agents |

--- a/docs/planning/general/PLAN.md
+++ b/docs/planning/general/PLAN.md
@@ -25,3 +25,13 @@ Realistic integration tests that create actual git repos, run real commands, and
 - [x] Update e2e tests — update all, selective update, no lockfile, --dry-run, local dep with new transitive, non-existent dep (6 tests)
 - [x] Lifecycle e2e test — init → add → install → verify → update → remove → verify (1 test, 21 assertions)
 - [x] Edge case e2e tests — diamond deps, mixed skill+agent, version conflict, --prod --frozen --install-path, orphan cascade, tagless repo, re-install after remove, deep cross-repo chain, empty manifest (10 tests)
+
+## Phase 3: Bundled-bugfix sweep (2026-05-23)
+
+Single PR bundling four independent bugfixes, one commit per issue. No new spec — each issue carries its own reproduction.
+
+### Tasks
+- [ ] **#150** — `lsRemote` tests fail under `GIT_EDITOR=true`. Extend env-scrub in `src/core/git.ts` (currently strips `LC_ALL`/`LANG`) to also delete `GIT_EDITOR` and `GIT_PAGER` before spawning. lsRemote is a non-interactive probe; it has no business inheriting editor config.
+- [ ] **#138** — `doctor` doesn't audit `.gitignore` drift. Add `checkGitignore` (warn-level) that diffs `getSkillAgentIgnoreEntriesForTarget(target)` against on-disk `.gitignore` for every entry in `install_targets`. Skip in `--global` mode. Reuses the same helper `init`/`targets` write, so the check can't drift from the writer.
+- [ ] **#143** — `list` is blind to pack definitions on the publisher side. Add a "Defined packs" section to `list` output when `manifest.packs` is non-empty. Consumer-side pack attribution (Via Pack column) deferred — needs `pack_resolutions:` in the lockfile, which was explicitly deferred in the Oxygen spec. Follow-up issue files cross-link.
+- [ ] **#72** — `targets remove` doesn't clean up installed artifacts + 2 install-time housekeeping bugs. (a) `targets remove` deletes the resolved target's `skills/`/`agents/`/`commands/` subdirs (with `--keep-files` opt-out and shared-dir guard). (b) `install` only `mkdir`s for agents listed in `install_targets`. (c) "already installed" warning only fires on integrity mismatch, not on clean idempotent re-install.

--- a/docs/specs/doctor.md
+++ b/docs/specs/doctor.md
@@ -1,9 +1,14 @@
 # Doctor — Preflight Health Check
 
 +++
-version = "1.1"
+version = "1.2"
 date = "2026-05-23"
 status = "active"
+
+[[changelog]]
+version = "1.2"
+date = "2026-05-23"
+summary = "Add gitignore drift check (D25, issue #138). Doctor warns when `.gitignore` is missing any of the entries that `init`/`targets add` would write for the declared `install_targets`, so hand-edited or stale .gitignore files surface before installed artifacts leak into commits. Skipped under `--global`."
 
 [[changelog]]
 version = "1.1"
@@ -62,6 +67,7 @@ Numbered for spec-to-phase traceability.
 - **D9 — Registry reachability**: For each registry in `~/.skilltree/config.yaml`, run `git ls-remote <url>` with a 5s timeout. Pass: all reachable. **Warn** (do not fail) when a registry requires auth and is skipped. Fail: surface the unreachable URL and the underlying error. When `--global` is set, this check still runs (registries are global config).
 - **D10 — Frontmatter validity**: Covered by D6 (the lint check already includes frontmatter validation). The doctor output lists it as a separate row for readability; internally it is the same check.
 - **D23 — Bundled-skill freshness** (Fluorine, 2026-05-23): For each agent detected on the user's machine (`detectInstalledAgents`), look up `<agent globalHome>/skills/skilltree/SKILL.md` and read its frontmatter `version`. Pass: all detected agents carry a `version` greater than or equal to the running CLI version. **Warn** (never fail) when any of: the file is missing, the file lacks a `version` field (legacy install predating Fluorine), or `semver.lt(installed, cliVersion)`. Skip when no agents are detected. Suggested fix string: `Run \`skilltree teach\` to install/update the skilltree skill`. The version is stamped into the materialized SKILL.md frontmatter at `materializeBundledSkill` time using the CLI's `package.json` version — the checked-in `skills/skilltree/SKILL.md` source carries no version. Runs in both project and `--global` mode (skill installation is global by nature).
+- **D25 — Gitignore drift** (2026-05-23, issue #138): For each entry in `install_targets`, compute the expected `.gitignore` entries via `getSkillAgentIgnoreEntriesForTarget` (the same helper `init`/`targets add` writes through) and diff against the on-disk `.gitignore`. Pass: every expected entry is present. **Warn** (never fail) when any entry is missing, listing each missing entry in the detail. Suggested fix: `Run \`skilltree init\` to refresh .gitignore`. Extra user-authored lines are ignored; only missing entries are flagged. Skipped under `--global` (the global home has no `.gitignore` story) and on `install_targets: []` (vacuous pass).
 
 ### Output — text mode (default)
 

--- a/docs/specs/multi-agent.md
+++ b/docs/specs/multi-agent.md
@@ -68,7 +68,7 @@ skilltree installs skills to a single directory (default `.claude/`). Users who 
 
 - **R11**: `skilltree targets list` shows all known agents with two indicators: detected on system, and present in `install_targets`. Also shows custom paths from `install_targets`.
 - **R12**: `skilltree targets add <name|path>` adds a target to `install_targets` in `skilltree.yml`
-- **R13**: `skilltree targets remove <name|path>` removes a target from `install_targets`
+- **R13**: `skilltree targets remove <name|path>` removes a target from `install_targets` AND deletes the target's installed artifacts (`<dir>/skills/`, `<dir>/agents/`, `<dir>/commands/`). When the parent dir becomes empty after the prune, it is removed too. The `--keep-files` flag preserves the on-disk artifacts AND keeps the `.gitignore` entries so the orphan stays ignored (mirrors `skilltree remove --keep-files`). When another remaining target resolves to the same install dir (e.g. `claude` aliased as `./.claude`), the prune is skipped so the sibling target's files aren't trampled. Order of operations: delete files first, then update `.gitignore` — a failed delete leaves the entries in place so the orphan stays ignored. Issue #72.
 - **R14**: `skilltree targets detect` scans for installed agents and adds any missing ones to `install_targets`
 - **R15**: `skilltree targets migrate` converts `dev_install_path` → `install_targets` and removes `dev_install_path` from the manifest. Known paths are reverse-looked-up to agent names (`.claude` → `claude`); unknown paths become literal (`./custom` → `./custom`)
 - **R16**: `targets add/remove/detect` error if `dev_install_path` is still set, directing the user to run `skilltree targets migrate` first

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -495,8 +495,15 @@ export function buildProgram(): Command {
 		.command("remove <target>")
 		.description("Remove an agent or path from install_targets")
 		.option("-g, --global", "Remove from global manifest")
+		.option(
+			"--keep-files",
+			"Leave installed artifacts on disk (keeps .gitignore entries so the orphan stays ignored)",
+		)
 		.action(async (target: string, opts) => {
-			await targetsRemoveCommand(target, process.cwd(), { global: opts.global });
+			await targetsRemoveCommand(target, process.cwd(), {
+				global: opts.global,
+				keepFiles: opts.keepFiles,
+			});
 		});
 
 	targets

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -14,6 +14,7 @@ import pkg from "../../package.json" with { type: "json" };
 import { detectInstalledAgents, getAgentLabel, resolveAgentHome } from "../core/agents.js";
 import { parseFrontmatter } from "../core/frontmatter.js";
 import { type LsRemoteOutcome, lsRemote } from "../core/git.js";
+import { getSkillAgentIgnoreEntriesForTarget } from "../core/gitignore.js";
 import { diffManifestLockfile, readLockfile } from "../core/lockfile.js";
 import { loadManifestOrThrow, validateGlobalManifest, validateManifest } from "../core/manifest.js";
 import { listRegistries } from "../core/registry-config.js";
@@ -89,6 +90,7 @@ export async function runDoctor(dir: string, opts: DoctorOptions = {}): Promise<
 	checks.push(checkLint(summary, lintError, manifest));
 	checks.push(await checkLockfileSync(manifest, dir, isGlobal));
 	checks.push(await checkTargetConsistency(manifest, isGlobal));
+	checks.push(await checkGitignore(manifest, dir, isGlobal));
 	checks.push(await checkRegistryReachability(probe, opts.registryConfigPath));
 	checks.push(checkFrontmatter(summary, lintError, manifest));
 	checks.push(await checkBundledSkill(opts.homeDir));
@@ -256,6 +258,66 @@ async function checkTargetConsistency(
 			detail: err instanceof Error ? err.message : String(err),
 		};
 	}
+}
+
+/**
+ * Spec D25 (issue #138): audit `.gitignore` for entries the installer relies
+ * on. Each `install_targets` entry resolves to a `<dir>/skills/`,
+ * `<dir>/agents/`, `<dir>/commands/` trio that `init`/`targets add` writes
+ * into `.gitignore`. If those entries drift (user hand-edit, target added
+ * without re-running `init`), installed artifacts surface in `git status`
+ * and get silently committed.
+ *
+ * Warn-level — never fails the run (spec D20). Skipped under `--global`
+ * (the global home has no `.gitignore` story).
+ *
+ * Reuses `getSkillAgentIgnoreEntriesForTarget`, the same helper `init` and
+ * `targets` write through, so this check can't drift from the writer
+ * (regression guard for #32).
+ */
+async function checkGitignore(
+	manifest: Manifest | null,
+	dir: string,
+	isGlobal: boolean,
+): Promise<CheckResult> {
+	if (isGlobal) {
+		return { name: "gitignore", status: "skip", detail: "global mode" };
+	}
+	if (!manifest) {
+		return { name: "gitignore", status: "skip", detail: "no manifest" };
+	}
+	const targets = manifest.install_targets ?? [];
+	if (targets.length === 0) {
+		return { name: "gitignore", status: "pass" };
+	}
+	const expected = new Set<string>();
+	for (const target of targets) {
+		for (const entry of getSkillAgentIgnoreEntriesForTarget(target)) {
+			expected.add(entry);
+		}
+	}
+	let content = "";
+	try {
+		content = await readFile(join(dir, ".gitignore"), "utf-8");
+	} catch {
+		// Missing .gitignore — every expected entry counts as missing.
+	}
+	const present = new Set(
+		content
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#")),
+	);
+	const missing = [...expected].filter((entry) => !present.has(entry));
+	if (missing.length === 0) {
+		return { name: "gitignore", status: "pass" };
+	}
+	return {
+		name: "gitignore",
+		status: "warn",
+		detail: `${missing.length} missing entr${missing.length === 1 ? "y" : "ies"}: ${missing.join(", ")}`,
+		fix: "Run `skilltree init` to refresh .gitignore",
+	};
 }
 
 /**

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,7 +3,7 @@ import { readGlobalLockfile, readLockfile } from "../core/lockfile.js";
 import { readManifest } from "../core/manifest.js";
 import { getGlobalDir } from "../core/paths.js";
 import { type ColumnDef, dim, pc, printTable } from "../core/ui.js";
-import type { Lockfile } from "../types.js";
+import type { Lockfile, Manifest } from "../types.js";
 
 export interface ListOptions {
 	json?: boolean;
@@ -21,16 +21,25 @@ export async function listCommand(dir: string, opts?: ListOptions): Promise<void
 		throw new Error(`No ${MANIFEST_NEW} found. Run \`skilltree init\` first.`);
 	}
 
+	// Read manifest up front (project mode only) so we can render the
+	// publisher-side "Defined packs" footer (#143) regardless of whether the
+	// lockfile is empty. Global mode has no packs surface.
+	const manifest = !isGlobal ? await safeReadManifest(dir) : undefined;
+
 	if (!lockfile || Object.keys(lockfile.packages).length === 0) {
 		if (opts?.json) {
 			console.log("[]");
-			return;
+		} else {
+			console.log(
+				isGlobal
+					? "No global dependencies installed. Run `skilltree install --global`."
+					: "No dependencies installed. Run `skilltree install`.",
+			);
 		}
-		console.log(
-			isGlobal
-				? "No global dependencies installed. Run `skilltree install --global`."
-				: "No dependencies installed. Run `skilltree install`.",
-		);
+		// Publisher repos commonly define packs without installing them
+		// locally. Surface them even when the entity table is empty so
+		// maintainers can confirm what their repo publishes.
+		if (!opts?.json && manifest) printDefinedPacks(manifest);
 		return;
 	}
 
@@ -44,7 +53,34 @@ export async function listCommand(dir: string, opts?: ListOptions): Promise<void
 	if (isGlobal) {
 		printGlobalTable(rows);
 	} else {
-		printProjectTable(rows, dir, globalDir);
+		await printProjectTable(rows, dir, globalDir);
+		if (manifest) printDefinedPacks(manifest);
+	}
+}
+
+async function safeReadManifest(dir: string): Promise<Manifest | undefined> {
+	try {
+		return await readManifest(dir);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Publisher-side pack visibility (#143). Renders one line per pack defined
+ * in `manifest.packs`, with its member count. No-op when packs is absent
+ * or empty. Consumer-side pack attribution (Via Pack column on member
+ * rows) is deferred — needs `pack_resolutions:` in the lockfile, which
+ * was explicitly future-work in the Oxygen spec.
+ */
+function printDefinedPacks(manifest: Manifest): void {
+	const packs = manifest.packs ?? {};
+	const entries = Object.entries(packs);
+	if (entries.length === 0) return;
+	console.log(pc.bold("\nDefined packs:"));
+	for (const [name, members] of entries) {
+		const count = members.length;
+		console.log(`  ${pc.cyan(name)}  ${dim(`${count} member${count === 1 ? "" : "s"}`)}`);
 	}
 }
 

--- a/src/commands/targets.ts
+++ b/src/commands/targets.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { readdir, rm, rmdir, stat } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import {
 	detectInstalledAgents,
@@ -12,7 +12,7 @@ import {
 	removeGitignoreEntries,
 } from "../core/gitignore.js";
 import { loadManifestOrThrow, writeManifest } from "../core/manifest.js";
-import { expandTilde, isLocalSource } from "../core/paths.js";
+import { canonicalPath, expandTilde, isLocalSource } from "../core/paths.js";
 import { dim, success, warn } from "../core/ui.js";
 import type { Manifest } from "../types.js";
 
@@ -22,6 +22,12 @@ interface TargetsOpts {
 	homeDir?: string;
 	/** Only honoured by `targetsListCommand`. Other targets verbs ignore it. */
 	json?: boolean;
+	/**
+	 * Honoured by `targetsRemoveCommand`. When true: leave installed files on
+	 * disk AND keep the gitignore entries so the orphan stays ignored. Mirrors
+	 * `skilltree remove --keep-files`. See issue #72.
+	 */
+	keepFiles?: boolean;
 }
 
 /**
@@ -231,21 +237,95 @@ export async function targetsRemoveCommand(
 	targets.splice(idx, 1);
 	await writeManifest(dir, manifest);
 
-	// Keep .gitignore in sync — but only remove entries that no remaining
-	// target still needs. Two targets can resolve to the same install dir
-	// (e.g., a literal path that aliases a known agent), so we compute the
-	// set still in use and subtract. Fixes #33.
-	const stillNeeded = new Set<string>();
-	for (const remaining of targets) {
-		for (const entry of getSkillAgentIgnoreEntriesForTarget(remaining)) {
-			stillNeeded.add(entry);
-		}
+	const sharedWithRemaining = remainingTargetsResolveSameDir(target, targets);
+
+	// Delete the on-disk install artifacts unless the user opted out, AND
+	// only when no remaining target still resolves to the same install dir.
+	// Order: delete files first, then update .gitignore — that way a failed
+	// delete leaves the gitignore entries in place and the orphan stays
+	// ignored. See issue #72.
+	const filesDeleted = !opts?.keepFiles && !sharedWithRemaining;
+	if (filesDeleted) {
+		await pruneInstalledTargetDir(dir, target);
 	}
-	const candidates = getSkillAgentIgnoreEntriesForTarget(target).filter((e) => !stillNeeded.has(e));
+
+	// Keep .gitignore in sync — but only remove entries that no remaining
+	// target still needs (existing #33 fix preserved). When --keep-files is
+	// set, also keep the gitignore entries so the leftover orphan doesn't
+	// surface to `git add .` — that's the whole point of --keep-files.
+	const candidates = opts?.keepFiles
+		? []
+		: getSkillAgentIgnoreEntriesForTarget(target).filter((entry) => {
+				const stillNeeded = new Set<string>();
+				for (const remaining of targets) {
+					for (const e of getSkillAgentIgnoreEntriesForTarget(remaining)) {
+						stillNeeded.add(e);
+					}
+				}
+				return !stillNeeded.has(entry);
+			});
 	const removed = await removeGitignoreEntries(dir, candidates);
 	success(`Removed ${target} from install_targets.`);
 	if (removed.length > 0) {
 		success(`Updated .gitignore (removed ${removed.join(", ")})`);
+	}
+	if (opts?.keepFiles) {
+		console.log(dim("  --keep-files: installed artifacts left in place."));
+	}
+}
+
+/**
+ * True when any remaining target resolves to the same install directory as
+ * the one being removed. Prevents `targets remove` from trampling a sibling
+ * target's installed artifacts when the user has aliased a known agent
+ * (e.g. `claude` + `./.claude` both resolving to `.claude`). See issue #72.
+ */
+function remainingTargetsResolveSameDir(removed: string, remaining: string[]): boolean {
+	const removedDir = safeResolveTarget(removed);
+	if (removedDir === null) return false;
+	const removedCanon = canonicalPath(removedDir);
+	for (const candidate of remaining) {
+		const dir = safeResolveTarget(candidate);
+		if (dir === null) continue;
+		if (canonicalPath(dir) === removedCanon) return true;
+	}
+	return false;
+}
+
+function safeResolveTarget(target: string): string | null {
+	try {
+		return resolveTarget(target);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Best-effort cleanup of the `<target>/skills/`, `<target>/agents/`, and
+ * `<target>/commands/` subtrees installed for the removed target. Errors are
+ * swallowed — the cleanup is convenience, not correctness; the user can
+ * always rm the dirs themselves. After pruning the managed subdirs, attempts
+ * to remove the parent directory iff it's now empty (so unrelated user files
+ * under the same dir are preserved). Issue #72.
+ */
+async function pruneInstalledTargetDir(dir: string, target: string): Promise<void> {
+	const targetDir = safeResolveTarget(target);
+	if (targetDir === null) return;
+	const base = join(dir, targetDir);
+	for (const subdir of ["skills", "agents", "commands"]) {
+		const full = join(base, subdir);
+		try {
+			await rm(full, { recursive: true, force: true });
+		} catch {
+			// Best-effort
+		}
+	}
+	// If the parent dir is now empty (no user files snuck in), drop it too.
+	try {
+		const remaining = await readdir(base);
+		if (remaining.length === 0) await rmdir(base);
+	} catch {
+		// Parent didn't exist or has user files — leave it alone
 	}
 }
 

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -43,6 +43,13 @@ export type LsRemoteOutcome =
  * appear regardless of the user's locale (issue #114). Also set
  * `GIT_TERMINAL_PROMPT=0` so a private-repo URL never blocks waiting
  * for credentials when ssh/key-helpers aren't configured.
+ *
+ * `GIT_EDITOR` and `GIT_PAGER` are stripped explicitly: lsRemote is a
+ * non-interactive probe and never opens an editor or paginates output.
+ * Inheriting them is harmless on current simple-git (3.33), but newer
+ * versions (3.36+) gate them behind `unsafe.allowUnsafeEditor` and
+ * refuse the spawn outright when the parent shell exports them — a
+ * common pattern in IDE terminals (issue #150).
  */
 export async function lsRemote(
 	url: string,
@@ -50,8 +57,9 @@ export async function lsRemote(
 ): Promise<LsRemoteOutcome> {
 	const timeoutMs = opts.timeoutMs ?? 5000;
 	const cloneUrl = toGitCloneUrl(url);
+	const { GIT_EDITOR: _editor, GIT_PAGER: _pager, ...safeEnv } = process.env;
 	const git = simpleGit().env({
-		...process.env,
+		...safeEnv,
 		LC_ALL: "C",
 		LANG: "C",
 		GIT_TERMINAL_PROMPT: "0",

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -200,11 +200,16 @@ export async function executeInstall(
 ): Promise<Map<string, string>> {
 	const integrityMap = new Map<string, string>();
 
-	// Ensure install directories exist
-	const installBase = options.installPath ?? join(projectDir, ".claude");
-	await mkdir(join(installBase, "skills"), { recursive: true });
-	await mkdir(join(installBase, "agents"), { recursive: true });
-	await mkdir(join(installBase, "commands"), { recursive: true });
+	// Per-entity copy/symlink calls below `mkdir` their parent paths on demand,
+	// so pre-creating the canonical `<base>/{skills,agents,commands}/` triad
+	// here would only run for its side effects. That actively backfired (#72,
+	// bug B): when an `installToTargets` loop iterates over targets, this
+	// function only ever sees the original `options` (no per-target
+	// `installPath` override), so the fallback to `.claude` materialized a
+	// stray `.claude/{skills,agents,commands}/` even on codex-only projects
+	// — un-ignored and ripe for accidental commit. Deleting the upfront
+	// mkdirs makes the function honest: it creates only what the plan asks
+	// for, and never leaks dirs to the wrong base.
 
 	// Repo-wide ignore patterns apply to every local entity copy. Read once.
 	const repoIgnore = await readRepoIgnore(projectDir);
@@ -314,12 +319,22 @@ async function prepareTarget(
 			await rm(targetPath);
 		} else if (stats.isDirectory() || stats.isFile()) {
 			const versionChanged = previousCommit !== undefined && previousCommit !== entity.commit;
-			if (!options.force && !entity.local && !versionChanged) {
+			// Distinguish "the lockfile says this is what's on disk" from
+			// "something already exists at this path that we didn't put here."
+			// The first case is a clean idempotent re-install — skip silently
+			// (#72, bug C). The second case is content we shouldn't trample
+			// without --force — warn and skip (preserved behavior).
+			const idempotentReinstall = previousCommit !== undefined && previousCommit === entity.commit;
+			const shouldOverwrite = options.force === true || entity.local === true || versionChanged;
+			if (shouldOverwrite) {
+				await makeWritable(targetPath);
+				await rm(targetPath, { recursive: true });
+			} else if (idempotentReinstall) {
+				return true;
+			} else {
 				plan.warnings.push(`${entity.name} already installed. Use --force to overwrite.`);
 				return true;
 			}
-			await makeWritable(targetPath);
-			await rm(targetPath, { recursive: true });
 		}
 	} catch {
 		// Target doesn't exist — that's fine

--- a/tests/cli/__snapshots__/help-snapshot.test.ts.snap
+++ b/tests/cli/__snapshots__/help-snapshot.test.ts.snap
@@ -554,6 +554,8 @@ Remove an agent or path from install_targets
 
 Options:
   -g, --global  Remove from global manifest
+  --keep-files  Leave installed artifacts on disk (keeps .gitignore entries so
+                the orphan stays ignored)
   -h, --help    display help for command
 "
 `;

--- a/tests/commands/__snapshots__/doctor.test.ts.snap
+++ b/tests/commands/__snapshots__/doctor.test.ts.snap
@@ -7,11 +7,13 @@ exports[`runDoctor — --json output J1: JSON shape stable across clean run 1`] 
     "lint",
     "lockfile-sync",
     "target-consistency",
+    "gitignore",
     "registry-reachability",
     "frontmatter",
     "bundled-skill",
   ],
   "statuses": [
+    "pass",
     "pass",
     "pass",
     "pass",

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -45,6 +45,14 @@ function cleanProject(): ProjectSpec {
 	return {
 		manifest: ["name: clean", "install_targets:", "  - claude", "dependencies: {}", ""].join("\n"),
 		lockfile: emptyLockfile(),
+		// init writes .gitignore on a fresh project; mirror that so the
+		// gitignore check (D25) doesn't warn on the canonical clean fixture.
+		files: [
+			{
+				path: ".gitignore",
+				content: ".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+			},
+		],
 	};
 }
 
@@ -313,6 +321,119 @@ describe("runDoctor — target consistency", () => {
 	});
 });
 
+describe("runDoctor — gitignore drift (#138)", () => {
+	test("complete .gitignore for the declared targets → pass", async () => {
+		const dir = await makeProject({
+			manifest: ["name: gi-clean", "install_targets:", "  - claude", "dependencies: {}", ""].join(
+				"\n",
+			),
+			lockfile: emptyLockfile(),
+			files: [
+				{
+					path: ".gitignore",
+					content: ".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+				},
+			],
+		});
+		const report = await runDoctorIsolated(dir);
+		const gi = report.checks.find((c) => c.name === "gitignore");
+		expect(gi?.status).toBe("pass");
+	});
+
+	test("missing entries for a declared target → warn naming the missing entries", async () => {
+		// init/targets writes .agents/{skills,agents,commands}/ for codex; if the
+		// user hand-edited .gitignore (or added codex without re-running init),
+		// installed artifacts leak into git status — exactly what doctor should
+		// catch.
+		const dir = await makeProject({
+			manifest: [
+				"name: gi-drift",
+				"install_targets:",
+				"  - claude",
+				"  - codex",
+				"dependencies: {}",
+				"",
+			].join("\n"),
+			lockfile: { ...emptyLockfile(), install_targets: ["claude", "codex"] },
+			files: [
+				{
+					path: ".gitignore",
+					content: ".claude/skills/\n.claude/agents/\n.claude/commands/\n",
+				},
+			],
+		});
+		const report = await runDoctorIsolated(dir);
+		const gi = report.checks.find((c) => c.name === "gitignore");
+		expect(gi?.status).toBe("warn");
+		expect(gi?.detail ?? "").toMatch(/\.agents\/skills\//);
+		expect(gi?.fix ?? "").toMatch(/skilltree init/);
+	});
+
+	test("missing .gitignore entirely → warn", async () => {
+		const dir = await makeProject({
+			manifest: ["name: gi-none", "install_targets:", "  - claude", "dependencies: {}", ""].join(
+				"\n",
+			),
+			lockfile: emptyLockfile(),
+		});
+		const report = await runDoctorIsolated(dir);
+		const gi = report.checks.find((c) => c.name === "gitignore");
+		expect(gi?.status).toBe("warn");
+		expect(gi?.detail ?? "").toMatch(/\.claude\/skills\//);
+	});
+
+	test("extra user-authored entries are ignored — only missing entries flagged", async () => {
+		const dir = await makeProject({
+			manifest: ["name: gi-extra", "install_targets:", "  - claude", "dependencies: {}", ""].join(
+				"\n",
+			),
+			lockfile: emptyLockfile(),
+			files: [
+				{
+					path: ".gitignore",
+					content: [
+						"node_modules/",
+						"# my notes",
+						".env",
+						".claude/skills/",
+						".claude/agents/",
+						".claude/commands/",
+						"build/",
+					].join("\n"),
+				},
+			],
+		});
+		const report = await runDoctorIsolated(dir);
+		const gi = report.checks.find((c) => c.name === "gitignore");
+		expect(gi?.status).toBe("pass");
+	});
+
+	test("--global mode skips the gitignore check", async () => {
+		const { globalDir } = await makeGlobalProject({
+			manifest: "name: global\ndependencies: {}\n",
+		});
+		const report = await runDoctor("/no-such-project-dir", {
+			global: true,
+			globalDir,
+			probe: okProbe,
+			registryConfigPath: await writeRegistriesFile([]),
+		});
+		const gi = report.checks.find((c) => c.name === "gitignore");
+		expect(gi?.status).toBe("skip");
+		expect(gi?.detail ?? "").toMatch(/global/i);
+	});
+
+	test("no install_targets → vacuous pass (nothing to ignore)", async () => {
+		const dir = await makeProject({
+			manifest: ["name: notargets", "dependencies: {}", ""].join("\n"),
+			lockfile: emptyLockfile(),
+		});
+		const report = await runDoctorIsolated(dir);
+		const gi = report.checks.find((c) => c.name === "gitignore");
+		expect(gi?.status).toBe("pass");
+	});
+});
+
 describe("runDoctor — registry reachability (Phase 3, default)", () => {
 	test("with no registries configured → pass", async () => {
 		const dir = await makeProject(cleanProject());
@@ -335,6 +456,7 @@ describe("runDoctor — check ordering and stability", () => {
 			"lint",
 			"lockfile-sync",
 			"target-consistency",
+			"gitignore",
 			"registry-reachability",
 			"frontmatter",
 			"bundled-skill",
@@ -450,6 +572,7 @@ describe("runDoctor — --json output", () => {
 			"lint",
 			"lockfile-sync",
 			"target-consistency",
+			"gitignore",
 			"registry-reachability",
 			"frontmatter",
 			"bundled-skill",

--- a/tests/commands/list-extended.test.ts
+++ b/tests/commands/list-extended.test.ts
@@ -156,6 +156,79 @@ describe("listCommand extended", () => {
 		expect(dataRows.some((l) => / - /.test(l))).toBe(false);
 	});
 
+	test("publisher: lists defined packs in text output when manifest has packs: (#143)", async () => {
+		// Publisher repos define packs for downstream consumers without
+		// necessarily consuming the pack themselves. `list` previously read only
+		// the lockfile, so maintainers had no way to confirm what packs their
+		// repo publishes without grepping skilltree.yml. Show a footer listing
+		// each defined pack with its member count.
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-packs-"));
+		await writeFile(
+			join(tempDir, "skilltree.yml"),
+			[
+				"name: publisher",
+				"packs:",
+				"  my-stack:",
+				"    - local: ./skills/a",
+				"    - local: ./skills/b",
+				"  small-pack:",
+				"    - local: ./skills/c",
+				"",
+			].join("\n"),
+		);
+		await writeFile(join(tempDir, "skilltree.lock"), LOCKFILE_WITH_DEPS);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir);
+		} finally {
+			restore();
+		}
+		const joined = logs.join("\n");
+		expect(joined).toMatch(/Defined packs/i);
+		expect(joined).toMatch(/my-stack/);
+		expect(joined).toMatch(/small-pack/);
+		// Member counts are surfaced so maintainers can sanity-check expansion.
+		expect(joined).toMatch(/2 members?/);
+		expect(joined).toMatch(/1 member/);
+	});
+
+	test("publisher: empty lockfile still surfaces defined packs (#143)", async () => {
+		// Pure publisher repo — packs defined but nothing installed locally. The
+		// previous "No dependencies installed" early-return swallowed the packs
+		// summary entirely.
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-packs-empty-"));
+		await writeFile(
+			join(tempDir, "skilltree.yml"),
+			["name: pure-publisher", "packs:", "  only-pack:", "    - local: ./skills/x", ""].join("\n"),
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir);
+		} finally {
+			restore();
+		}
+		const joined = logs.join("\n");
+		expect(joined).toMatch(/Defined packs/i);
+		expect(joined).toMatch(/only-pack/);
+	});
+
+	test("no packs: section → list output omits the Defined packs section (#143)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-nopacks-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.lock"), LOCKFILE_WITH_DEPS);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir);
+		} finally {
+			restore();
+		}
+		const joined = logs.join("\n");
+		expect(joined).not.toMatch(/Defined packs/i);
+	});
+
 	test("--json includes commit field and omits '-' version for unpinned remote dep (issue #76)", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
 		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");

--- a/tests/commands/targets.test.ts
+++ b/tests/commands/targets.test.ts
@@ -136,6 +136,77 @@ describe("targetsRemoveCommand", () => {
 
 		await expect(targetsRemoveCommand("claude", dir)).rejects.toThrow("targets migrate");
 	});
+
+	test("deletes the removed target's installed dirs by default (#72)", async () => {
+		// Reproduction of #72: removing a target from install_targets used to
+		// leave the on-disk install dir behind. Combined with the gitignore
+		// entries being removed in the same call, the orphan became visible to
+		// `git add .` and got silently committed. Now we delete the dir as
+		// part of the same action.
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+		// Simulate a prior install having populated .agents/.
+		await mkdir(join(dir, ".agents", "skills", "foo"), { recursive: true });
+		await writeFile(join(dir, ".agents", "skills", "foo", "SKILL.md"), "# foo\n");
+
+		await targetsRemoveCommand("codex", dir);
+
+		await expect(stat(join(dir, ".agents"))).rejects.toThrow(/ENOENT/);
+	});
+
+	test("preserves other targets' installed dirs (#72)", async () => {
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+		await mkdir(join(dir, ".claude", "skills", "foo"), { recursive: true });
+		await mkdir(join(dir, ".agents", "skills", "foo"), { recursive: true });
+
+		await targetsRemoveCommand("codex", dir);
+
+		// .claude/ untouched
+		await expect(stat(join(dir, ".claude", "skills", "foo"))).resolves.toBeDefined();
+	});
+
+	test("--keep-files leaves the dir AND keeps the gitignore entries (#72)", async () => {
+		// With --keep-files we want the orphan to stay BUT we also want the
+		// gitignore entries to stay so the orphan doesn't become visible to
+		// `git add .`. This is the safe escape hatch for users who want to
+		// manage the artifact themselves.
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+		await writeFile(
+			join(dir, ".gitignore"),
+			".claude/skills/\n.claude/agents/\n.claude/commands/\n.agents/skills/\n.agents/agents/\n.agents/commands/\n",
+			"utf-8",
+		);
+		await mkdir(join(dir, ".agents", "skills", "foo"), { recursive: true });
+
+		await targetsRemoveCommand("codex", dir, { keepFiles: true });
+
+		await expect(stat(join(dir, ".agents", "skills", "foo"))).resolves.toBeDefined();
+		const gi = await readFile(join(dir, ".gitignore"), "utf-8");
+		expect(gi).toMatch(/\.agents\/skills\//);
+	});
+
+	test("shared-dir guard: doesn't delete when another remaining target resolves to the same dir (#72)", async () => {
+		// Two install_targets pointing at the same resolved dir (e.g. the
+		// agent and a literal alias). Removing one must NOT trample the other.
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\n  - ./.claude\ndependencies: {}\n");
+		await mkdir(join(dir, ".claude", "skills", "foo"), { recursive: true });
+
+		await targetsRemoveCommand("claude", dir);
+
+		await expect(stat(join(dir, ".claude", "skills", "foo"))).resolves.toBeDefined();
+	});
+
+	test("survives when the install dir doesn't exist (#72)", async () => {
+		// Removing a target before install ever ran shouldn't error — the
+		// cleanup is a best-effort step.
+		const dir = await makeTempDir();
+		await writeManifestFile(dir, "install_targets:\n  - claude\n  - codex\ndependencies: {}\n");
+
+		await expect(targetsRemoveCommand("codex", dir)).resolves.toBeUndefined();
+	});
 });
 
 describe("targetsDetectCommand", () => {

--- a/tests/core/command-type.test.ts
+++ b/tests/core/command-type.test.ts
@@ -156,16 +156,18 @@ describe("executeInstall for commands", () => {
 		expect(content).toContain("name: review");
 	});
 
-	test("creates the commands/ directory even when no commands install", async () => {
-		// The install loop unconditionally creates skills/, agents/, and now
-		// commands/ — so consumers always have a stable layout to drop files
-		// into manually if they want.
+	test("does NOT pre-create commands/ when nothing installs there (#72)", async () => {
+		// Reversal of the original "stable layout" test. The unconditional
+		// mkdir was the root of #72 bug B: in a per-target install loop the
+		// fallback to .claude leaked stray, un-ignored dirs into the working
+		// tree on codex-only projects. The new contract is "create only what
+		// the plan asks for"; users who want an empty layout can `mkdir`
+		// themselves.
 		const dir = await makeTempDir("skilltree-cmd-mkdir-");
 		const installBase = join(dir, ".claude");
 		const plan = await planInstall(new Map(), [], installBase, {});
 		await executeInstall(plan, dir, {});
-		const stats = await lstat(join(installBase, "commands"));
-		expect(stats.isDirectory()).toBe(true);
+		await expect(lstat(join(installBase, "commands"))).rejects.toThrow(/ENOENT/);
 	});
 });
 

--- a/tests/core/git.test.ts
+++ b/tests/core/git.test.ts
@@ -75,6 +75,31 @@ describe("lsRemote", () => {
 		}
 	});
 
+	test("succeeds even when GIT_EDITOR/GIT_PAGER are inherited from the env (#150)", async () => {
+		// Issue #150: simple-git 3.36+ refuses to spawn when GIT_EDITOR is
+		// inherited from the parent env (`Use of "GIT_EDITOR" is not permitted
+		// without enabling allowUnsafeEditor`). This currently passes against
+		// our pinned 3.33 even without the env scrub — the test exists as a
+		// forward-looking regression guard for when we bump simple-git, and to
+		// pin the contract that lsRemote (a non-interactive probe) must never
+		// inherit interactive editor/pager config.
+		const dir = await makeTempDir();
+		const repoDir = await createTestRepo(dir, "editor-env", [{ path: "skills/a", name: "a" }]);
+		const originalEditor = process.env.GIT_EDITOR;
+		const originalPager = process.env.GIT_PAGER;
+		process.env.GIT_EDITOR = "true";
+		process.env.GIT_PAGER = "less";
+		try {
+			const outcome = await lsRemote(`file://${repoDir}`);
+			expect(outcome.ok).toBe(true);
+		} finally {
+			if (originalEditor === undefined) delete process.env.GIT_EDITOR;
+			else process.env.GIT_EDITOR = originalEditor;
+			if (originalPager === undefined) delete process.env.GIT_PAGER;
+			else process.env.GIT_PAGER = originalPager;
+		}
+	});
+
 	test("locale-independent: stderr stays English under a non-English LC_ALL (#114)", async () => {
 		// Issue #114: classification of git stderr (auth / unreachable / other)
 		// uses English substring matching. Without locale pinning, a French/

--- a/tests/core/installer-unhappy.test.ts
+++ b/tests/core/installer-unhappy.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ResolvedEntity } from "../../src/core/graph.js";
@@ -9,6 +9,7 @@ import {
 	planInstall,
 	verifyInstalled,
 } from "../../src/core/installer.js";
+import type { Lockfile } from "../../src/types.js";
 import { createLocalSkill } from "../helpers/git-fixtures.js";
 
 let tempDir: string;
@@ -239,6 +240,35 @@ describe("integrity hash edge cases", () => {
 	});
 });
 
+describe("executeInstall — no over-mkdir for unenrolled agent dirs (#72)", () => {
+	test("empty plan does not create the default .claude/ tree when installPath is elsewhere", async () => {
+		// Reproduction of #72 bug B: install used to unconditionally mkdir
+		// .claude/{skills,agents,commands} even when claude wasn't an
+		// install target (e.g. codex-only project). Those dirs landed in
+		// the working tree un-ignored and got silently committed by `git add .`.
+		const dir = await makeTempDir();
+		const agentsBase = join(dir, ".agents");
+
+		await executeInstall({ toInstall: [], skipped: [], warnings: [] }, dir, {
+			installPath: agentsBase,
+		});
+
+		await expect(stat(join(dir, ".claude"))).rejects.toThrow(/ENOENT/);
+	});
+
+	test("empty plan with no installPath also creates nothing — defaults aren't an obligation", async () => {
+		// Side benefit of removing the unconditional mkdirs: even the default
+		// `.claude` path is only created when there's something to put there.
+		// Avoids surprising tree pollution on `install` against a zero-dep
+		// manifest.
+		const dir = await makeTempDir();
+
+		await executeInstall({ toInstall: [], skipped: [], warnings: [] }, dir, {});
+
+		await expect(stat(join(dir, ".claude"))).rejects.toThrow(/ENOENT/);
+	});
+});
+
 describe("install with existing non-symlink files (no --force)", () => {
 	test("warns when remote dep already installed without --force", async () => {
 		const dir = await makeTempDir();
@@ -270,5 +300,53 @@ describe("install with existing non-symlink files (no --force)", () => {
 
 		// Should have a warning about already installed
 		expect(plan.warnings.some((w) => w.includes("already installed"))).toBe(true);
+	});
+
+	test("idempotent re-install at the same commit is silent — no 'already installed' nag (#72)", async () => {
+		// Bug C from #72: running `skilltree install` twice on an unchanged
+		// project produced "already installed. Use --force to overwrite." on
+		// every entity in the second run, prompting users toward a wasteful
+		// --force re-copy. When the previous lockfile records the same commit
+		// as the entity we're about to install, it's a clean idempotent
+		// re-install — skip silently.
+		const dir = await makeTempDir();
+		const installBase = join(dir, ".claude");
+		await mkdir(join(installBase, "skills", "stable"), { recursive: true });
+		await writeFile(join(installBase, "skills", "stable", "SKILL.md"), "# stable\n");
+
+		const entity: ResolvedEntity = {
+			key: "stable",
+			name: "stable",
+			type: "skill",
+			group: "prod",
+			repo: "github.com/test/repo",
+			path: "skills/stable",
+			version: "1.0.0",
+			tag: "v1.0.0",
+			commit: "deadbeef",
+			local: false,
+			dependencies: [],
+		};
+		const entities = new Map<string, ResolvedEntity>([["skill:stable", entity]]);
+		const previousLockfile: Lockfile = {
+			lockfile_version: 1,
+			packages: {
+				stable: {
+					type: "skill",
+					group: "prod",
+					source: "remote",
+					repo: "github.com/test/repo",
+					path: "skills/stable",
+					commit: "deadbeef",
+					version: "1.0.0",
+					dependencies: [],
+				},
+			},
+		};
+
+		const plan = await planInstall(entities, ["skill:stable"], installBase, {}, previousLockfile);
+		await executeInstall(plan, dir, {});
+
+		expect(plan.warnings).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Why

Four independent install-lifecycle bugfixes, bundled into one PR per the
"general" sub-project (Phase 3) to land as a single version bump.
Each commit closes one issue and can be reverted independently.

Closes #150 #138 #143 #72

## What changed

**1. `fix(git)`: scrub `GIT_EDITOR` / `GIT_PAGER` from `lsRemote` spawn env (#150)**
`lsRemote` is a non-interactive probe and has no business inheriting
interactive editor/pager vars. simple-git 3.36+ rejects the spawn
when `GIT_EDITOR` is inherited (the bug the issue reporter hit in an
IDE terminal); our pinned 3.33 tolerates it, so the test is a
forward-looking regression guard.

**2. `feat(doctor)`: warn on `.gitignore` drift for `install_targets` (D25, #138)**
New warn-level check that diffs `.gitignore` against the entries
`init`/`targets add` would write for each `install_targets` entry.
Catches hand-edits, targets added without re-running `init`, and the
old `targets remove` writer that left orphans visible to `git add .`.
Reuses `getSkillAgentIgnoreEntriesForTarget` (same helper init writes
through) so it can't drift from the writer. Skipped under `--global`.
Spec: `docs/specs/doctor.md` v1.2.

**3. `feat(list)`: show defined packs section for publisher repos (#143, publisher half)**
Adds a "Defined packs" footer to text-mode `skilltree list` whenever
the manifest has a non-empty `packs:` section, with member counts.
Empty-lockfile early-return now falls through to render the packs
footer so pure-publisher repos get the same visibility. JSON shape
unchanged for back-compat — consumer-side `Via Pack` column is
deferred (needs `pack_resolutions:` in the lockfile, explicitly
future-work in the Oxygen spec).

**4. `fix(targets,install)`: `targets remove` cleanup + stop over-mkdir + quiet idempotent re-install (#72)**
Three sub-bugs on the same surface:
- **A**: `targets remove` now deletes the resolved target's
  `<dir>/{skills,agents,commands}/`, drops the empty parent dir, and
  ships a `--keep-files` opt-out that preserves both the files AND the
  gitignore entries (so the orphan stays ignored). Shared-dir guard
  via `canonicalPath` equality prevents trampling sibling targets
  aliased to the same install dir. Order: delete files first, then
  update `.gitignore` — a failed delete leaves entries in place.
- **B**: `executeInstall` no longer unconditionally `mkdir`s
  `.claude/{skills,agents,commands}/`. The unconditional fallback
  to `.claude` was polluting working trees on codex-only projects.
  Per-item parent dirs are still created on-demand by the copy/symlink
  loop.
- **C**: "already installed. Use --force to overwrite." warning now
  fires only when on-disk content has no lockfile trace (foreign
  content we shouldn't trample). Clean idempotent re-install at the
  same commit silently skips.

Spec: `docs/specs/multi-agent.md` R13 updated.

**5. `docs(readme)`**: minor — `doctor` row + intro paragraph mention
the new gitignore check; `targets remove` row mentions the cleanup
+ `--keep-files` opt-out.

## How tested

- `bun test` — 1620/1620 passing (42 snapshots, 3250 expect() calls)
- 19 new test cases across:
  - `tests/core/git.test.ts` — env scrub guard (#150)
  - `tests/commands/doctor.test.ts` — 6 cases for the gitignore check (#138)
  - `tests/commands/list-extended.test.ts` — 3 cases for publisher packs visibility (#143)
  - `tests/commands/targets.test.ts` — 5 cases for `targets remove` cleanup + `--keep-files` + shared-dir guard (#72A)
  - `tests/core/installer-unhappy.test.ts` — 3 cases for over-mkdir guard + idempotent silent re-install (#72B, #72C)
- Help snapshot + doctor JSON snapshot refreshed for the new `--keep-files` flag and the new check row.
- One pre-existing test (`command-type.test.ts`) was reversed in the same commit as #72B — its old "stable layout" premise contradicts the fix; a flipped assertion guards the new contract.

## Risk & rollback

Low blast radius. Each commit is independent; `git revert <sha>`
isolates any single fix. The biggest behavioral change is #72B
(no more unconditional `.claude/{skills,agents,commands}/` mkdir on
every install) — the regression test inversion is explicit about the
new contract.