### PR TITLE
feat(list): surface consumer-side pack attribution (via_pack)

### DIFF
--- a/docs/specs/packs.md
+++ b/docs/specs/packs.md
@@ -202,4 +202,8 @@ None blocking v1 — all resolved during planning (see "Confirmed design decisio
 - **Consumer-side overrides** (`exclude:` member list, per-member version pin) — defer until real demand surfaces.
 - **`skilltree why <pack>`** — a follow-up. v1 only supports `why <member>` which reports `_viaPack` provenance.
 - **Glob mode for `skilltree add 'X-pack-*'`** — defer.
-- **Lockfile `pack_resolutions:` section** — only if reproducibility of *which pack version was used* becomes a need.
+- **Lockfile `pack_resolutions:` section** — a richer structured block recording the pin and member set per pack reference. Not needed yet; the lighter-weight per-entry `via_pack:` field added for #153 already covers consumer-side attribution.
+
+## Consumer-side attribution (#153)
+
+Each lockfile entry injected by expanding a `pack:` reference carries a `via_pack:` field naming the consumer's yaml key for that pack reference. Direct entries omit the field. `skilltree list` reads this to render a "Via Pack" column (text mode) and a `viaPack` field on each row (`--json`); the column is hidden when no entry carries the field, so non-pack projects see no visual change. The install path does not read `via_pack:` — it is provenance only.

--- a/docs/specs/reference.md
+++ b/docs/specs/reference.md
@@ -209,6 +209,7 @@ packages:
 | `integrity` | SHA-256 content hash (remote deps only) |
 | `name` | Actual entity name (only present when aliased) |
 | `dependencies` | List of dependency names |
+| `via_pack` | Consumer's yaml key for the pack reference that injected this entry. Only present on pack-expanded members. Read by `list` for the "Via Pack" column; never used in the install path. (#153) |
 
 **Integrity hash algorithm:** List all files recursively, sort by relative path (alphabetical), concatenate `"{relative_path}\0{file_content}"` for each, SHA-256 the result. Deterministic across platforms.
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -92,6 +92,12 @@ interface ListRow {
 	source: string;
 	/** Resolved commit SHA — present for remote deps, omitted for `source: local`. */
 	commit?: string;
+	/**
+	 * Consumer-side pack attribution (#153). Populated only for entries
+	 * injected by a pack expansion; rendered as the "Via Pack" column in
+	 * text mode and as `viaPack` in --json output.
+	 */
+	viaPack?: string;
 }
 
 /** Short SHA convention used elsewhere in the codebase (see graph.ts install warnings). */
@@ -129,6 +135,14 @@ function buildRows(lockfile: Lockfile): ListRow[] {
 		if (entry.source !== "local" && entry.commit) {
 			row.commit = entry.commit;
 		}
+		// #153: only attach viaPack when present so direct deps stay clean in
+		// JSON output and the column-presence check in `printProjectTable`
+		// can use a plain `=== undefined` test. Presence check per the
+		// hardening pattern — a hand-edited `via_pack: ""` flows through
+		// unchanged so the bad data is visible rather than silently dropped.
+		if (entry.via_pack !== undefined) {
+			row.viaPack = entry.via_pack;
+		}
 		return row;
 	});
 }
@@ -143,19 +157,28 @@ const VERSION_COL: ColumnDef<ListRow> = {
 	color: pc.green,
 };
 const SOURCE_COL: ColumnDef<ListRow> = { header: "Source", value: (r) => r.source, color: dim };
+const VIA_PACK_COL: ColumnDef<ListRow> = {
+	header: "Via Pack",
+	value: (r) => r.viaPack ?? "—",
+	color: pc.magenta,
+};
 
 function printGlobalTable(rows: ListRow[]): void {
 	printTable(rows, [NAME_COL, TYPE_COL, VERSION_COL, SOURCE_COL]);
 }
 
 async function printProjectTable(rows: ListRow[], dir: string, globalDir: string): Promise<void> {
-	printTable(rows, [
+	// #153: only show the Via Pack column when at least one row has pack
+	// attribution. Projects that don't use packs stay visually unchanged.
+	const hasPackAttribution = rows.some((r) => r.viaPack !== undefined);
+	const columns: ColumnDef<ListRow>[] = [
 		NAME_COL,
 		TYPE_COL,
 		{ header: "Group", value: (r) => r.group, color: dim },
-		VERSION_COL,
-		SOURCE_COL,
-	]);
+	];
+	if (hasPackAttribution) columns.push(VIA_PACK_COL);
+	columns.push(VERSION_COL, SOURCE_COL);
+	printTable(rows, columns);
 
 	// Vendor mode indicator
 	try {

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -72,8 +72,9 @@ export interface ResolvedEntity {
 	exclude?: string[];
 	/**
 	 * If this entity was injected by a pack expansion, the consumer's yaml key
-	 * for that pack reference. Internal; never serialized to lockfile. Drives
-	 * future `why <entity>` provenance ("via pack X"). Oxygen Phase 2.
+	 * for that pack reference. Set during pack expansion (Oxygen Phase 2);
+	 * persisted to the lockfile as `via_pack` so `list` can render consumer-side
+	 * pack attribution (#153). Not consumed by the install path.
 	 */
 	viaPack?: string;
 }

--- a/src/core/lockfile.ts
+++ b/src/core/lockfile.ts
@@ -54,6 +54,15 @@ export function buildLockfile(
 			entry.name = entity.name;
 		}
 
+		// #153: persist pack provenance so `list` can render the consumer-side
+		// "Via Pack" column. The resolver expands packs into N flat entries
+		// before the lockfile is written, so without this field the attribution
+		// is lost by the time `list` reads back. Presence check, per the
+		// hardening pattern — direct deps leave the field unset, not "".
+		if (entity.viaPack !== undefined) {
+			entry.via_pack = entity.viaPack;
+		}
+
 		packages[entity.key] = entry;
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,13 @@ export interface LockfileEntry {
 	integrity?: string;
 	name?: string;
 	dependencies: string[];
+	/**
+	 * Consumer-side pack attribution (#153). When this entry was injected by
+	 * expanding a `pack:` reference, holds the consumer's yaml key for that
+	 * pack. Omitted for directly-declared deps. Read by `list` to surface a
+	 * "Via Pack" column; never used in the install path.
+	 */
+	via_pack?: string;
 }
 
 export interface Lockfile {

--- a/tests/commands/list-extended.test.ts
+++ b/tests/commands/list-extended.test.ts
@@ -229,6 +229,125 @@ describe("listCommand extended", () => {
 		expect(joined).not.toMatch(/Defined packs/i);
 	});
 
+	test("consumer: text output shows 'Via Pack' column when pack-attributed entries exist (#153)", async () => {
+		// Resolver expands packs into N flat members before writing the lockfile.
+		// Without the via_pack column the consumer can't tell which top-level
+		// pack reference each row came from.
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-viapack-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
+		await writeFile(
+			join(tempDir, "skilltree.lock"),
+			[
+				"lockfile_version: 1",
+				"packages:",
+				"  elastic-architect:",
+				"    type: skill",
+				"    group: prod",
+				"    repo: github.com/marios-oss/elastic-skills",
+				"    path: skills/elastic-architect",
+				"    version: 0.1.5",
+				"    commit: abc1234",
+				"    via_pack: elastic-stack",
+				"    dependencies: []",
+				"  esql-details:",
+				"    type: skill",
+				"    group: prod",
+				"    repo: github.com/marios-oss/elastic-skills",
+				"    path: skills/esql-details",
+				"    version: 0.1.5",
+				"    commit: abc1234",
+				"    via_pack: elastic-stack",
+				"    dependencies: []",
+				"  standalone:",
+				"    type: skill",
+				"    group: prod",
+				"    repo: github.com/user/skills",
+				"    path: skills/standalone",
+				"    version: 1.0.0",
+				"    commit: def5678",
+				"    dependencies: []",
+				"",
+			].join("\n"),
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir);
+		} finally {
+			restore();
+		}
+
+		const joined = logs.join("\n");
+		expect(joined).toMatch(/Via Pack/);
+		// Pack-injected rows surface the pack name; the standalone row stays blank.
+		const elasticRow = logs.find((l) => l.includes("elastic-architect"));
+		expect(elasticRow).toMatch(/elastic-stack/);
+		const standaloneRow = logs.find((l) => l.includes("standalone"));
+		expect(standaloneRow).not.toMatch(/elastic-stack/);
+	});
+
+	test("consumer: text output omits 'Via Pack' column when no entry has via_pack (#153)", async () => {
+		// Don't clutter the table for projects that don't use packs at all.
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-noviapack-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
+		await writeFile(join(tempDir, "skilltree.lock"), LOCKFILE_WITH_DEPS);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir);
+		} finally {
+			restore();
+		}
+		const joined = logs.join("\n");
+		expect(joined).not.toMatch(/Via Pack/);
+	});
+
+	test("--json: pack-attributed rows include viaPack field; others omit it (#153)", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-viapack-json-"));
+		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");
+		await writeFile(
+			join(tempDir, "skilltree.lock"),
+			[
+				"lockfile_version: 1",
+				"packages:",
+				"  elastic-architect:",
+				"    type: skill",
+				"    group: prod",
+				"    repo: github.com/marios-oss/elastic-skills",
+				"    path: skills/elastic-architect",
+				"    version: 0.1.5",
+				"    commit: abc1234",
+				"    via_pack: elastic-stack",
+				"    dependencies: []",
+				"  standalone:",
+				"    type: skill",
+				"    group: prod",
+				"    repo: github.com/user/skills",
+				"    path: skills/standalone",
+				"    version: 1.0.0",
+				"    commit: def5678",
+				"    dependencies: []",
+				"",
+			].join("\n"),
+		);
+
+		const { logs, restore } = captureConsole();
+		try {
+			await listCommand(tempDir, { json: true });
+		} finally {
+			restore();
+		}
+
+		const json = JSON.parse(logs.join("")) as Array<{ name: string; viaPack?: string }>;
+		const elastic = json.find((r) => r.name === "elastic-architect");
+		const standalone = json.find((r) => r.name === "standalone");
+		expect(elastic?.viaPack).toBe("elastic-stack");
+		expect(standalone).toBeDefined();
+		expect(standalone?.viaPack).toBeUndefined();
+		// Back-compat: output is still a bare array, not an object wrapper.
+		expect(Array.isArray(json)).toBe(true);
+	});
+
 	test("--json includes commit field and omits '-' version for unpinned remote dep (issue #76)", async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "skilltree-list-"));
 		await writeFile(join(tempDir, "skilltree.yml"), "name: test\n");

--- a/tests/core/lockfile.test.ts
+++ b/tests/core/lockfile.test.ts
@@ -94,6 +94,51 @@ describe("buildLockfile", () => {
 		const lockfile = buildLockfile(entities);
 		expect(lockfile.packages["workflow-builder-agent"]?.name).toBe("workflow-builder");
 	});
+
+	// #153: a pack-injected member must carry its origin pack's yaml key into
+	// the lockfile so `list` can surface the "via pack" attribution on the
+	// consumer side. The resolver already records `viaPack` on the resolved
+	// entity; the lockfile is just the persistence boundary.
+	test("persists viaPack from pack-expanded members as via_pack (#153)", () => {
+		const entities = new Map<string, ResolvedEntity>([
+			[
+				"skill:elastic-architect",
+				{
+					key: "elastic-architect",
+					name: "elastic-architect",
+					type: "skill",
+					group: "prod",
+					repo: "github.com/marios-oss/elastic-skills",
+					path: "skills/elastic-architect",
+					version: "0.1.5",
+					commit: "abc123",
+					local: false,
+					dependencies: [],
+					viaPack: "elastic-stack",
+				},
+			],
+			[
+				"skill:standalone",
+				{
+					key: "standalone",
+					name: "standalone",
+					type: "skill",
+					group: "prod",
+					repo: "github.com/user/skills",
+					path: "skills/standalone",
+					version: "1.0.0",
+					commit: "def456",
+					local: false,
+					dependencies: [],
+				},
+			],
+		]);
+
+		const lockfile = buildLockfile(entities);
+		expect(lockfile.packages["elastic-architect"]?.via_pack).toBe("elastic-stack");
+		// Direct (non-pack-injected) entries omit the field entirely.
+		expect(lockfile.packages.standalone?.via_pack).toBeUndefined();
+	});
 });
 
 describe("serializeLockfile + parseLockfile roundtrip", () => {

--- a/tests/e2e/packs-e2e.test.ts
+++ b/tests/e2e/packs-e2e.test.ts
@@ -81,6 +81,12 @@ describe("e2e packs", () => {
 		expect(lock.packages.bar).toBeDefined();
 		expect(lock.packages.baz).toBeDefined();
 		expect(lock.packages["python-pack"]).toBeUndefined();
+
+		// #153: each expanded member carries the consumer's yaml key for the
+		// pack so `list` can render the "Via Pack" column.
+		expect(lock.packages.foo?.via_pack).toBe("python-pack");
+		expect(lock.packages.bar?.via_pack).toBe("python-pack");
+		expect(lock.packages.baz?.via_pack).toBe("python-pack");
 	});
 
 	test("remote pack: install reads pack from origin manifest and installs members", async () => {
@@ -138,5 +144,9 @@ describe("e2e packs", () => {
 		expect(lock.packages.foo).toBeDefined();
 		expect(lock.packages.bar).toBeDefined();
 		expect(lock.packages["python-pack"]).toBeUndefined();
+
+		// #153: members of a remote pack also record consumer-side attribution.
+		expect(lock.packages.foo?.via_pack).toBe("python-pack");
+		expect(lock.packages.bar?.via_pack).toBe("python-pack");
 	});
 });


### PR DESCRIPTION
## Why

`skilltree list` currently flattens pack-injected members into unrelated rows, hiding the fact that they came from a single `pack:` reference. The publisher half shipped in #152 surfaces *defined* packs; this PR completes #143 by adding **consumer-side** attribution.

Closes #153.

## What changed

- **`LockfileEntry` schema**: new optional `via_pack:` field holding the consumer's yaml key for the pack reference that injected the entry. Documented in `docs/specs/reference.md` and `docs/specs/packs.md`.
- **`buildLockfile`**: copies `ResolvedEntity.viaPack` (already set by the resolver during pack expansion) into the new field. Presence check `!== undefined` per the hardening pattern.
- **`skilltree list` (text mode)**: renders a new "Via Pack" column when at least one row has pack attribution. Hidden otherwise — non-pack projects see no visual change. Direct deps render as `—`.
- **`skilltree list --json`**: per-row `viaPack` field, only set for pack-attributed entries. Output stays a bare array (back-compat).
- Tightened comment on `ResolvedEntity.viaPack` — it is now serialized, where it previously was internal.

## How tested

- `tests/core/lockfile.test.ts`: `buildLockfile` persists `viaPack` → `via_pack`; direct deps omit the field.
- `tests/commands/list-extended.test.ts`: three new cases — text mode shows the column when any row is pack-attributed, omits it otherwise, and `--json` carries `viaPack` only on attributed rows while staying a bare array.
- `tests/e2e/packs-e2e.test.ts`: extended the local-pack and remote-pack flows to assert each expanded member carries the expected `via_pack` value, proving the resolver-to-lockfile path end-to-end.
- Spot-checked the live CLI against a synthetic lockfile — text and `--json` output match the mockup in the issue.
- Full suite: 1624 tests, 0 fails.

## Risk & rollback

Low. Lockfile schema is additive (optional field); old lockfiles parse unchanged. Install path doesn't read `via_pack` so a stale field has no effect. Revert with `git revert <sha>` if needed.